### PR TITLE
ci: harden E2E deps step against transient apt mirror flakes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,16 @@ jobs:
       # X server. install-deps pulls the shared libs; xvfb-run provides the display.
       - name: Install Electron system dependencies
         run: |
+          # Runner-added third-party apt sources (Google Chrome, Microsoft, VSCode)
+          # intermittently fail `apt-get update` mid mirror-sync ("File has
+          # unexpected size ... Mirror sync in progress?"), reddening the E2E job.
+          # None are needed for Electron's Chromium libs or xvfb, so drop them
+          # first. Globs cover both .list and deb822 .sources naming; rm -f is a
+          # no-op if a given runner image doesn't have them.
+          sudo rm -f /etc/apt/sources.list.d/*google* \
+            /etc/apt/sources.list.d/*chrome* \
+            /etc/apt/sources.list.d/*microsoft* \
+            /etc/apt/sources.list.d/*vscode*
           npx playwright install-deps
           sudo apt-get install -y xvfb
 


### PR DESCRIPTION
The E2E (Electron) job intermittently goes red on the "Install Electron system dependencies" step (not on tests). npx playwright install-deps runs apt-get update, which fails when a runner-added THIRD-PARTY apt source is mid mirror-sync:

    Err: https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
      File has unexpected size (1210 != 1211). Mirror sync in progress?

(This reddened main right after the #14 merge; a job re-run then passed, confirming it is a transient infra flake, not the code.)

## Fix
The Google Chrome / Microsoft / VSCode apt sources GitHub pre-adds to the runner are not needed for Electron's Chromium libs or xvfb - but any one of them syncing fails the whole apt-get update. Remove them before the install. Globs cover both .list and deb822 .sources naming; rm -f is a no-op when a runner image does not have them. The actual installs (playwright install-deps + xvfb) are unchanged.

Codex-assisted; YAML validated.

Generated with Claude Code
