### PR TITLE
Fix: deterministic terminal focus on tab/pane switch and overlay close

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -7,19 +7,23 @@ import {
 import { execSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
-import { seedEnv, type SeededEnv } from "./helpers/seed";
+import { seedEnv, type SeededEnv, type SeedOptions } from "./helpers/seed";
 
 const APP_ROOT = join(__dirname, "..");
 
 /** Fixtures that launch the built Aya app once per test against an isolated,
  *  seeded environment and tear it down afterward. */
 export const test = base.extend<{
+  /** Per-test seed options. Override with `test.use({ seedOptions: {...} })`. */
+  seedOptions: SeedOptions;
   seeded: SeededEnv;
   app: ElectronApplication;
   window: Page;
 }>({
-  seeded: async ({}, use) => {
-    const s = seedEnv();
+  seedOptions: [{}, { option: true }],
+
+  seeded: async ({ seedOptions }, use) => {
+    const s = seedEnv(seedOptions);
     await use(s);
     rmSync(s.root, { recursive: true, force: true });
   },

--- a/e2e/focus-scenarios.spec.ts
+++ b/e2e/focus-scenarios.spec.ts
@@ -5,18 +5,7 @@ import type { Page } from "@playwright/test";
 // asserts the behavior a user expects ("I can type without an extra click"); a
 // red test = a reproduced bug. Uses the default 1x2 split seed.
 
-// Aya intercepts app shortcuts via webContents before-input-event, which
-// Playwright's synthetic keyboard does NOT trigger. So fire the shortcut the
-// way main.ts ultimately does: send the "shortcut" action straight to the
-// renderer from the main process. This tests the App's shortcut HANDLING (and
-// whether focus follows), not the OS keybinding.
-import type { ElectronApplication } from "@playwright/test";
-async function fireShortcut(app: ElectronApplication, action: string) {
-  await app.evaluate(({ BrowserWindow }, act) => {
-    const win = BrowserWindow.getAllWindows()[0];
-    win?.webContents.send("shortcut", act);
-  }, action);
-}
+import { fireShortcut } from "./helpers/shortcut";
 
 function focusInfo(window: Page) {
   return window.evaluate(() => {
@@ -87,6 +76,42 @@ test("closing Settings returns focus to the terminal", async ({ window, app }) =
   await expect
     .poll(async () => (await focusInfo(window)).inAnyTerminal, {
       message: "focus should return to the terminal after the modal closes",
+    })
+    .toBe(true);
+});
+
+test("closing Search returns focus to the terminal", async ({ window, app }) => {
+  await window.locator(".aya-pane").first().locator(".aya-xterm-host").click();
+
+  await fireShortcut(app, "search");
+  await expect(window.locator(".aya-modal--search")).toBeVisible();
+  // The search input holds focus, so Escape reaches the modal (not xterm).
+  await window.keyboard.press("Escape");
+  await expect(window.locator(".aya-modal--search")).toHaveCount(0);
+
+  await expect
+    .poll(async () => (await focusInfo(window)).inAnyTerminal, {
+      message: "focus should return to the terminal after Search closes",
+    })
+    .toBe(true);
+});
+
+test("the find bar holds focus while open and returns it to the terminal on close", async ({
+  window,
+  app,
+}) => {
+  await window.locator(".aya-pane").first().locator(".aya-xterm-host").click();
+
+  // Open the in-pane find bar; its input — not the terminal — must take focus.
+  await fireShortcut(app, "find-in-pane");
+  await expect(window.locator(".aya-findbar-input")).toBeFocused();
+
+  // Close the find bar (the ✕ button); focus must return to the terminal.
+  await window.locator('.aya-findbar-btn[title^="Close"]').click();
+  await expect(window.locator(".aya-findbar")).toHaveCount(0);
+  await expect
+    .poll(async () => (await focusInfo(window)).inAnyTerminal, {
+      message: "focus should return to the terminal after the find bar closes",
     })
     .toBe(true);
 });

--- a/e2e/focus-scenarios.spec.ts
+++ b/e2e/focus-scenarios.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+// Maps the breadth of the focus glitch beyond the sidebar tab switch. Each test
+// asserts the behavior a user expects ("I can type without an extra click"); a
+// red test = a reproduced bug. Uses the default 1x2 split seed.
+
+// Aya intercepts app shortcuts via webContents before-input-event, which
+// Playwright's synthetic keyboard does NOT trigger. So fire the shortcut the
+// way main.ts ultimately does: send the "shortcut" action straight to the
+// renderer from the main process. This tests the App's shortcut HANDLING (and
+// whether focus follows), not the OS keybinding.
+import type { ElectronApplication } from "@playwright/test";
+async function fireShortcut(app: ElectronApplication, action: string) {
+  await app.evaluate(({ BrowserWindow }, act) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.webContents.send("shortcut", act);
+  }, action);
+}
+
+function focusInfo(window: Page) {
+  return window.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll(".aya-pane"));
+    const active = document.activeElement;
+    const owner = panes.find((p) => active && p.contains(active));
+    return {
+      tag: active ? active.tagName.toLowerCase() : null,
+      inAnyTerminal: !!owner && active!.tagName.toLowerCase() === "textarea",
+      ownerTitle: owner?.querySelector(".aya-pane-header-title")?.textContent ?? null,
+      activeCellTitle:
+        document
+          .querySelector(".aya-pane--active-split .aya-pane-header-title")
+          ?.textContent ?? null,
+    };
+  });
+}
+
+test("the active terminal is focused on launch (no click needed to type)", async ({
+  window,
+}) => {
+  await expect(window.locator(".aya-pane")).toHaveCount(2);
+  await expect
+    .poll(async () => (await focusInfo(window)).inAnyTerminal, {
+      message: "a terminal should hold focus right after launch",
+    })
+    .toBe(true);
+});
+
+test("focus-pane-right shortcut moves focus to the next split pane", async ({
+  window,
+  app,
+}) => {
+  // Focus pane 1 first.
+  await window.locator(".aya-pane").first().locator(".aya-xterm-host").click();
+  await expect(window.locator(".aya-pane--active-split .aya-pane-header-title")).toHaveText(
+    "shell 1",
+  );
+
+  await fireShortcut(app, "focus-pane-right");
+
+  // Active cell should move to pane 2 AND keyboard focus should follow it.
+  await expect(window.locator(".aya-pane--active-split .aya-pane-header-title")).toHaveText(
+    "shell 2",
+  );
+  await expect
+    .poll(
+      async () => {
+        const f = await focusInfo(window);
+        return f.inAnyTerminal && f.ownerTitle === "shell 2";
+      },
+      { message: "focus should follow the active cell" },
+    )
+    .toBe(true);
+});
+
+test("closing Settings returns focus to the terminal", async ({ window, app }) => {
+  await window.locator(".aya-pane").first().locator(".aya-xterm-host").click();
+
+  // Open Settings via the shortcut action, then close with Escape (a normal
+  // page keydown listener, which Playwright's keyboard does reach).
+  await fireShortcut(app, "open-settings");
+  await expect(window.locator(".aya-modal--settings")).toBeVisible();
+  // Close via the Cancel button (Escape is swallowed by the focused xterm).
+  await window.locator(".aya-modal-btn", { hasText: "Cancel" }).click();
+  await expect(window.locator(".aya-modal--settings")).toHaveCount(0);
+
+  await expect
+    .poll(async () => (await focusInfo(window)).inAnyTerminal, {
+      message: "focus should return to the terminal after the modal closes",
+    })
+    .toBe(true);
+});

--- a/e2e/focus-tab.spec.ts
+++ b/e2e/focus-tab.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+// Reproduces the reported "focus doesn't switch / have to click twice" glitch.
+// Aya hides inactive terminals with display:none and never re-focuses the
+// terminal that becomes visible, so switching tabs via the sidebar leaves the
+// keyboard focus behind. This single-terminal (no split) layout is where it
+// bites: only the active tab is visible, so a tab switch is a real show/hide.
+test.use({ seedOptions: { split: false } });
+
+function sidebarRow(window: Page, name: string) {
+  return window.locator(".aya-sidebar-row", {
+    has: window.locator(".aya-sidebar-name", { hasText: new RegExp(`^${name}$`) }),
+  });
+}
+
+function visiblePaneTitle(window: Page) {
+  return window.evaluate(() => {
+    const pane = Array.from(document.querySelectorAll(".aya-pane")).find(
+      (p) => getComputedStyle(p as HTMLElement).display !== "none",
+    );
+    return pane?.querySelector(".aya-pane-header-title")?.textContent ?? null;
+  });
+}
+
+test("switching terminals via the sidebar moves keyboard focus to the new terminal", async ({
+  window,
+}) => {
+  // Start with focus established inside shell 1.
+  await window.locator(".aya-pane:visible .aya-xterm-host").click();
+  await expect.poll(() => visiblePaneTitle(window)).toBe("shell 1");
+
+  // One click on shell 2's sidebar row.
+  await sidebarRow(window, "shell 2").click();
+  await expect.poll(() => visiblePaneTitle(window)).toBe("shell 2");
+
+  // Keyboard focus must now be inside shell 2's terminal — not left on shell 1,
+  // the sidebar row, or the body. If it isn't, the user has to click the
+  // terminal a second time before typing reaches it.
+  await expect
+    .poll(
+      () =>
+        window.evaluate(() => {
+          const pane = Array.from(document.querySelectorAll(".aya-pane")).find(
+            (p) => getComputedStyle(p as HTMLElement).display !== "none",
+          );
+          const active = document.activeElement;
+          return !!(
+            pane &&
+            active &&
+            pane.contains(active) &&
+            active.tagName.toLowerCase() === "textarea"
+          );
+        }),
+      { message: "focus should land inside the newly-shown terminal" },
+    )
+    .toBe(true);
+});

--- a/e2e/focus-tab.spec.ts
+++ b/e2e/focus-tab.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./fixtures";
 import type { Page } from "@playwright/test";
+import { fireShortcut } from "./helpers/shortcut";
 
 // Reproduces the reported "focus doesn't switch / have to click twice" glitch.
 // Aya hides inactive terminals with display:none and never re-focuses the
@@ -53,6 +54,35 @@ test("switching terminals via the sidebar moves keyboard focus to the new termin
           );
         }),
       { message: "focus should land inside the newly-shown terminal" },
+    )
+    .toBe(true);
+});
+
+test("the next-tab keyboard shortcut moves focus to the next terminal", async ({
+  window,
+  app,
+}) => {
+  await window.locator(".aya-pane:visible .aya-xterm-host").click();
+  await expect.poll(() => visiblePaneTitle(window)).toBe("shell 1");
+
+  await fireShortcut(app, "next-tab");
+  await expect.poll(() => visiblePaneTitle(window)).toBe("shell 2");
+
+  await expect
+    .poll(() =>
+      window.evaluate(() => {
+        const pane = Array.from(document.querySelectorAll(".aya-pane")).find(
+          (p) => getComputedStyle(p as HTMLElement).display !== "none",
+        );
+        const active = document.activeElement;
+        return !!(
+          pane &&
+          active &&
+          pane.contains(active) &&
+          active.tagName.toLowerCase() === "textarea"
+        );
+      }),
+      { message: "focus should follow the keyboard tab switch" },
     )
     .toBe(true);
 });

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -15,11 +15,19 @@ export interface SeededEnv {
   tabIds: { left: string; right: string };
 }
 
+export interface SeedOptions {
+  /** When false, the project has no split layout, so only the active tab is
+   *  visible and switching happens via the sidebar (one terminal at a time).
+   *  Defaults to true (1x2 split, both panes visible). */
+  split?: boolean;
+}
+
 /** Build a throwaway, deterministic environment for one Electron launch:
- *  a project with two shell terminals in a 1x2 split, a single shell preset
- *  (so no PATH harness scan pulls in claude/codex), and an empty snippet store
- *  that the app seeds with its defaults on boot. */
-export function seedEnv(): SeededEnv {
+ *  a project with two shell terminals (in a 1x2 split by default), a single
+ *  shell preset (so no PATH harness scan pulls in claude/codex), and an empty
+ *  snippet store that the app seeds with its defaults on boot. */
+export function seedEnv(opts: SeedOptions = {}): SeededEnv {
+  const split = opts.split !== false;
   const root = mkdtempSync(join(tmpdir(), "aya-e2e-"));
   const ayaHome = join(root, "aya-home");
   const userDataDir = join(root, "electron-data");
@@ -49,14 +57,18 @@ export function seedEnv(): SeededEnv {
           { id: left, presetId: "shell", name: "shell 1" },
           { id: right, presetId: "shell", name: "shell 2" },
         ],
-        splitLayout: {
-          rows: 1,
-          cols: 2,
-          rowFr: [1],
-          colFr: [1, 1],
-          cells: [left, right],
-          activeCell: 0,
-        },
+        ...(split
+          ? {
+              splitLayout: {
+                rows: 1,
+                cols: 2,
+                rowFr: [1],
+                colFr: [1, 1],
+                cells: [left, right],
+                activeCell: 0,
+              },
+            }
+          : {}),
       },
       null,
       2,

--- a/e2e/helpers/shortcut.ts
+++ b/e2e/helpers/shortcut.ts
@@ -1,0 +1,13 @@
+import type { ElectronApplication } from "@playwright/test";
+
+/** Fire an Aya app shortcut action the way main.ts ultimately does — by sending
+ *  the "shortcut" IPC straight to the renderer. Playwright's synthetic keyboard
+ *  does NOT trigger main.ts's webContents before-input-event interception, so
+ *  this is how we exercise shortcut-driven behavior (and whether focus follows)
+ *  in E2E. Action strings match electron/main.ts: "search", "find-in-pane",
+ *  "next-tab", "prev-tab", "focus-pane-right", "open-settings", etc. */
+export async function fireShortcut(app: ElectronApplication, action: string) {
+  await app.evaluate(({ BrowserWindow }, act) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send("shortcut", act);
+  }, action);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1739,6 +1739,15 @@ export function App() {
 
   const currentMissingDir = missingDirQueue[0] ?? null;
   const chromeBlocked = !!currentMissingDir || !!newProjectModal;
+  // Any overlay that should hold focus instead of the terminal. While one is
+  // open, no terminal is "active" for focus purposes; closing the last one
+  // hands focus back to the active terminal (via TerminalView's isActive effect).
+  const anyOverlayOpen =
+    chromeBlocked ||
+    showSettings ||
+    showSearch ||
+    showAttentionCenter ||
+    !!pendingRepoImport;
 
   const activeTheme = themes.find((t) => t.id === activeThemeId) ?? themes[0];
   const activeThemeColors: ThemeColors =
@@ -1990,6 +1999,10 @@ export function App() {
                   onRequestRestart={() => restartTerminal(terminal.id)}
                   restartTrigger={restartTriggers[terminal.id] ?? 0}
                   isActivePane={isSplit && splitLayout.activeCell === cellIndex}
+                  isActive={
+                    (isSplit ? splitLayout.activeCell === cellIndex : true) &&
+                    !anyOverlayOpen
+                  }
                   onActivatePane={() =>
                     activeProjectId && setActiveSplitCell(activeProjectId, cellIndex)
                   }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -40,6 +40,10 @@ interface Props {
    *  The component reuses its xterm instance and spawns a fresh PTY. */
   restartTrigger: number;
   isActivePane?: boolean;
+  /** True when this is THE terminal the user is interacting with right now:
+   *  active project + active tab + active split cell, and no overlay/modal is
+   *  open. Drives deterministic keyboard focus (see the focus effect below). */
+  isActive?: boolean;
   onActivatePane?: () => void;
   enableWebgl?: boolean;
 }
@@ -103,6 +107,7 @@ export function TerminalView({
   onRequestRestart,
   restartTrigger,
   isActivePane = false,
+  isActive = false,
   onActivatePane,
   enableWebgl = true,
 }: Props) {
@@ -481,14 +486,47 @@ export function TerminalView({
 
   useEffect(() => {
     if (!isVisible) return;
-    repairTerminalRender(true);
-    const frame = requestAnimationFrame(() => repairTerminalRender(true));
-    const timer = setTimeout(() => repairTerminalRender(true), 80);
+    // Repaint the freshly-shown terminal (webgl atlas, scrollback). Focus is
+    // NOT done here — it's owned by the isActive effect below, so a concurrent
+    // fit can't swallow it.
+    repairTerminalRender(false);
+    const frame = requestAnimationFrame(() => repairTerminalRender(false));
+    const timer = setTimeout(() => repairTerminalRender(false), 80);
     return () => {
       cancelAnimationFrame(frame);
       clearTimeout(timer);
     };
   }, [isVisible, repairTerminalRender]);
+
+  // Single source of truth for keyboard focus: whenever this becomes THE active
+  // terminal (tab switch, split-pane navigation, or an overlay/modal closing),
+  // focus its xterm. Deliberately decoupled from fitTerminal's shared,
+  // cancellable rAF so a stray fit can't drop the focus. The find bar wants the
+  // focus while it's open, so defer to it.
+  const wantsFocus = isActive && !findOpen;
+  useEffect(() => {
+    if (!wantsFocus) return;
+    const focusNow = () => {
+      try {
+        const term = xtermRef.current;
+        const host = containerRef.current;
+        if (term && host && host.clientWidth > 0 && host.clientHeight > 0) {
+          term.focus();
+        }
+      } catch {
+        /* ignore — xterm may be mid-dispose */
+      }
+    };
+    // Focus now, and retry across a couple of frames because xterm may still be
+    // measuring right after a visibility/layout change.
+    focusNow();
+    const raf = requestAnimationFrame(focusNow);
+    const timer = setTimeout(focusNow, 60);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
+  }, [wantsFocus]);
 
   useEffect(() => {
     if (!isVisible) return;


### PR DESCRIPTION
## The bug

Reported as "focus doesn't switch / I have to click the terminal twice". Reproduced with the new E2E harness (#6): switching terminals, navigating split panes, and closing modals all left keyboard focus behind, intermittently.

## Root cause — one architectural flaw, several symptoms

Keyboard focus was a **side effect of layout-fitting**. `term.focus()` only ran inside `fitTerminal(shouldFocus=true)`, which lives in a **shared, cancellable `requestAnimationFrame`** (`fitFrameRef`). Any other fit — `ResizeObserver`, window `resize`, font-size change — calls `fitTerminal()` with `shouldFocus=false` and **cancels the pending focus rAF**, silently dropping the focus. And the only trigger that ever *requested* focus was the `isVisible` false→true effect. So:

| Symptom | Why |
|---|---|
| Tab switch — focus lands late / not at all | focus scheduled, then the layout change's ResizeObserver fit **cancels** it (race → the "click twice" flake) |
| Split-pane navigation — no focus | `isVisible` never changes; `isActivePane` only sets a CSS class → **no focus trigger at all** |
| Closing Settings/Search — focus never returns | `isVisible` never changed → nothing re-focuses the terminal; it sits on `<body>` |

`App` never called `.focus()` at all — focus was entirely delegated to that one racy effect + xterm's built-in click handler.

## The fix — make focus first-class and declarative

- New **`isActive`** prop on `TerminalView` = "this is THE terminal the user is interacting with" (active project + active tab + active split cell, **and** no overlay open). `App` computes it; `anyOverlayOpen` covers Settings, Search, Attention Center, and the new-project / missing-dir / repo-import chrome.
- A **dedicated focus effect** focuses the xterm when `isActive && !findOpen` becomes true — **decoupled from the cancellable fit rAF** so a stray fit can't drop it, with a short retry for xterm still measuring after a layout change.
- The `isVisible` effect no longer focuses (repairs render only).

One mechanism (active-terminal → focus) fixes tab switch, split-pane nav, **and** overlay-close, and removes the flakiness from the click/boot paths.

## Tests (all green, deterministic across repeats)

- `e2e/focus-tab.spec.ts` — sidebar tab switch moves focus (new non-split seed).
- `e2e/focus-scenarios.spec.ts` — focus on launch, `focus-pane-right` shortcut, Settings close returns focus.
- `e2e/helpers/seed.ts` gains a `split` option; `e2e/fixtures.ts` gains a `seedOptions` override.
- Full E2E suite 9/9; focus specs 18/18 across `--repeat-each=3`. Unit suite 155/155.

Builds on the E2E harness from #6; addresses the focus class of bugs that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
