### PR TITLE
E2E: Playwright-for-Electron interaction test harness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,11 @@ jobs:
       # resolves to a real file. Diagnostics print on the way for fast triage.
       - name: Ensure Electron binary
         run: |
-          env | grep -i '^ELECTRON' || echo "(no ELECTRON_* env)"
           rm -rf node_modules/electron/dist node_modules/electron/path.txt ~/.cache/electron
-          npm rebuild electron
+          DEBUG='@electron/get:*' force_no_cache=true node node_modules/electron/install.js 2>&1 | tail -60 || echo "INSTALL EXIT $?"
+          echo "=== dist contents ==="
+          ls -laR node_modules/electron/dist 2>/dev/null | head -40 || echo "NO DIST"
           [ -f node_modules/electron/path.txt ] || printf 'electron' > node_modules/electron/path.txt
-          ls -la node_modules/electron/dist 2>/dev/null | head
           node -e "const fs=require('fs'); const e=require('electron'); if (typeof e!=='string' || !fs.existsSync(e)) throw new Error('electron binary missing: '+e); console.log('electron ->', e)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,20 @@ jobs:
       # download + extract dist/. Write path.txt if the installer still omits it
       # (Linux job -> binary is dist/electron), then validate require('electron')
       # resolves to a real file. Diagnostics print on the way for fast triage.
+      # @electron/get downloads the zip fine on this runner, but electron's own
+      # extraction leaves dist/ without the binary. So force the download, then
+      # extract the cached zip ourselves with unzip (Linux x64 job), and point
+      # path.txt at it. Validate that require('electron') resolves to a real file.
       - name: Ensure Electron binary
         run: |
-          rm -rf node_modules/electron/dist node_modules/electron/path.txt ~/.cache/electron
-          DEBUG='@electron/get:*' force_no_cache=true node node_modules/electron/install.js 2>&1 | tail -60 || echo "INSTALL EXIT $?"
-          echo "=== dist contents ==="
-          ls -laR node_modules/electron/dist 2>/dev/null | head -40 || echo "NO DIST"
-          [ -f node_modules/electron/path.txt ] || printf 'electron' > node_modules/electron/path.txt
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt
+          force_no_cache=true node node_modules/electron/install.js || true
+          zip="$(find "$HOME/.cache/electron" -name 'electron-v*-linux-x64.zip' | head -1)"
+          echo "cached electron zip: $zip"
+          test -f "$zip"
+          mkdir -p node_modules/electron/dist
+          unzip -o -q "$zip" -d node_modules/electron/dist
+          printf 'electron' > node_modules/electron/path.txt
           node -e "const fs=require('fs'); const e=require('electron'); if (typeof e!=='string' || !fs.existsSync(e)) throw new Error('electron binary missing: '+e); console.log('electron ->', e)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,17 +56,19 @@ jobs:
       # ~/.cache/electron download cache during npm ci, which makes electron's
       # own postinstall skip extraction and never write path.txt. Force a clean
       # re-extract and fail loudly if path.txt is still missing.
-      # install.js extracts dist/ on the runner but does not reliably write
-      # node_modules/electron/path.txt (the pointer Playwright's electron.launch
-      # reads). Run it to extract, then write path.txt ourselves - on Linux the
-      # binary lives at dist/electron, so the file's content is just "electron".
+      # On this runner electron's install.js needs force_no_cache to actually
+      # extract dist/, and even then it does not write node_modules/electron/
+      # path.txt - the pointer Playwright's electron.launch reads via
+      # require('electron'). So: force the extract, then write path.txt ourselves
+      # if still missing (Linux-only job -> the binary is dist/electron), and
+      # validate that require('electron') resolves to an existing file. No
+      # `|| true`: a real installer failure must surface, not be masked.
       - name: Ensure Electron binary
         run: |
           rm -rf node_modules/electron/dist node_modules/electron/path.txt
-          node node_modules/electron/install.js || true
+          force_no_cache=true node node_modules/electron/install.js
           [ -f node_modules/electron/path.txt ] || printf 'electron' > node_modules/electron/path.txt
-          test -x node_modules/electron/dist/electron
-          echo "electron binary OK; path.txt -> $(cat node_modules/electron/path.txt)"
+          node -e "const fs=require('fs'); const e=require('electron'); if (typeof e!=='string' || !fs.existsSync(e)) throw new Error('electron binary missing: '+e); console.log('electron ->', e)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual
       # X server. install-deps pulls the shared libs; xvfb-run provides the display.
@@ -89,7 +91,7 @@ jobs:
   package-linux:
     name: Package Linux x64
     runs-on: ubuntu-24.04
-    needs: test
+    needs: [test, e2e]
     if: github.event_name != 'pull_request'
     steps:
       - name: Check out repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Ensure the Electron binary + node_modules/electron/path.txt exist.
+      # npm ci does not reliably run electron's download postinstall here, and
+      # Playwright's electron.launch reads path.txt to find the binary.
+      - name: Ensure Electron binary
+        run: node node_modules/electron/install.js
+
       # Electron on Linux CI needs the Chromium system libraries plus a virtual
       # X server. install-deps pulls the shared libs; xvfb-run provides the display.
       - name: Install Electron system dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,40 @@ jobs:
       - name: Build renderer and Electron main
         run: npm run build
 
+  e2e:
+    name: E2E (Electron)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Electron on Linux CI needs the Chromium system libraries plus a virtual
+      # X server. install-deps pulls the shared libs; xvfb-run provides the display.
+      - name: Install Electron system dependencies
+        run: |
+          npx playwright install-deps
+          sudo apt-get install -y xvfb
+
+      - name: Run Playwright E2E
+        run: xvfb-run -a npm run test:e2e
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   package-linux:
     name: Package Linux x64
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,16 +56,17 @@ jobs:
       # ~/.cache/electron download cache during npm ci, which makes electron's
       # own postinstall skip extraction and never write path.txt. Force a clean
       # re-extract and fail loudly if path.txt is still missing.
+      # install.js extracts dist/ on the runner but does not reliably write
+      # node_modules/electron/path.txt (the pointer Playwright's electron.launch
+      # reads). Run it to extract, then write path.txt ourselves - on Linux the
+      # binary lives at dist/electron, so the file's content is just "electron".
       - name: Ensure Electron binary
         run: |
           rm -rf node_modules/electron/dist node_modules/electron/path.txt
-          # force_no_cache makes @electron/get re-download instead of reusing a
-          # cache entry that install-app-deps may have left in a form electron's
-          # own installer won't extract.
-          force_no_cache=true node node_modules/electron/install.js
-          ls -la node_modules/electron/
-          test -f node_modules/electron/path.txt
-          echo "electron path.txt -> $(cat node_modules/electron/path.txt)"
+          node node_modules/electron/install.js || true
+          [ -f node_modules/electron/path.txt ] || printf 'electron' > node_modules/electron/path.txt
+          test -x node_modules/electron/dist/electron
+          echo "electron binary OK; path.txt -> $(cat node_modules/electron/path.txt)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual
       # X server. install-deps pulls the shared libs; xvfb-run provides the display.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,18 +56,19 @@ jobs:
       # ~/.cache/electron download cache during npm ci, which makes electron's
       # own postinstall skip extraction and never write path.txt. Force a clean
       # re-extract and fail loudly if path.txt is still missing.
-      # On this runner electron's install.js needs force_no_cache to actually
-      # extract dist/, and even then it does not write node_modules/electron/
-      # path.txt - the pointer Playwright's electron.launch reads via
-      # require('electron'). So: force the extract, then write path.txt ourselves
-      # if still missing (Linux-only job -> the binary is dist/electron), and
-      # validate that require('electron') resolves to an existing file. No
-      # `|| true`: a real installer failure must surface, not be masked.
+      # electron is recorded with hasInstallScript:false in the lockfile, so
+      # `npm ci` never downloads its binary. Clear any stale cache and run
+      # `npm rebuild electron`, which executes electron's install script to
+      # download + extract dist/. Write path.txt if the installer still omits it
+      # (Linux job -> binary is dist/electron), then validate require('electron')
+      # resolves to a real file. Diagnostics print on the way for fast triage.
       - name: Ensure Electron binary
         run: |
-          rm -rf node_modules/electron/dist node_modules/electron/path.txt
-          force_no_cache=true node node_modules/electron/install.js
+          env | grep -i '^ELECTRON' || echo "(no ELECTRON_* env)"
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt ~/.cache/electron
+          npm rebuild electron
           [ -f node_modules/electron/path.txt ] || printf 'electron' > node_modules/electron/path.txt
+          ls -la node_modules/electron/dist 2>/dev/null | head
           node -e "const fs=require('fs'); const e=require('electron'); if (typeof e!=='string' || !fs.existsSync(e)) throw new Error('electron binary missing: '+e); console.log('electron ->', e)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,12 @@ jobs:
       # re-extract and fail loudly if path.txt is still missing.
       - name: Ensure Electron binary
         run: |
-          rm -f node_modules/electron/path.txt
-          rm -rf node_modules/electron/dist
-          node node_modules/electron/install.js
+          rm -rf node_modules/electron/dist node_modules/electron/path.txt
+          # force_no_cache makes @electron/get re-download instead of reusing a
+          # cache entry that install-app-deps may have left in a form electron's
+          # own installer won't extract.
+          force_no_cache=true node node_modules/electron/install.js
+          ls -la node_modules/electron/
           test -f node_modules/electron/path.txt
           echo "electron path.txt -> $(cat node_modules/electron/path.txt)"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Ensure the Electron binary + node_modules/electron/path.txt exist.
-      # npm ci does not reliably run electron's download postinstall here, and
-      # Playwright's electron.launch reads path.txt to find the binary.
+      # Ensure node_modules/electron/path.txt exists (Playwright's
+      # electron.launch reads it to find the binary). install-app-deps fills the
+      # ~/.cache/electron download cache during npm ci, which makes electron's
+      # own postinstall skip extraction and never write path.txt. Force a clean
+      # re-extract and fail loudly if path.txt is still missing.
       - name: Ensure Electron binary
-        run: node node_modules/electron/install.js
+        run: |
+          rm -f node_modules/electron/path.txt
+          rm -rf node_modules/electron/dist
+          node node_modules/electron/install.js
+          test -f node_modules/electron/path.txt
+          echo "electron path.txt -> $(cat node_modules/electron/path.txt)"
 
       # Electron on Linux CI needs the Chromium system libraries plus a virtual
       # X server. install-deps pulls the shared libs; xvfb-run provides the display.

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ tui-prototype/.pytest_cache/
 
 # Scratchpad design docs that live alongside the codebase but aren't shipped
 docs/onboarding.md
+
+# Playwright E2E artifacts
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,59 @@
+# End-to-end tests (Playwright + Electron)
+
+These drive the **real built app** through Playwright's Electron driver - they
+click, focus, and assert on the live DOM, catching the interaction bugs that the
+pure-core `node:test` suites can't see (focus not switching, click-twice,
+overlay click-traps).
+
+## Running
+
+```sh
+npm run test:e2e          # builds, then runs headless
+npm run test:e2e:headed   # builds, then runs with a visible window
+npx playwright test e2e/focus.spec.ts   # one spec (build must be current)
+npx playwright show-report              # open the HTML report
+```
+
+`npm run test:e2e` runs `npm run build` first, so the specs always test the
+current renderer + main.
+
+## How isolation works
+
+Each test launches a fresh app instance via `e2e/fixtures.ts` against a
+throwaway environment built by `e2e/helpers/seed.ts`:
+
+- **`AYA_HOME`** points at a temp dir, seeded with a deterministic project (two
+  shell terminals in a 1x2 split) and a single shell preset - so no real `~/.aya`
+  is touched and no PATH scan pulls in claude/codex.
+- **`--user-data-dir`** is a separate temp dir, so the test instance never trips
+  the single-instance lock of a running Aya or shares its cache.
+- **No `AYA_DEV`** - the app loads the built `dist/index.html`, i.e. production
+  mode, not the Vite dev server.
+- `ELECTRON_RUN_AS_NODE` is stripped from the child env (it would make Electron
+  start as plain Node with no `app`).
+
+The app is launched with `dist-electron/main.js` as the entry (not the repo
+root) because a bare directory arg is interpreted by `main.ts` as "open this
+project".
+
+## Specs
+
+- `smoke.spec.ts` - app boots, hydrates the seeded split, renders two panes.
+- `focus.spec.ts` - clicking a split pane activates it and moves keyboard focus
+  into its terminal in a single click (guards the focus-switch / click-twice
+  class of bug).
+- `snippets.spec.ts` - the snippet drawer opens, shows the seeded default with
+  its full text, collapses after sending; the closed drawer is `inert` (F14
+  ghost-drawer regression guard).
+
+## CI
+
+The `e2e` job in `.github/workflows/build.yml` runs the suite on Linux under
+`xvfb-run`; in CI the app is launched with `--no-sandbox` (the Chromium SUID
+sandbox is unavailable on runners).
+
+## Adding a test for a specific glitch
+
+To pin a "needs two clicks" / "focus doesn't switch" bug, reproduce the exact
+sequence (which element, in what order) in a spec, assert the correct
+single-action outcome, and let it fail first - then fix the app until it passes.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -43,21 +43,27 @@ export const test = base.extend<{
       join(APP_ROOT, "dist-electron", "main.js"),
       `--user-data-dir=${seeded.userDataDir}`,
     ];
-    // CI runners can't use the Chromium SUID sandbox; disable it there only.
-    if (process.env.CI) launchArgs.push("--no-sandbox");
+    // CI runners can't use the Chromium SUID sandbox, and the GPU process under
+    // xvfb keeps app.close() from ever resolving (leaving the worker hung). Both
+    // flags are CI-only.
+    if (process.env.CI) {
+      launchArgs.push("--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage");
+    }
 
     const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
     await use(app);
-    // Under CI/xvfb a graceful app.close() hangs (Aya's detached pty-host keeps
-    // Electron from exiting). SIGKILL the process FIRST so it's already dead,
-    // THEN await close() - which now resolves immediately and still tears down
-    // Playwright's CDP transport so the worker can exit cleanly.
+    // With --disable-gpu (CI) the graceful close resolves; locally it always
+    // has. Guard with a hard SIGKILL fallback if it ever stalls so the worker
+    // can still exit.
+    await Promise.race([
+      app.close().catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, 8000)),
+    ]);
     try {
       app.process().kill("SIGKILL");
     } catch {
       /* already gone */
     }
-    await app.close().catch(() => {});
   },
 
   window: async ({ app }, use) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -48,14 +48,16 @@ export const test = base.extend<{
 
     const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
     await use(app);
-    // Aya spawns a detached pty-host (its "PTYs survive restart" design), so
-    // app.close() can hang under CI/xvfb and a dangling close() promise keeps
-    // Playwright's worker from exiting. SIGKILL the Electron process directly.
+    // Under CI/xvfb a graceful app.close() hangs (Aya's detached pty-host keeps
+    // Electron from exiting). SIGKILL the process FIRST so it's already dead,
+    // THEN await close() - which now resolves immediately and still tears down
+    // Playwright's CDP transport so the worker can exit cleanly.
     try {
       app.process().kill("SIGKILL");
     } catch {
       /* already gone */
     }
+    await app.close().catch(() => {});
   },
 
   window: async ({ app }, use) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -4,6 +4,7 @@ import {
   type ElectronApplication,
   type Page,
 } from "@playwright/test";
+import { execSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { seedEnv, type SeededEnv } from "./helpers/seed";
@@ -52,17 +53,23 @@ export const test = base.extend<{
 
     const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
     await use(app);
-    // With --disable-gpu (CI) the graceful close resolves; locally it always
-    // has. Guard with a hard SIGKILL fallback if it ever stalls so the worker
-    // can still exit.
-    await Promise.race([
-      app.close().catch(() => {}),
-      new Promise((resolve) => setTimeout(resolve, 8000)),
-    ]);
     try {
       app.process().kill("SIGKILL");
     } catch {
       /* already gone */
+    }
+    if (process.env.CI) {
+      // Aya spawns a detached pty-host (its "PTYs survive restart" design) that
+      // outlives the window; on the isolated CI runner that leftover process
+      // keeps Playwright's worker from exiting (45s teardown timeout). Reap it.
+      // CI-only: locally this would also kill a developer's running Aya.
+      try {
+        execSync("pkill -9 -f pty-host.js", { stdio: "ignore" });
+      } catch {
+        /* nothing to kill */
+      }
+    } else {
+      await app.close().catch(() => {});
     }
   },
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -48,7 +48,19 @@ export const test = base.extend<{
 
     const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
     await use(app);
-    await app.close();
+    // Aya spawns a detached pty-host (its "PTYs survive restart" design), which
+    // can keep app.close() from resolving under CI/xvfb. Race a graceful close
+    // against a short timeout, then hard-kill the Electron process so teardown
+    // never eats the whole test timeout.
+    await Promise.race([
+      app.close().catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, 5000)),
+    ]);
+    try {
+      app.process().kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
   },
 
   window: async ({ app }, use) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -48,14 +48,9 @@ export const test = base.extend<{
 
     const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
     await use(app);
-    // Aya spawns a detached pty-host (its "PTYs survive restart" design), which
-    // can keep app.close() from resolving under CI/xvfb. Race a graceful close
-    // against a short timeout, then hard-kill the Electron process so teardown
-    // never eats the whole test timeout.
-    await Promise.race([
-      app.close().catch(() => {}),
-      new Promise((resolve) => setTimeout(resolve, 5000)),
-    ]);
+    // Aya spawns a detached pty-host (its "PTYs survive restart" design), so
+    // app.close() can hang under CI/xvfb and a dangling close() promise keeps
+    // Playwright's worker from exiting. SIGKILL the Electron process directly.
     try {
       app.process().kill("SIGKILL");
     } catch {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,61 @@
+import {
+  test as base,
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { seedEnv, type SeededEnv } from "./helpers/seed";
+
+const APP_ROOT = join(__dirname, "..");
+
+/** Fixtures that launch the built Aya app once per test against an isolated,
+ *  seeded environment and tear it down afterward. */
+export const test = base.extend<{
+  seeded: SeededEnv;
+  app: ElectronApplication;
+  window: Page;
+}>({
+  seeded: async ({}, use) => {
+    const s = seedEnv();
+    await use(s);
+    rmSync(s.root, { recursive: true, force: true });
+  },
+
+  app: async ({ seeded }, use) => {
+    // Production-like launch: no AYA_DEV, so the app loads the built
+    // dist/index.html. ELECTRON_RUN_AS_NODE must be stripped or Electron starts
+    // as plain Node (no `app`). AYA_HOME + --user-data-dir isolate all state.
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === "string" && k !== "ELECTRON_RUN_AS_NODE" && k !== "AYA_DEV") {
+        env[k] = v;
+      }
+    }
+    env.AYA_HOME = seeded.ayaHome;
+
+    // Point Electron at the built main entry, NOT the app root: a bare
+    // directory arg is interpreted by main.ts as "open this project", which
+    // would open the aya repo itself as a spurious project. main.ts skips argv
+    // entries ending in "main.js", so this avoids that.
+    const launchArgs = [
+      join(APP_ROOT, "dist-electron", "main.js"),
+      `--user-data-dir=${seeded.userDataDir}`,
+    ];
+    // CI runners can't use the Chromium SUID sandbox; disable it there only.
+    if (process.env.CI) launchArgs.push("--no-sandbox");
+
+    const app = await electron.launch({ args: launchArgs, cwd: APP_ROOT, env });
+    await use(app);
+    await app.close();
+  },
+
+  window: async ({ app }, use) => {
+    const win = await app.firstWindow();
+    await win.waitForLoadState("domcontentloaded");
+    await use(win);
+  },
+});
+
+export const expect = test.expect;

--- a/e2e/focus.spec.ts
+++ b/e2e/focus.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+// Pin down the "focus does not switch / needs two clicks" class of bug: clicking
+// a split pane must, in a SINGLE click, make it the active cell AND move
+// keyboard focus into its terminal. If the app needs two clicks, this fails.
+
+function paneByTitle(window: Page, title: string) {
+  return window.locator(".aya-pane").filter({
+    has: window.locator(".aya-pane-header-title", { hasText: new RegExp(`^${title}$`) }),
+  });
+}
+
+test("clicking a split pane activates it and focuses its terminal in one click", async ({
+  window,
+}) => {
+  const pane1 = paneByTitle(window, "shell 1");
+  const pane2 = paneByTitle(window, "shell 2");
+
+  // Seeded initial state: cell 0 (shell 1) is the active split cell.
+  await expect(pane1).toHaveClass(/aya-pane--active-split/);
+  await expect(pane2).not.toHaveClass(/aya-pane--active-split/);
+
+  // ONE click into the second pane's terminal area.
+  await pane2.locator(".aya-xterm-host").click();
+
+  // Active-split must move to pane 2 (and leave pane 1) on that single click.
+  await expect(pane2).toHaveClass(/aya-pane--active-split/);
+  await expect(pane1).not.toHaveClass(/aya-pane--active-split/);
+
+  // Keyboard focus must now live inside pane 2's terminal, not pane 1.
+  await expect
+    .poll(() =>
+      window.evaluate(() => {
+        const panes = Array.from(document.querySelectorAll(".aya-pane"));
+        const p2 = panes.find(
+          (p) => p.querySelector(".aya-pane-header-title")?.textContent === "shell 2",
+        );
+        const active = document.activeElement;
+        return !!(p2 && active && active !== document.body && p2.contains(active));
+      }),
+    )
+    .toBe(true);
+});
+
+test("typing after one click on a pane goes to that pane's terminal", async ({ window }) => {
+  // A stronger statement of the same contract: after a single click, the focused
+  // element is a text input (xterm's helper textarea), so keystrokes would land
+  // in shell 2 rather than being swallowed or routed to shell 1.
+  const pane2 = paneByTitle(window, "shell 2");
+  await pane2.locator(".aya-xterm-host").click();
+
+  const activeTag = await window.evaluate(
+    () => document.activeElement?.tagName.toLowerCase() ?? null,
+  );
+  expect(activeTag).toBe("textarea");
+});

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface SeededEnv {
+  /** Temp root holding all isolated state for one app launch. */
+  root: string;
+  /** AYA_HOME passed to the app (its config dir). */
+  ayaHome: string;
+  /** Electron `--user-data-dir` (cache, single-instance lock) - kept distinct
+   *  so the test instance never collides with a running Aya. */
+  userDataDir: string;
+  /** Working directory of the seeded project (must exist for terminals). */
+  projectDir: string;
+  tabIds: { left: string; right: string };
+}
+
+/** Build a throwaway, deterministic environment for one Electron launch:
+ *  a project with two shell terminals in a 1x2 split, a single shell preset
+ *  (so no PATH harness scan pulls in claude/codex), and an empty snippet store
+ *  that the app seeds with its defaults on boot. */
+export function seedEnv(): SeededEnv {
+  const root = mkdtempSync(join(tmpdir(), "aya-e2e-"));
+  const ayaHome = join(root, "aya-home");
+  const userDataDir = join(root, "electron-data");
+  const projectDir = join(root, "project");
+  mkdirSync(join(ayaHome, "projects"), { recursive: true });
+  mkdirSync(userDataDir, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+
+  writeFileSync(
+    join(ayaHome, "presets.json"),
+    JSON.stringify(
+      { presets: [{ id: "shell", name: "Shell", icon: "$", color: "", command: "$SHELL" }] },
+      null,
+      2,
+    ),
+  );
+
+  const left = "tab-left";
+  const right = "tab-right";
+  writeFileSync(
+    join(ayaHome, "projects", "e2e-proj.json"),
+    JSON.stringify(
+      {
+        name: "e2e",
+        directory: projectDir,
+        tabs: [
+          { id: left, presetId: "shell", name: "shell 1" },
+          { id: right, presetId: "shell", name: "shell 2" },
+        ],
+        splitLayout: {
+          rows: 1,
+          cols: 2,
+          rowFr: [1],
+          colFr: [1, 1],
+          cells: [left, right],
+          activeCell: 0,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(ayaHome, "projects-state.json"),
+    JSON.stringify({ version: 1, order: ["e2e-proj"], open: ["e2e-proj"], recent: ["e2e-proj"] }, null, 2),
+  );
+
+  return { root, ayaHome, userDataDir, projectDir, tabIds: { left, right } };
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "./fixtures";
+
+test("launches the built app and hydrates the seeded split project", async ({ window }) => {
+  // Two panes from the seeded 1x2 split layout prove: window opened, renderer
+  // booted, project loaded, terminals hydrated, split rendered.
+  await expect(window.locator(".aya-pane")).toHaveCount(2);
+
+  // The project's terminal names came from the seeded config.
+  await expect(window.locator(".aya-pane-header-title").first()).toHaveText("shell 1");
+});

--- a/e2e/snippets.spec.ts
+++ b/e2e/snippets.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "./fixtures";
+
+// The snippet drawer end to end: it opens from the pane header, shows the
+// seeded default snippet with its full text, and collapses after a send so the
+// terminal result stays visible.
+
+test("snippet drawer opens, shows the seeded default, and collapses after sending", async ({
+  window,
+}) => {
+  // The fresh AYA_HOME has no snippets file, so the app seeds DEFAULT_SNIPPETS
+  // on boot. Open the first pane's drawer.
+  await window.locator(".aya-pane-snippettoggle").first().click();
+
+  const drawer = window.locator(".aya-snippetbar--open").first();
+  await expect(drawer).toBeVisible();
+
+  // Seeded default renders with its name AND its full text (the point of the
+  // drawer: verify a prompt before sending).
+  await expect(
+    drawer.locator(".aya-snippet-name", { hasText: "magic numbers audit" }),
+  ).toBeVisible();
+  await expect(drawer.locator(".aya-snippet-text").first()).toContainText(
+    "Run a full magic-numbers audit",
+  );
+
+  // Sending collapses the drawer (no open drawer remains anywhere).
+  await drawer.locator(".aya-snippet").first().click();
+  await expect(window.locator(".aya-snippetbar--open")).toHaveCount(0);
+});
+
+test("closed snippet drawer is inert (cannot be tab-focused or clicked)", async ({
+  window,
+}) => {
+  // Regression guard for the F14 ghost-drawer fix: while closed, the drawer's
+  // buttons must be removed from the a11y/tab tree (inert), so they can't steal
+  // focus or clicks over the status bar.
+  const closedDrawer = window.locator(".aya-snippetbar").first();
+  await expect(closedDrawer).not.toHaveClass(/aya-snippetbar--open/);
+  await expect(closedDrawer).toHaveAttribute("inert", "");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "plist": "^3.1.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^25.9.1",
         "@types/plist": "^3.0.5",
         "@types/react": "^19.2.15",
@@ -538,6 +539,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4007,6 +4024,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build:test-src": "tsc -p tsconfig.test-src.json",
     "build": "npm run build:renderer && npm run build:electron",
     "test": "npm run typecheck:renderer && npm run build:electron && npm run build:test-src && node --test \"tests/**/*.test.mjs\"",
+    "test:e2e": "npm run build && playwright test",
+    "test:e2e:headed": "npm run build && playwright test --headed",
     "package": "npm run build && electron-builder",
     "postinstall": "electron-builder install-app-deps"
   },
@@ -32,6 +34,7 @@
     "plist": "^3.1.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.1",
     "@types/plist": "^3.0.5",
     "@types/react": "^19.2.15",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+// Electron end-to-end tests. Each test launches the built app (dist-electron +
+// dist) through Playwright's Electron driver against an isolated, seeded
+// AYA_HOME and a throwaway Electron user-data-dir, so runs are deterministic
+// and never touch the real ~/.aya or collide with a running Aya instance.
+export default defineConfig({
+  testDir: "./e2e",
+  // App launches are heavy and share node_modules/electron + the window server;
+  // run serially for stability.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+});


### PR DESCRIPTION
## What

A production-grade end-to-end harness that drives the **real built app** through Playwright's Electron driver - clicking, focusing, and asserting on the live DOM. This covers the interaction bugs the pure-core `node:test` suites structurally can't see (focus not switching, click-twice, overlay click-traps) - the "Step B" real-pipeline gap the snippets work flagged.

## How it's isolated (production-like, zero blast radius)

Each test launches a fresh app via `e2e/fixtures.ts` against a throwaway environment from `e2e/helpers/seed.ts`:

- **`AYA_HOME`** = temp dir, seeded with a deterministic 1x2 split project (two shell terminals) + a single shell preset. Never touches the real `~/.aya`; no PATH scan pulls in claude/codex.
- **`--user-data-dir`** = separate temp dir, so the test instance never trips a running Aya's single-instance lock or shares its cache.
- **No `AYA_DEV`** - loads the built `dist/index.html` (production mode), launched via `dist-electron/main.js` (a bare dir arg would be read by `main.ts` as "open this project").
- `ELECTRON_RUN_AS_NODE` stripped; `--no-sandbox` only under CI.

## Specs (all green locally)

- **smoke** - app boots, hydrates the seeded split, renders two panes.
- **focus** - clicking a split pane activates it and moves keyboard focus into its terminal in a **single click** (the focus-switch / click-twice guard).
- **snippets** - the drawer opens, shows the seeded default with full text, collapses after sending; the closed drawer is `inert` (F14 ghost-drawer regression guard - confirms that fix actually shipped in the build).

## Tooling

- `npm run test:e2e` / `npm run test:e2e:headed` (builds, then runs).
- New **e2e CI job** in `build.yml`: runs on Linux under `xvfb`, installs Electron system deps, uploads the Playwright report on failure.
- `docs/e2e.md` documents running, isolation, and how to add a glitch-repro test.

## Notes

- The CI e2e job is the canonical Playwright-on-Electron-Linux pattern but is **unverified in GitHub Actions until this PR's own CI runs it** - that run is the verification. It executes on this branch, so `main` is unaffected; if it's red I'll tune it here before merge.
- The focus spec currently **passes** for the split-pane-click scenario, so it did not reproduce the "needs two clicks" glitch reported separately - a targeted repro test (exact element + sequence) will be added once the scenario is pinned down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
