### PR TITLE
refactor: extract domain-meaningful magic numbers into named constants

### DIFF
--- a/electron/config.ts
+++ b/electron/config.ts
@@ -11,6 +11,7 @@ import {
   PROJECTS_STATE_FILE,
 } from "./paths";
 import type { ProjectCollectionState, ProjectConfig, SplitLayout } from "./types";
+import { MAX_SPLIT_COLS, MAX_SPLIT_ROWS } from "./validation";
 
 const RESERVED_SLUGS = new Set(["aya-sentinel-new"]);
 
@@ -68,11 +69,11 @@ export function normalizeSplitLayout(
   const r = raw as Record<string, unknown>;
   const rows =
     typeof r.rows === "number" && Number.isInteger(r.rows)
-      ? Math.max(1, Math.min(5, r.rows))
+      ? Math.max(1, Math.min(MAX_SPLIT_ROWS, r.rows))
       : 1;
   const cols =
     typeof r.cols === "number" && Number.isInteger(r.cols)
-      ? Math.max(1, Math.min(5, r.cols))
+      ? Math.max(1, Math.min(MAX_SPLIT_COLS, r.cols))
       : 1;
   const size = rows * cols;
   const rowFr = (numberArray(r.rowFr) ?? []).slice(0, rows);

--- a/electron/control.ts
+++ b/electron/control.ts
@@ -6,6 +6,11 @@ import { parseControlRequest, type ControlRequest } from "./control-protocol";
 import { CONTROL_SOCKET_PATH } from "./paths";
 import type { ControlStatusUpdate } from "./types";
 
+// Max control-socket message size before rejecting the request (bytes).
+const CONTROL_REQUEST_MAX_SIZE_BYTES = 64_000;
+// rw------- permissions for the control socket file.
+const SOCKET_FILE_PERMISSIONS = 0o600;
+
 interface ControlServerOptions {
   getWindow: () => BrowserWindow | null;
   openProject: (directory: string) => void;
@@ -85,7 +90,7 @@ export function startControlServer(options: ControlServerOptions): () => void {
     socket.setEncoding("utf8");
     socket.on("data", (chunk) => {
       buffer += chunk;
-      if (buffer.length > 64_000) {
+      if (buffer.length > CONTROL_REQUEST_MAX_SIZE_BYTES) {
         sendJson(socket, { ok: false, error: "request too large" });
         socket.end();
         return;
@@ -110,7 +115,7 @@ export function startControlServer(options: ControlServerOptions): () => void {
 
   server.listen(CONTROL_SOCKET_PATH, () => {
     try {
-      fs.chmodSync(CONTROL_SOCKET_PATH, 0o600);
+      fs.chmodSync(CONTROL_SOCKET_PATH, SOCKET_FILE_PERMISSIONS);
     } catch {
       // best effort
     }

--- a/electron/git.ts
+++ b/electron/git.ts
@@ -9,8 +9,19 @@ import type { ProjectGitInfo } from "./types";
 
 const execAsync = promisify(exec);
 
-const OPTS = { timeout: 1500, windowsHide: true } as const;
-const DIFF_OPTS = { timeout: 3000, maxBuffer: 5_000_000, windowsHide: true } as const;
+// Timeout for quick git info commands (branch / status).
+const GIT_COMMAND_TIMEOUT_MS = 1500;
+// Timeout for the (potentially larger) git diff command.
+const GIT_DIFF_TIMEOUT_MS = 3000;
+// Ceiling on git diff output buffered into memory (5MB).
+const GIT_DIFF_MAX_BUFFER_BYTES = 5_000_000;
+
+const OPTS = { timeout: GIT_COMMAND_TIMEOUT_MS, windowsHide: true } as const;
+const DIFF_OPTS = {
+  timeout: GIT_DIFF_TIMEOUT_MS,
+  maxBuffer: GIT_DIFF_MAX_BUFFER_BYTES,
+  windowsHide: true,
+} as const;
 
 export async function getGitInfo(directory: string): Promise<ProjectGitInfo> {
   try {

--- a/electron/harnesses.ts
+++ b/electron/harnesses.ts
@@ -21,6 +21,9 @@ export interface HarnessDef {
   command: string;
 }
 
+// Timeout for the login-shell PATH probe used to detect a harness binary.
+const COMMAND_PROBE_TIMEOUT_MS = 2500;
+
 /** Known agent harnesses + interactive AI CLIs we'll probe for. Add new
  *  ones here as the ecosystem grows. */
 export const KNOWN_HARNESSES: readonly HarnessDef[] = [
@@ -126,7 +129,7 @@ async function commandExists(binary: string): Promise<boolean> {
     execFile(
       userShell(),
       ["-l", "-c", `command -v -- ${binary} >/dev/null 2>&1`],
-      { timeout: 2500, windowsHide: true },
+      { timeout: COMMAND_PROBE_TIMEOUT_MS, windowsHide: true },
       (err) => resolve(err === null),
     );
   });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -53,6 +53,24 @@ import type { CliStatus } from "./types";
 
 const DEV_SERVER_URL = "http://localhost:5183";
 const WINDOW_TITLE = IS_DEV ? "Aya Dev" : "Aya";
+
+// Filesystem mode for the installed CLI executable (rwxr-xr-x)
+const CLI_EXECUTABLE_MODE = 0o755;
+// Maximum number of entries returned by path completion
+const MAX_PATH_COMPLETION_ENTRIES = 100;
+// Maximum number of keyboard-navigable projects (Cmd/Ctrl+1..9)
+const MAX_KEYBOARD_PROJECTS = 9;
+// Minimum dimensions of the main application window (px)
+const WINDOW_MIN_WIDTH = 800;
+const WINDOW_MIN_HEIGHT = 500;
+// Theme colors shared between About-dialog CSS and BrowserWindow chrome
+const COLOR_DARK_BG = "#0d1117";
+const COLOR_LIGHT_TEXT = "#f0f6fc";
+// About dialog window dimensions (square, px)
+const ABOUT_DIALOG_SIZE = 360;
+// About dialog icon dimensions (square, px)
+const ABOUT_ICON_SIZE = 128;
+
 const ptyHost = new PtyHostClient(path.join(__dirname, "pty-host.js"));
 
 function pathEntries(): string[] {
@@ -123,8 +141,8 @@ async function installCli(): Promise<CliStatus> {
   const source = bundledAyaCliPath();
   const target = path.join(installDir, "aya");
   const script = `#!/bin/sh\nexec ${JSON.stringify(source)} "$@"\n`;
-  await fs.writeFile(target, script, { mode: 0o755 });
-  await fs.chmod(target, 0o755);
+  await fs.writeFile(target, script, { mode: CLI_EXECUTABLE_MODE });
+  await fs.chmod(target, CLI_EXECUTABLE_MODE);
   return {
     ...(await cliStatus()),
     path: target,
@@ -259,7 +277,7 @@ async function completeDirectoryPath(rawPrefix: string): Promise<string[]> {
       return entry.name.startsWith(namePrefix);
     })
     .sort((a, b) => a.name.localeCompare(b.name))
-    .slice(0, 100)
+    .slice(0, MAX_PATH_COMPLETION_ENTRIES)
     .map((entry) => `${rawDirPrefix}${entry.name}/`);
 }
 
@@ -286,8 +304,8 @@ function showAyaAboutPanel(): void {
   }
   const parent = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
   const about = new BrowserWindow({
-    width: 360,
-    height: 360,
+    width: ABOUT_DIALOG_SIZE,
+    height: ABOUT_DIALOG_SIZE,
     resizable: false,
     minimizable: false,
     maximizable: false,
@@ -295,7 +313,7 @@ function showAyaAboutPanel(): void {
     parent,
     modal: !!parent,
     title: `About ${WINDOW_TITLE}`,
-    backgroundColor: "#0d1117",
+    backgroundColor: COLOR_DARK_BG,
     show: false,
     webPreferences: {
       sandbox: true,
@@ -323,8 +341,8 @@ function showAyaAboutPanel(): void {
         height: 100%;
         overflow: hidden;
         font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
-        color: #f0f6fc;
-        background: #0d1117;
+        color: ${COLOR_LIGHT_TEXT};
+        background: ${COLOR_DARK_BG};
       }
       body {
         display: flex;
@@ -338,8 +356,8 @@ function showAyaAboutPanel(): void {
       }
       img {
         display: block;
-        width: 128px;
-        height: 128px;
+        width: ${ABOUT_ICON_SIZE}px;
+        height: ${ABOUT_ICON_SIZE}px;
         margin: 0 auto 18px;
       }
       h1 {
@@ -359,7 +377,7 @@ function showAyaAboutPanel(): void {
         height: 30px;
         border: 1px solid #30363d;
         border-radius: 6px;
-        color: #f0f6fc;
+        color: ${COLOR_LIGHT_TEXT};
         background: #161b22;
         font: inherit;
         font-size: 13px;
@@ -518,7 +536,7 @@ function installApplicationMenu(): void {
     },
     {
       label: "Project",
-      submenu: Array.from({ length: 9 }, (_, i) => ({
+      submenu: Array.from({ length: MAX_KEYBOARD_PROJECTS }, (_, i) => ({
         label: `Select Project ${i + 1}`,
         accelerator: `CmdOrCtrl+${i + 1}`,
         click: () => dispatchShortcut(`project-${i + 1}`),
@@ -571,11 +589,11 @@ function createWindow(initial: WindowGeometry): BrowserWindow {
     y: initial.y,
     width: initial.width,
     height: initial.height,
-    minWidth: 800,
-    minHeight: 500,
+    minWidth: WINDOW_MIN_WIDTH,
+    minHeight: WINDOW_MIN_HEIGHT,
     title: WINDOW_TITLE,
     titleBarStyle: "hiddenInset",
-    backgroundColor: "#0d1117",
+    backgroundColor: COLOR_DARK_BG,
     show: false,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
@@ -652,7 +670,7 @@ function createWindow(initial: WindowGeometry): BrowserWindow {
     else if (key === "]") action = "next-tab";
     else if (key === "f") action = "find-in-pane";
     else if (key === "k") action = "search";
-    else if (key.length === 1 && key >= "1" && key <= "9") {
+    else if (key.length === 1 && key >= "1" && key <= String(MAX_KEYBOARD_PROJECTS)) {
       action = `project-${key}`;
     }
     if (!action) return;

--- a/electron/pty-host-client.ts
+++ b/electron/pty-host-client.ts
@@ -13,6 +13,11 @@ import {
 import type { BufferSearchHit } from "./pty";
 import type { SpawnRequest } from "./types";
 
+// Deadline waiting for the pty host to create its socket (ms).
+const PTY_HOST_SOCKET_WAIT_TIMEOUT_MS = 5_000;
+// Interval between socket-existence polls while waiting (ms).
+const PTY_HOST_SOCKET_POLL_INTERVAL_MS = 50;
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
@@ -124,10 +129,10 @@ export class PtyHostClient {
   }
 
   private async waitForSocket(): Promise<void> {
-    const deadline = Date.now() + 5_000;
+    const deadline = Date.now() + PTY_HOST_SOCKET_WAIT_TIMEOUT_MS;
     while (Date.now() < deadline) {
       if (fs.existsSync(PTY_HOST_SOCKET_PATH)) return;
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, PTY_HOST_SOCKET_POLL_INTERVAL_MS));
     }
     throw new Error(`PTY host did not create ${path.basename(PTY_HOST_SOCKET_PATH)}`);
   }

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -19,6 +19,11 @@ import {
 } from "./pty";
 import type { PtyEvent } from "./types";
 
+// Wait before shutting down the idle pty host with no clients or ptys (ms).
+const IDLE_SHUTDOWN_TIMEOUT_MS = 30_000;
+// rw------- permissions for the pty-host socket file.
+const SOCKET_FILE_PERMISSIONS = 0o600;
+
 const clients = new Set<net.Socket>();
 let idleTimer: NodeJS.Timeout | null = null;
 
@@ -70,7 +75,7 @@ function scheduleIdleShutdown(): void {
   if (clients.size > 0 || activePtyCount() > 0 || idleTimer) return;
   idleTimer = setTimeout(() => {
     if (clients.size === 0 && activePtyCount() === 0) process.exit(0);
-  }, 30_000);
+  }, IDLE_SHUTDOWN_TIMEOUT_MS);
 }
 
 function start(): void {
@@ -121,7 +126,7 @@ function start(): void {
 
   server.listen(PTY_HOST_SOCKET_PATH, () => {
     try {
-      fs.chmodSync(PTY_HOST_SOCKET_PATH, 0o600);
+      fs.chmodSync(PTY_HOST_SOCKET_PATH, SOCKET_FILE_PERMISSIONS);
     } catch {
       // best effort
     }

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -15,6 +15,17 @@ import type * as PtyModule from "node-pty";
 import type { PtyEvent, SpawnFailureReason, SpawnRequest } from "./types";
 import { AYA_HOME, CONTROL_SOCKET_PATH } from "./paths";
 
+// Timeout for the shell `command -v` existence check during spawn preflight.
+const COMMAND_CHECK_TIMEOUT_MS = 2500;
+// Minimum PTY dimensions clamped before spawn/resize (node-pty needs >0).
+const MIN_PTY_COLS = 4; // minimum PTY columns
+const MIN_PTY_ROWS = 2; // minimum PTY rows
+// Search-snippet context window around a match (chars).
+const SEARCH_SNIPPET_CONTEXT_BEFORE = 30; // chars before the match
+const SEARCH_SNIPPET_CONTEXT_AFTER = 50; // chars after the match
+// Stop counting occurrences past this many (snippet "more" cap).
+const SEARCH_MAX_COUNT_DISPLAY = 99;
+
 let nodePty: typeof PtyModule | null = null;
 
 function loadNodePty(): typeof PtyModule {
@@ -131,8 +142,11 @@ export function searchPtyOutputs(query: string): BufferSearchHit[] {
       (best, t) => (t.idx < best.idx ? t : best),
       tokenIdxs[0],
     );
-    const start = Math.max(0, earliest.idx - 30);
-    const end = Math.min(cleaned.length, earliest.idx + earliest.len + 50);
+    const start = Math.max(0, earliest.idx - SEARCH_SNIPPET_CONTEXT_BEFORE);
+    const end = Math.min(
+      cleaned.length,
+      earliest.idx + earliest.len + SEARCH_SNIPPET_CONTEXT_AFTER,
+    );
     const snippet = cleaned.slice(start, end).replace(/\s+/g, " ").trim();
     const matchStartInSnippet = Math.max(
       0,
@@ -147,9 +161,9 @@ export function searchPtyOutputs(query: string): BufferSearchHit[] {
         if (next < 0) break;
         more += 1;
         from = next + tok.length;
-        if (more > 99) break;
+        if (more > SEARCH_MAX_COUNT_DISPLAY) break;
       }
-      if (more > 99) break;
+      if (more > SEARCH_MAX_COUNT_DISPLAY) break;
     }
     hits.push({
       ptyId,
@@ -225,7 +239,7 @@ function commandExists(binary: string): Promise<boolean> {
     execFile(
       userShell(),
       ["-l", "-c", `command -v -- ${binary} >/dev/null 2>&1`],
-      { timeout: 2500, windowsHide: true },
+      { timeout: COMMAND_CHECK_TIMEOUT_MS, windowsHide: true },
       (err) => resolve(err === null),
     );
   });
@@ -335,8 +349,8 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
   try {
     child = loadNodePty().spawn(file, args, {
       name: "xterm-256color",
-      cols: Math.max(req.cols, 4),
-      rows: Math.max(req.rows, 2),
+      cols: Math.max(req.cols, MIN_PTY_COLS),
+      rows: Math.max(req.rows, MIN_PTY_ROWS),
       cwd,
       env: safeEnv(req, cwd),
     });
@@ -376,7 +390,7 @@ export function resizePty(ptyId: string, cols: number, rows: number): void {
   const p = ptys.get(ptyId);
   if (!p) return;
   try {
-    p.resize(Math.max(cols, 4), Math.max(rows, 2));
+    p.resize(Math.max(cols, MIN_PTY_COLS), Math.max(rows, MIN_PTY_ROWS));
   } catch {
     // ignore — pty may have just exited
   }

--- a/electron/validation.ts
+++ b/electron/validation.ts
@@ -18,6 +18,12 @@ import { isSnippet, SNIPPET_TEXT_MAX } from "./snippets";
  *  payloads before any per-item work happens. */
 const SNIPPETS_IPC_MAX = 1_000;
 
+/** Maximum split-grid dimensions (rows x cols). Single source of truth for the
+ *  split-layout limit — imported by config.ts so the clamp and this validator
+ *  enforce the same rule. */
+export const MAX_SPLIT_ROWS = 5;
+export const MAX_SPLIT_COLS = 5;
+
 function fail(name: string, expected: string): never {
   throw new Error(`Invalid IPC payload for ${name}: expected ${expected}.`);
 }
@@ -86,8 +92,10 @@ function validateSplitLayout(value: unknown): SplitLayout {
   if (!isRecord(value)) fail("projects:update.splitLayout", "SplitLayout object");
   const rows = requirePositiveInt(value.rows, "projects:update.splitLayout.rows");
   const cols = requirePositiveInt(value.cols, "projects:update.splitLayout.cols");
-  if (rows > 5) fail("projects:update.splitLayout.rows", "integer <= 5");
-  if (cols > 5) fail("projects:update.splitLayout.cols", "integer <= 5");
+  if (rows > MAX_SPLIT_ROWS)
+    fail("projects:update.splitLayout.rows", `integer <= ${MAX_SPLIT_ROWS}`);
+  if (cols > MAX_SPLIT_COLS)
+    fail("projects:update.splitLayout.cols", `integer <= ${MAX_SPLIT_COLS}`);
   const size = rows * cols;
   const cellsValue = value.cells;
   if (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,21 @@ import {
   type WorkingTab,
 } from "./types";
 
+// Cadence for polling the active project's git branch/dirty count (no inotify watch).
+const GIT_STATUS_POLL_INTERVAL_MS = 3000;
+// Cap on retained entries in the project event timeline.
+const MAX_PROJECT_EVENTS = 200;
+// Cap on preset suggestions offered during repo preset import.
+const MAX_SUGGESTED_PRESETS = 8;
+// Minimum fractional size of a split pane; drives the drag clamp.
+const MIN_SPLIT_PANE_FRACTION = 0.18;
+// Default sidebar width in pixels.
+const DEFAULT_SIDEBAR_WIDTH_PX = 240;
+// Default terminal font size in pixels.
+const TERMINAL_FONT_SIZE_PX = 13;
+// Persisted schema version for ProjectCollectionState.
+const PROJECT_STATE_VERSION = 1;
+
 // Hard fallback used only if the themes file is somehow empty before boot
 // resolves — matches AYA_DARK in electron/themes.ts.
 const FALLBACK_THEME_COLORS: ThemeColors = {
@@ -315,7 +330,7 @@ export function App() {
   const [allProjects, setAllProjects] = useState<ProjectConfig[]>([]);
   const [projects, setProjects] = useState<ProjectConfig[]>([]);
   const [projectState, setProjectState] = useState<ProjectCollectionState>({
-    version: 1,
+    version: PROJECT_STATE_VERSION,
     order: [],
     open: [],
     recent: [],
@@ -350,7 +365,7 @@ export function App() {
   const [pendingRepoImport, setPendingRepoImport] =
     useState<PendingRepoImport | null>(null);
   const [findInPaneFor, setFindInPaneFor] = useState<string | null>(null);
-  const [sidebarWidth, setSidebarWidth] = useState(240);
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH_PX);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [didBootstrap, setDidBootstrap] = useState(false);
   const [harnessScanDone, setHarnessScanDone] = useState(false);
@@ -358,7 +373,7 @@ export function App() {
   const [hideNoHarnessHint, setHideNoHarnessHint] = useState(
     () => localStorage.getItem("aya:no-harness-hint-dismissed") === "1",
   );
-  const fontSize = 13;
+  const fontSize = TERMINAL_FONT_SIZE_PX;
 
   // Status-bar branch / dirty count goes stale once you `git checkout` in a
   // shell or commit something — there's no inotify watch, just a small poll
@@ -378,7 +393,7 @@ export function App() {
       });
     };
     refresh();
-    const id = setInterval(refresh, 3000);
+    const id = setInterval(refresh, GIT_STATUS_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(id);
@@ -470,7 +485,7 @@ export function App() {
           createdAt: event.createdAt ?? Date.now(),
         },
         ...prev,
-      ].slice(0, 200));
+      ].slice(0, MAX_PROJECT_EVENTS));
     },
     [],
   );
@@ -527,7 +542,7 @@ export function App() {
   const saveProjectCollectionState = useCallback(
     (next: ProjectCollectionState) => {
       const normalized: ProjectCollectionState = {
-        version: 1,
+        version: PROJECT_STATE_VERSION,
         order: dedupeSlugs(next.order),
         open: dedupeSlugs(next.open),
         recent: dedupeSlugs(next.recent),
@@ -630,7 +645,7 @@ export function App() {
       const recent =
         loadedProjectState.recent.length > 0 ? loadedProjectState.recent : order;
       const normalizedState: ProjectCollectionState = {
-        version: 1,
+        version: PROJECT_STATE_VERSION,
         order: dedupeSlugs(order).filter((slug) => seededSlugs.has(slug)),
         open: dedupeSlugs(open).filter((slug) => seededSlugs.has(slug)),
         recent: dedupeSlugs(recent).filter((slug) => seededSlugs.has(slug)),
@@ -787,7 +802,7 @@ export function App() {
         localStorage.setItem(ignoredKey, "1");
         return;
       }
-      setPendingRepoImport({ project, presets: suggestions.slice(0, 8) });
+      setPendingRepoImport({ project, presets: suggestions.slice(0, MAX_SUGGESTED_PRESETS) });
     });
     return () => {
       cancelled = true;
@@ -1147,7 +1162,7 @@ export function App() {
         if (index < 0 || index >= values.length - 1 || totalPx <= 0) return layout;
         const totalFr = values.reduce((sum, value) => sum + value, 0);
         const deltaFr = (deltaPx / totalPx) * totalFr;
-        const min = 0.18;
+        const min = MIN_SPLIT_PANE_FRACTION;
         const left = Math.max(min, values[index] + deltaFr);
         const right = Math.max(min, values[index + 1] - deltaFr);
         values[index] = left;

--- a/src/bell.ts
+++ b/src/bell.ts
@@ -5,6 +5,9 @@
 // approval-prompt strings. Imperfect but correct for the common case where the
 // agent literally renders the approval box on screen.
 
+// Min stripped char-count for a chunk to be treated as "busy output".
+const BUSY_OUTPUT_MIN_LENGTH = 64;
+
 const APPROVAL_PATTERNS: RegExp[] = [
   /Do you want to/i,
   /Do you want me to/i,
@@ -37,5 +40,5 @@ export function detectApproval(chunk: string): boolean {
 // signal that the agent is busy working, not waiting. Use length as a cheap
 // proxy after stripping ANSI.
 export function looksBusy(chunk: string): boolean {
-  return stripAnsi(chunk).trim().length > 64;
+  return stripAnsi(chunk).trim().length > BUSY_OUTPUT_MIN_LENGTH;
 }

--- a/src/components/AttentionCenter.tsx
+++ b/src/components/AttentionCenter.tsx
@@ -1,5 +1,8 @@
 import type { ProjectConfig, ProjectEvent, TerminalState } from "../types";
 
+// Max number of recent events shown in the attention center.
+const VISIBLE_EVENTS_LIMIT = 18;
+
 interface Props {
   projects: ProjectConfig[];
   terminals: Record<string, TerminalState>;
@@ -91,7 +94,7 @@ export function AttentionCenter({
       const rank = { error: 3, waiting: 2, done: 1 };
       return rank[b.level] - rank[a.level] || a.project.name.localeCompare(b.project.name);
     });
-  const visibleEvents = events.slice(0, 18);
+  const visibleEvents = events.slice(0, VISIBLE_EVENTS_LIMIT);
 
   return (
     <div className="aya-modal-backdrop" role="presentation" onMouseDown={onClose}>

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -8,6 +8,11 @@ import {
   type TerminalState,
 } from "../types";
 
+// Debounce delay (ms) applied to the search input before it becomes the active query.
+const SEARCH_DEBOUNCE_MS = 100;
+// Maximum number of ranked search results returned from a query.
+const SEARCH_MAX_RESULTS = 50;
+
 interface Props {
   projects: ProjectConfig[];
   allProjects: ProjectConfig[];
@@ -321,7 +326,7 @@ function buildResults(
   }
 
   out.sort((a, b) => b.score - a.score || a.label.localeCompare(b.label));
-  return out.slice(0, 50);
+  return out.slice(0, SEARCH_MAX_RESULTS);
 }
 
 export function SearchModal({
@@ -351,7 +356,7 @@ export function SearchModal({
   // it feels live, slow enough that single keystrokes don't trigger a
   // full re-rank + RPC round-trip.
   useEffect(() => {
-    const id = setTimeout(() => setQuery(inputValue), 100);
+    const id = setTimeout(() => setQuery(inputValue), SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(id);
   }, [inputValue]);
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -25,6 +25,14 @@ interface Props {
   onImportTheme: () => Promise<Theme | null>;
 }
 
+// Claude brand color (used for the Claude YOLO preset and as the color placeholder)
+const CLAUDE_BRAND_COLOR = "#d97757";
+// Preset table column widths (px) kept in sync between header row and body rows
+const PRESET_ROW_ICON_WIDTH = 36;
+const PRESET_ROW_NAME_WIDTH = 130;
+const PRESET_ROW_THEME_WIDTH = 130;
+const PRESET_ROW_COLOR_WIDTH = 70;
+
 function uuid(): string {
   return Math.random().toString(36).slice(2, 10);
 }
@@ -192,7 +200,7 @@ export function SettingsModal({
       id: "claude-yolo",
       name: "Claude YOLO",
       icon: "✻",
-      color: "#d97757",
+      color: CLAUDE_BRAND_COLOR,
       command: "claude --dangerously-skip-permissions",
       themeId: undefined,
     });
@@ -451,11 +459,11 @@ export function SettingsModal({
 
         <div className="aya-settings-list">
           <div className="aya-settings-row aya-settings-row--head">
-            <span style={{ width: 36 }}>Icon</span>
-            <span style={{ width: 130 }}>Name</span>
+            <span style={{ width: PRESET_ROW_ICON_WIDTH }}>Icon</span>
+            <span style={{ width: PRESET_ROW_NAME_WIDTH }}>Name</span>
             <span style={{ flex: 1 }}>Command</span>
-            <span style={{ width: 130 }}>Theme</span>
-            <span style={{ width: 70 }}>Color</span>
+            <span style={{ width: PRESET_ROW_THEME_WIDTH }}>Theme</span>
+            <span style={{ width: PRESET_ROW_COLOR_WIDTH }}>Color</span>
             <span style={{ width: 28 }} />
           </div>
           {draft.map((row) => {
@@ -464,14 +472,14 @@ export function SettingsModal({
               <div className="aya-settings-row" key={row.__key}>
                 <input
                   className="aya-modal-input aya-settings-icon-input"
-                  style={{ width: 36 }}
+                  style={{ width: PRESET_ROW_ICON_WIDTH }}
                   value={row.icon}
                   maxLength={3}
                   onChange={(e) => updateRow(row.__key, { icon: e.target.value })}
                 />
                 <input
                   className="aya-modal-input"
-                  style={{ width: 130 }}
+                  style={{ width: PRESET_ROW_NAME_WIDTH }}
                   value={row.name}
                   onChange={(e) => updateRow(row.__key, { name: e.target.value })}
                   placeholder="Display name"
@@ -502,7 +510,7 @@ export function SettingsModal({
                 </div>
                 <select
                   className="aya-modal-input"
-                  style={{ width: 130 }}
+                  style={{ width: PRESET_ROW_THEME_WIDTH }}
                   value={row.themeId ?? ""}
                   onChange={(e) =>
                     updateRow(row.__key, {
@@ -520,12 +528,12 @@ export function SettingsModal({
                 </select>
                 <input
                   className="aya-modal-input"
-                  style={{ width: 70 }}
+                  style={{ width: PRESET_ROW_COLOR_WIDTH }}
                   value={row.color}
                   onChange={(e) =>
                     updateRow(row.__key, { color: e.target.value })
                   }
-                  placeholder="#d97757"
+                  placeholder={CLAUDE_BRAND_COLOR}
                   spellCheck={false}
                 />
                 <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState, type DragEvent } from "react";
 import { getPreset, type Preset, type TerminalState } from "../types";
 
+// Clamp bounds for drag-resizing the sidebar (px).
+const SIDEBAR_MIN_WIDTH_PX = 180;
+const SIDEBAR_MAX_WIDTH_PX = 380;
+
 interface Props {
   terminals: TerminalState[];
   activeId: string | null;
@@ -158,7 +162,7 @@ export function Sidebar({
   useEffect(() => {
     const move = (e: MouseEvent) => {
       if (!resizing.current) return;
-      const w = Math.max(180, Math.min(380, e.clientX));
+      const w = Math.max(SIDEBAR_MIN_WIDTH_PX, Math.min(SIDEBAR_MAX_WIDTH_PX, e.clientX));
       onResize(w);
     };
     const up = () => {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js/lib/common";
 import type { GitChangedFile, ProjectConfig, TerminalState } from "../types";
 
+// Material Symbols small icon size (px) used for status-bar glyphs
+const ICON_SIZE_SM_PX = 13;
+
 interface GitInfo {
   branch: string | null;
   dirty: number;
@@ -83,7 +86,7 @@ export function StatusBar({
           title="Open project directory"
           onClick={() => onOpenProjectDirectory(project.directory)}
         >
-          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
             folder
           </span>
           {project.directory}
@@ -94,7 +97,7 @@ export function StatusBar({
           <span
             style={{
               fontFamily: "Material Symbols Outlined",
-              fontSize: 13,
+              fontSize: ICON_SIZE_SM_PX,
               fontVariationSettings: '"FILL" 1',
             }}
           >
@@ -108,7 +111,7 @@ export function StatusBar({
           className={`aya-statusbar-item aya-statusbar-item--agent aya-statusbar-item--agent-${externalStatus.level}`}
           title={new Date(externalStatus.updatedAt).toLocaleString()}
         >
-          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
             smart_toy
           </span>
           {externalStatus.text}
@@ -123,14 +126,14 @@ export function StatusBar({
         title="Open attention center"
         onClick={onOpenAttentionCenter}
       >
-        <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+        <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
           notifications_active
         </span>
         {attentionCount > 0 ? `${attentionCount} attention` : "activity"}
       </button>
       {git?.branch && (
         <span className="aya-statusbar-item">
-          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
             fork_right
           </span>
           {git.branch}
@@ -144,7 +147,7 @@ export function StatusBar({
             title="Show changed files"
             onClick={toggleDirtyFiles}
           >
-            <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+            <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
               edit_note
             </span>
             {git.dirty} dirty
@@ -216,7 +219,7 @@ export function StatusBar({
           className="aya-statusbar-item"
           style={{ color: "var(--status-active)" }}
         >
-          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: 13 }}>
+          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
             check_circle
           </span>
           clean

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState, type DragEvent } from "react";
 import type { ProjectConfig } from "../types";
 
+// Project tab width bounds (px): tabs shrink to min, then overflow the strip.
+const TAB_MIN_WIDTH_PX = 120;
+const TAB_MAX_WIDTH_PX = 320;
+
 interface ProjectAttention {
   count: number;
   level: "done" | "waiting" | "error";
@@ -192,8 +196,8 @@ export function TopBar({
               // fill spare room, shrink to 120px, then overflow the strip.
               style={{
                 flex: "1 1 240px",
-                minWidth: 120,
-                maxWidth: 320,
+                minWidth: TAB_MIN_WIDTH_PX,
+                maxWidth: TAB_MAX_WIDTH_PX,
               }}
               draggable={!isRenaming}
               onDragStart={(e) => handleDragStart(e, p.slug)}

--- a/src/hooks/useTerminalSignals.ts
+++ b/src/hooks/useTerminalSignals.ts
@@ -8,6 +8,9 @@ import {
 } from "react";
 import type { ProjectConfig, TerminalState } from "../types";
 
+// Poll interval (ms) for ticking recent-activity recomputation.
+const ACTIVITY_TICK_INTERVAL_MS = 800;
+
 export function useDockBadge(
   terminals: Record<string, TerminalState>,
 ): void {
@@ -70,7 +73,10 @@ export function useRecentTerminalActivity(): RecentActivity {
   const [activityTick, setActivityTick] = useState(0);
 
   useEffect(() => {
-    const id = setInterval(() => setActivityTick((t) => t + 1), 800);
+    const id = setInterval(
+      () => setActivityTick((t) => t + 1),
+      ACTIVITY_TICK_INTERVAL_MS,
+    );
     return () => clearInterval(id);
   }, []);
 

--- a/tests/atomic-write.test.mjs
+++ b/tests/atomic-write.test.mjs
@@ -16,6 +16,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { writeFileAtomic } from "../dist-electron/atomic-write.js";
 
+// Per-writer payload length (chars) in the concurrent-write race test.
+const RACE_TEST_PAYLOAD_SIZE = 2000;
+// Large-payload stress size (bytes) for the atomic-write durability test.
+const ATOMIC_WRITE_LARGE_PAYLOAD_BYTES = 200000;
+
 async function makeTmpDir() {
   return mkdtemp(path.join(tmpdir(), "aya-atomic-"));
 }
@@ -89,8 +94,10 @@ test("concurrent writes to the same path don't truncate the result", async () =>
   const dir = await makeTmpDir();
   try {
     const target = path.join(dir, "race.json");
-    const A = '{"writer":"A","payload":"' + "A".repeat(2000) + '"}';
-    const B = '{"writer":"B","payload":"' + "B".repeat(2000) + '"}';
+    const A =
+      '{"writer":"A","payload":"' + "A".repeat(RACE_TEST_PAYLOAD_SIZE) + '"}';
+    const B =
+      '{"writer":"B","payload":"' + "B".repeat(RACE_TEST_PAYLOAD_SIZE) + '"}';
     await Promise.all([writeFileAtomic(target, A), writeFileAtomic(target, B)]);
     const contents = await readFile(target, "utf8");
     assert.ok(
@@ -108,11 +115,11 @@ test("survives writing a large payload (~200KB)", async () => {
   const dir = await makeTmpDir();
   try {
     const target = path.join(dir, "big.json");
-    const big = '"' + "x".repeat(200_000) + '"';
+    const big = '"' + "x".repeat(ATOMIC_WRITE_LARGE_PAYLOAD_BYTES) + '"';
     await writeFileAtomic(target, big);
     const stats = await stat(target);
     // The +2 accounts for the surrounding quotes.
-    assert.equal(stats.size, 200_002);
+    assert.equal(stats.size, ATOMIC_WRITE_LARGE_PAYLOAD_BYTES + 2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/bell.test.mjs
+++ b/tests/bell.test.mjs
@@ -81,6 +81,14 @@ test("looksBusy returns false for short output (likely a prompt cursor or quiet 
   assert.equal(looksBusy(""), false);
 });
 
+test("looksBusy pins the length boundary (just-under is quiet, at/over is busy)", () => {
+  // The heuristic clears once a chunk's stripped length crosses the threshold.
+  const justUnder = "x".repeat(64);
+  const over = "x".repeat(65);
+  assert.equal(looksBusy(justUnder), false);
+  assert.equal(looksBusy(over), true);
+});
+
 test("looksBusy ignores ANSI noise when judging length", () => {
   // 100+ chars of ANSI but only a tiny stripped body.
   const ansiHeavy = "\x1b[1;31m\x1b[2J\x1b[H\x1b[0m\x1b[1;34m\x1b[K\x1b[0m" +

--- a/tests/ipc-validation.test.mjs
+++ b/tests/ipc-validation.test.mjs
@@ -136,6 +136,63 @@ test("validateProjectConfig rejects invalid split layout payloads", () => {
   );
 });
 
+test("validateProjectConfig accepts a max 5x5 split but rejects one beyond max", () => {
+  const base = {
+    slug: "aya",
+    name: "Aya",
+    directory: "/tmp/aya",
+    tabs: [{ id: "t1", presetId: "shell", name: "Shell" }],
+  };
+  // A layout at the split-grid maximum (5 rows x 5 cols) validates OK.
+  const atMax = validateProjectConfig({
+    ...base,
+    splitLayout: {
+      rows: 5,
+      cols: 5,
+      rowFr: [1, 1, 1, 1, 1],
+      colFr: [1, 1, 1, 1, 1],
+      cells: ["t1"],
+      activeCell: 0,
+    },
+  });
+  assert.equal(atMax.splitLayout?.rows, 5);
+  assert.equal(atMax.splitLayout?.cols, 5);
+
+  // One row beyond the maximum is rejected.
+  assert.throws(
+    () =>
+      validateProjectConfig({
+        ...base,
+        splitLayout: {
+          rows: 6,
+          cols: 5,
+          rowFr: [1],
+          colFr: [1],
+          cells: ["t1"],
+          activeCell: 0,
+        },
+      }),
+    /splitLayout\.rows/,
+  );
+
+  // One col beyond the maximum is rejected.
+  assert.throws(
+    () =>
+      validateProjectConfig({
+        ...base,
+        splitLayout: {
+          rows: 5,
+          cols: 6,
+          rowFr: [1],
+          colFr: [1],
+          cells: ["t1"],
+          activeCell: 0,
+        },
+      }),
+    /splitLayout\.cols/,
+  );
+});
+
 test("validateProjectCollectionState accepts order/open/recent arrays", () => {
   assert.deepEqual(
     validateProjectCollectionState({

--- a/tests/pty-buffer.test.mjs
+++ b/tests/pty-buffer.test.mjs
@@ -13,6 +13,9 @@ import {
   searchPtyOutputs,
 } from "../dist-electron/pty.js";
 
+// Per-chunk size (bytes) used to overflow the rolling buffer in the trim test.
+const BUFFER_TEST_CHUNK_SIZE_BYTES = 30000;
+
 // The buffer is private to pty.ts. To exercise it we expose getBufferedOutput
 // and rely on the public spawnPty path elsewhere. For unit testing the trim,
 // we drive a stub via a local reimplementation matching the production code.
@@ -89,14 +92,18 @@ test("buffer trims oldest chunks once total exceeds limit", () => {
   // Expect the oldest chunks to be dropped.
   for (let i = 0; i < 40; i++) {
     const tag = String.fromCharCode(97 + i); // "a", "b", "c", ...
-    b.append(tag.repeat(30_000));
+    b.append(tag.repeat(BUFFER_TEST_CHUNK_SIZE_BYTES));
   }
   const result = b.read();
   assert.ok(result.length <= OUTPUT_BUFFER_MAX);
   // The first chunk(s) should be gone. "a" is definitely gone.
   assert.equal(result.includes("a"), false);
   // The last chunk must be present in full.
-  assert.ok(result.includes(String.fromCharCode(97 + 39).repeat(30_000)));
+  assert.ok(
+    result.includes(
+      String.fromCharCode(97 + 39).repeat(BUFFER_TEST_CHUNK_SIZE_BYTES),
+    ),
+  );
 });
 
 test("buffer keeps at least one chunk even if it exceeds the limit", () => {


### PR DESCRIPTION
Project-wide magic-numbers audit: detection + extraction fanned out across modules in parallel, then a cross-cutting confirmation pass run until no new findings surfaced. Behaviour-preserving - every numeric value is unchanged, only named.

## What was extracted
Timeouts/intervals, limits/buffers, thresholds, file permissions, reused colors and icon sizes - across electron/ (git, pty, pty-host, control, main, harnesses, validation/config) and src/ (App, bell, StatusBar, SettingsModal, Sidebar, TopBar, AttentionCenter, SearchModal, hooks).

Highlight - real DRY rojazd fixed: the split-grid maximum (5) was duplicated as a bare literal in both the IPC validator (validation.ts) and the clamp (config.ts). Consolidated to one exported MAX_SPLIT_ROWS / MAX_SPLIT_COLS source of truth in validation.ts, imported by config.ts - code and validator now agree by construction.

## Tests
- Named the test-fixture sizes (atomic-write, pty-buffer).
- Added two honest behaviour-pinning boundary tests (split max accept/reject in ipc-validation; bell busy-length boundary). Both verified by smoking-gun mutation - mutating the constant fails exactly the test. No tautologies.

## Deliberately left (with justification)
- One-off CSS pixels / font-sizes / margins (naming adds nothing; a pin-test would be a tautology).
- SearchModal's ~35 ranking-score weights - a self-documenting relative-magnitude table (exact 1000 > prefix 500 > contains 200); naming each would scatter the gradient.
- Trivial 0/1 and slice indices.
- The coincidentally-equal 2500ms command-check (pty.ts) vs command-probe (harnesses.ts) timeouts - independent subsystems, no correctness coupling. Unifying would create a false single-source-of-truth (accidental duplication, kept separate).

## Verification
- npm run typecheck (renderer + electron): clean
- npm test: 157 unit tests green
- npm run test:e2e: green modulo a known teardown-race flake unrelated to this change

Generated with Claude Code
