### PR TITLE
fix: persist the active terminal/project/view across restart (#18)

### DIFF
--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -137,3 +137,49 @@ test("a dangling persisted activeTab falls back to the first terminal", async ()
     rmSync(s.root, { recursive: true, force: true });
   }
 });
+
+// The persisted activeProject (which project tab is selected) must also be
+// restored — not just the active terminal within a project. With two open
+// projects, the saved active one (here the SECOND, non-default) has to win over
+// "fall back to the first open project". Guards the bootstrap branch at
+// App.tsx setActiveProjectId(savedActiveProject) (#18).
+test("the last-active project is restored across a restart (#18)", async () => {
+  const s = seedEnv({ split: false }); // gives project "e2e" (slug e2e-proj)
+  try {
+    // Add a SECOND project ("Bravo") sharing the same (existing) directory, then
+    // mark it as the active project. e2e-proj is first in `order`, so without
+    // restore the app would default to it — the test only passes if the saved
+    // activeProject (proj-b) is honoured.
+    writeFileSync(
+      join(s.ayaHome, "projects", "proj-b.json"),
+      JSON.stringify({
+        name: "Bravo",
+        directory: s.projectDir,
+        tabs: [{ id: "tab-bravo", presetId: "shell", name: "bravo 1" }],
+      }),
+    );
+    writeFileSync(
+      join(s.ayaHome, "projects-state.json"),
+      JSON.stringify({
+        version: 1,
+        order: ["e2e-proj", "proj-b"],
+        open: ["e2e-proj", "proj-b"],
+        recent: ["proj-b", "e2e-proj"],
+        activeProject: "proj-b",
+      }),
+    );
+    const app = await launch(s.ayaHome, s.userDataDir, s.root);
+    const win = await app.firstWindow();
+    await win.waitForLoadState("domcontentloaded");
+    // The active project tab is Bravo (the saved one), not the first/default e2e.
+    await expect(
+      win.locator(".aya-tab--active .aya-tab-name"),
+    ).toHaveText(/Bravo/);
+    // And its terminal is the one shown in the sidebar (proves we switched the
+    // whole active context, not just the tab label).
+    await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/bravo 1/);
+    await killAndWait(app);
+  } finally {
+    rmSync(s.root, { recursive: true, force: true });
+  }
+});

--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -5,7 +5,7 @@ import {
   type ElectronApplication,
 } from "@playwright/test";
 import { join } from "node:path";
-import { rmSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import { seedEnv } from "./helpers/seed";
 
 // Reproduces: after restart the FIRST terminal is selected, not the one that
@@ -62,6 +62,41 @@ test("the last-active terminal stays active across a restart (#18)", async () =>
     win = await app.firstWindow();
     await win.waitForLoadState("domcontentloaded");
     await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
+    app.process().kill("SIGKILL");
+  } finally {
+    rmSync(s.root, { recursive: true, force: true });
+  }
+});
+
+// A persisted activeTab can point at a terminal that no longer exists (the user
+// deleted that tab between sessions). The restore must drop the dangling pointer
+// and fall back to the first tab — not select a ghost id and render a blank
+// pane. Guards the bootstrap validation branch (tabIds.has(saved)) + hydration's
+// stillValid check (#18).
+test("a dangling persisted activeTab falls back to the first terminal", async () => {
+  const s = seedEnv({ split: false });
+  try {
+    // Overwrite the seeded state so the active terminal points at an id that is
+    // not one of the project's tabs (tab-left / tab-right).
+    writeFileSync(
+      join(s.ayaHome, "projects-state.json"),
+      JSON.stringify({
+        version: 1,
+        order: ["e2e-proj"],
+        open: ["e2e-proj"],
+        recent: ["e2e-proj"],
+        activeProject: "e2e-proj",
+        activeTab: { "e2e-proj": "tab-deleted" },
+        singleView: { "e2e-proj": "tab-deleted" },
+      }),
+    );
+    const app = await launch(s.ayaHome, s.userDataDir, s.root);
+    const win = await app.firstWindow();
+    await win.waitForLoadState("domcontentloaded");
+    // Falls back to the first tab (shell 1) and actually renders a terminal
+    // (a dangling pointer would leave the active pane blank).
+    await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+    await expect(win.locator(".xterm").first()).toBeVisible();
     app.process().kill("SIGKILL");
   } finally {
     rmSync(s.root, { recursive: true, force: true });

--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -5,7 +5,7 @@ import {
   type ElectronApplication,
 } from "@playwright/test";
 import { join } from "node:path";
-import { rmSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { seedEnv } from "./helpers/seed";
 
 // Reproduces: after restart the FIRST terminal is selected, not the one that
@@ -37,6 +37,37 @@ function launch(
   return electron.launch({ args, cwd: APP_ROOT, env });
 }
 
+/** Poll projects-state.json until the persisted active terminal for a project
+ *  matches the expected id — deterministic replacement for a fixed sleep, so we
+ *  kill the app only once the debounced IPC write has actually landed on disk. */
+async function waitForPersistedActiveTab(
+  ayaHome: string,
+  slug: string,
+  tabId: string,
+): Promise<void> {
+  const file = join(ayaHome, "projects-state.json");
+  await expect
+    .poll(
+      () => {
+        try {
+          return JSON.parse(readFileSync(file, "utf8")).activeTab?.[slug] ?? null;
+        } catch {
+          return null;
+        }
+      },
+      { timeout: 5000 },
+    )
+    .toBe(tabId);
+}
+
+/** SIGKILL the app and wait for the OS to actually reap it before relaunching
+ *  the same AYA_HOME — deterministic replacement for a fixed settle sleep. */
+async function killAndWait(app: ElectronApplication): Promise<void> {
+  const proc = app.process();
+  proc.kill("SIGKILL");
+  await new Promise<void>((resolve) => proc.once("exit", () => resolve()));
+}
+
 // Regression guard for #18: the active terminal per project is now persisted
 // (ProjectCollectionState.activeTab), so it survives a restart instead of
 // resetting to the first one.
@@ -50,11 +81,10 @@ test("the last-active terminal stays active across a restart (#18)", async () =>
     await win.waitForLoadState("domcontentloaded");
     await win.locator(".aya-sidebar-row", { hasText: "shell 2" }).click();
     await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
-    // Let the async state save (IPC -> atomic write) flush before we kill it,
-    // otherwise the SIGKILL can interrupt the write and nothing was persisted.
-    await win.waitForTimeout(800);
-    app.process().kill("SIGKILL");
-    await new Promise((r) => setTimeout(r, 1500)); // let the pty-host / state settle
+    // Wait for the debounced IPC write to actually land on disk before killing —
+    // a fixed sleep here would race the write under load and persist nothing.
+    await waitForPersistedActiveTab(s.ayaHome, "e2e-proj", "tab-right");
+    await killAndWait(app);
 
     // Relaunch the same home. The terminal that was active should still be
     // active — not reset to the first one.
@@ -62,7 +92,7 @@ test("the last-active terminal stays active across a restart (#18)", async () =>
     win = await app.firstWindow();
     await win.waitForLoadState("domcontentloaded");
     await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
-    app.process().kill("SIGKILL");
+    await killAndWait(app);
   } finally {
     rmSync(s.root, { recursive: true, force: true });
   }
@@ -93,11 +123,16 @@ test("a dangling persisted activeTab falls back to the first terminal", async ()
     const app = await launch(s.ayaHome, s.userDataDir, s.root);
     const win = await app.firstWindow();
     await win.waitForLoadState("domcontentloaded");
-    // Falls back to the first tab (shell 1) and actually renders a terminal
-    // (a dangling pointer would leave the active pane blank).
+    // Falls back to the first tab (shell 1) and actually renders THAT terminal:
+    // the visible pane header reads "shell 1". A dangling pointer would instead
+    // leave the active pane showing the "Empty pane" placeholder (no terminal
+    // for the ghost id), so this pins which terminal renders, not just that one
+    // does.
     await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
-    await expect(win.locator(".xterm").first()).toBeVisible();
-    app.process().kill("SIGKILL");
+    await expect(
+      win.locator(".aya-pane-header-title").filter({ hasText: /shell 1/ }),
+    ).toBeVisible();
+    await killAndWait(app);
   } finally {
     rmSync(s.root, { recursive: true, force: true });
   }

--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -37,10 +37,10 @@ function launch(
   return electron.launch({ args, cwd: APP_ROOT, env });
 }
 
-// Known bug #18: the active terminal is not persisted, so it resets to the
-// first one on restart. Marked fixme so CI stays green until the fix lands —
-// flip `test.fixme` back to `test` then and it becomes the regression guard.
-test.fixme("the last-active terminal stays active across a restart (#18)", async () => {
+// Regression guard for #18: the active terminal per project is now persisted
+// (ProjectCollectionState.activeTab), so it survives a restart instead of
+// resetting to the first one.
+test("the last-active terminal stays active across a restart (#18)", async () => {
   const s = seedEnv({ split: false }); // sidebar switching, one terminal shown
   try {
     // First launch: the project opens on its first tab ("shell 1"). Switch to
@@ -50,6 +50,9 @@ test.fixme("the last-active terminal stays active across a restart (#18)", async
     await win.waitForLoadState("domcontentloaded");
     await win.locator(".aya-sidebar-row", { hasText: "shell 2" }).click();
     await expect(win.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
+    // Let the async state save (IPC -> atomic write) flush before we kill it,
+    // otherwise the SIGKILL can interrupt the write and nothing was persisted.
+    await win.waitForTimeout(800);
     app.process().kill("SIGKILL");
     await new Promise((r) => setTimeout(r, 1500)); // let the pty-host / state settle
 

--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -13,6 +13,15 @@ import { seedEnv } from "./helpers/seed";
 // second terminal, quit, relaunch, and check which terminal is shown.
 
 const APP_ROOT = join(__dirname, "..");
+const ACTIVE_TAB_PERSISTENCE_TIMEOUT_MS = 5_000;
+
+function projectStatePath(ayaHome: string): string {
+  return join(ayaHome, "projects-state.json");
+}
+
+function writeProjectState(ayaHome: string, state: unknown): void {
+  writeFileSync(projectStatePath(ayaHome), JSON.stringify(state));
+}
 
 function launch(
   ayaHome: string,
@@ -45,7 +54,7 @@ async function waitForPersistedActiveTab(
   slug: string,
   tabId: string,
 ): Promise<void> {
-  const file = join(ayaHome, "projects-state.json");
+  const file = projectStatePath(ayaHome);
   await expect
     .poll(
       () => {
@@ -55,7 +64,7 @@ async function waitForPersistedActiveTab(
           return null;
         }
       },
-      { timeout: 5000 },
+      { timeout: ACTIVE_TAB_PERSISTENCE_TIMEOUT_MS },
     )
     .toBe(tabId);
 }
@@ -108,18 +117,15 @@ test("a dangling persisted activeTab falls back to the first terminal", async ()
   try {
     // Overwrite the seeded state so the active terminal points at an id that is
     // not one of the project's tabs (tab-left / tab-right).
-    writeFileSync(
-      join(s.ayaHome, "projects-state.json"),
-      JSON.stringify({
-        version: 1,
-        order: ["e2e-proj"],
-        open: ["e2e-proj"],
-        recent: ["e2e-proj"],
-        activeProject: "e2e-proj",
-        activeTab: { "e2e-proj": "tab-deleted" },
-        singleView: { "e2e-proj": "tab-deleted" },
-      }),
-    );
+    writeProjectState(s.ayaHome, {
+      version: 1,
+      order: ["e2e-proj"],
+      open: ["e2e-proj"],
+      recent: ["e2e-proj"],
+      activeProject: "e2e-proj",
+      activeTab: { "e2e-proj": "tab-deleted" },
+      singleView: { "e2e-proj": "tab-deleted" },
+    });
     const app = await launch(s.ayaHome, s.userDataDir, s.root);
     const win = await app.firstWindow();
     await win.waitForLoadState("domcontentloaded");
@@ -158,16 +164,13 @@ test("the last-active project is restored across a restart (#18)", async () => {
         tabs: [{ id: "tab-bravo", presetId: "shell", name: "bravo 1" }],
       }),
     );
-    writeFileSync(
-      join(s.ayaHome, "projects-state.json"),
-      JSON.stringify({
-        version: 1,
-        order: ["e2e-proj", "proj-b"],
-        open: ["e2e-proj", "proj-b"],
-        recent: ["proj-b", "e2e-proj"],
-        activeProject: "proj-b",
-      }),
-    );
+    writeProjectState(s.ayaHome, {
+      version: 1,
+      order: ["e2e-proj", "proj-b"],
+      open: ["e2e-proj", "proj-b"],
+      recent: ["proj-b", "e2e-proj"],
+      activeProject: "proj-b",
+    });
     const app = await launch(s.ayaHome, s.userDataDir, s.root);
     const win = await app.firstWindow();
     await win.waitForLoadState("domcontentloaded");

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -11,7 +11,12 @@ import {
   PROJECTS_STATE_FILE,
 } from "./paths";
 import type { ProjectCollectionState, ProjectConfig, SplitLayout } from "./types";
-import { MAX_SPLIT_COLS, MAX_SPLIT_ROWS } from "./validation";
+import {
+  MAX_SPLIT_COLS,
+  MAX_SPLIT_ROWS,
+  PROJECT_STATE_VERSION,
+  sanitizeStringRecord,
+} from "./validation";
 
 const RESERVED_SLUGS = new Set(["aya-sentinel-new"]);
 
@@ -111,18 +116,6 @@ async function loadStringArrayFile(filePath: string): Promise<string[] | null> {
   }
 }
 
-/** A plain string->string map, dropping any non-string values. Used for the
- *  optional activeTab / singleView selections (back-compat: absent => {}). */
-function stringRecord(x: unknown): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (typeof x === "object" && x !== null && !Array.isArray(x)) {
-    for (const [k, v] of Object.entries(x)) {
-      if (typeof v === "string") out[k] = v;
-    }
-  }
-  return out;
-}
-
 export function normalizeProjectState(
   raw: unknown,
 ): ProjectCollectionState | null {
@@ -133,13 +126,13 @@ export function normalizeProjectState(
   const recent = stringArray(r.recent);
   if (!order || !open || !recent) return null;
   return {
-    version: 1,
+    version: PROJECT_STATE_VERSION,
     order,
     open,
     recent,
     activeProject: typeof r.activeProject === "string" ? r.activeProject : null,
-    activeTab: stringRecord(r.activeTab),
-    singleView: stringRecord(r.singleView),
+    activeTab: sanitizeStringRecord(r.activeTab),
+    singleView: sanitizeStringRecord(r.singleView),
   };
 }
 
@@ -155,7 +148,12 @@ export async function listProjectState(): Promise<ProjectCollectionState> {
   const order = (await loadStringArrayFile(PROJECTS_ORDER_FILE)) ?? [];
   const open = (await loadStringArrayFile(OPEN_PROJECTS_FILE)) ?? order;
   const recent = order.length > 0 ? order : open;
-  const migrated: ProjectCollectionState = { version: 1, order, open, recent };
+  const migrated: ProjectCollectionState = {
+    version: PROJECT_STATE_VERSION,
+    order,
+    open,
+    recent,
+  };
   if (order.length > 0 || open.length > 0) {
     await saveProjectState(migrated);
   }
@@ -171,7 +169,7 @@ export async function saveProjectState(
   // bug — a dropped activeTab/activeProject — is exactly what reset the active
   // selection on restart, #18).
   const normalized = normalizeProjectState(state) ?? {
-    version: 1 as const,
+    version: PROJECT_STATE_VERSION,
     order: [],
     open: [],
     recent: [],

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -111,14 +111,36 @@ async function loadStringArrayFile(filePath: string): Promise<string[] | null> {
   }
 }
 
-function normalizeProjectState(raw: unknown): ProjectCollectionState | null {
+/** A plain string->string map, dropping any non-string values. Used for the
+ *  optional activeTab / singleView selections (back-compat: absent => {}). */
+function stringRecord(x: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (typeof x === "object" && x !== null && !Array.isArray(x)) {
+    for (const [k, v] of Object.entries(x)) {
+      if (typeof v === "string") out[k] = v;
+    }
+  }
+  return out;
+}
+
+export function normalizeProjectState(
+  raw: unknown,
+): ProjectCollectionState | null {
   if (typeof raw !== "object" || raw === null) return null;
   const r = raw as Record<string, unknown>;
   const order = stringArray(r.order);
   const open = stringArray(r.open);
   const recent = stringArray(r.recent);
   if (!order || !open || !recent) return null;
-  return { version: 1, order, open, recent };
+  return {
+    version: 1,
+    order,
+    open,
+    recent,
+    activeProject: typeof r.activeProject === "string" ? r.activeProject : null,
+    activeTab: stringRecord(r.activeTab),
+    singleView: stringRecord(r.singleView),
+  };
 }
 
 export async function listProjectState(): Promise<ProjectCollectionState> {
@@ -143,11 +165,19 @@ export async function listProjectState(): Promise<ProjectCollectionState> {
 export async function saveProjectState(
   state: ProjectCollectionState,
 ): Promise<void> {
-  const normalized: ProjectCollectionState = {
-    version: 1,
-    order: state.order,
-    open: state.open,
-    recent: state.recent,
+  // Persist through the SAME normalizer the loader uses, so read and write can
+  // never diverge: every field the schema knows about is round-tripped, and no
+  // future field can be silently dropped by a hand-maintained pick list (that
+  // bug — a dropped activeTab/activeProject — is exactly what reset the active
+  // selection on restart, #18).
+  const normalized = normalizeProjectState(state) ?? {
+    version: 1 as const,
+    order: [],
+    open: [],
+    recent: [],
+    activeProject: null,
+    activeTab: {},
+    singleView: {},
   };
   await writeFileAtomic(
     PROJECTS_STATE_FILE,

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -53,6 +53,12 @@ export interface ProjectCollectionState {
   order: string[];
   open: string[];
   recent: string[];
+  /** Last active project (slug), restored on boot. Optional for back-compat. */
+  activeProject?: string | null;
+  /** Active terminal id per project slug, so the selection survives a restart. */
+  activeTab?: Record<string, string>;
+  /** Per-project single-terminal view: the shown terminal id (absent = all/split). */
+  singleView?: Record<string, string>;
 }
 
 export interface SpawnRequest {

--- a/electron/validation.ts
+++ b/electron/validation.ts
@@ -134,17 +134,41 @@ export function validateProjectConfig(value: unknown): ProjectConfig {
   };
 }
 
+/** A lenient string->string map for the optional active-selection fields:
+ *  absent or non-object => {}, and any non-string value is dropped. Mirrors
+ *  config.ts `stringRecord` so the IPC boundary and the persistence normalizer
+ *  agree on the shape. */
+function optionalStringRecord(value: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (isRecord(value)) {
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === "string") out[k] = v;
+    }
+  }
+  return out;
+}
+
 export function validateProjectCollectionState(
   value: unknown,
 ): ProjectCollectionState {
   if (!isRecord(value)) {
     fail("projects:save-state", "ProjectCollectionState object");
   }
+  // The active-selection fields (activeProject / activeTab / singleView) are
+  // optional and validated leniently: the renderer is the source of truth for
+  // them and a malformed entry must never block a save. They are passed through
+  // here so the IPC boundary doesn't silently drop them — dropping them is
+  // exactly the hand-built-subset bug that reset the active terminal on restart
+  // (#18). Read this together with config.ts saveProjectState / normalizeProjectState.
   return {
     version: 1,
     order: requireStringArray(value.order, "projects:save-state.order"),
     open: requireStringArray(value.open, "projects:save-state.open"),
     recent: requireStringArray(value.recent, "projects:save-state.recent"),
+    activeProject:
+      typeof value.activeProject === "string" ? value.activeProject : null,
+    activeTab: optionalStringRecord(value.activeTab),
+    singleView: optionalStringRecord(value.singleView),
   };
 }
 

--- a/electron/validation.ts
+++ b/electron/validation.ts
@@ -18,6 +18,9 @@ import { isSnippet, SNIPPET_TEXT_MAX } from "./snippets";
  *  payloads before any per-item work happens. */
 const SNIPPETS_IPC_MAX = 1_000;
 
+/** Persisted schema version for projects-state.json. */
+export const PROJECT_STATE_VERSION = 1;
+
 /** Maximum split-grid dimensions (rows x cols). Single source of truth for the
  *  split-layout limit — imported by config.ts so the clamp and this validator
  *  enforce the same rule. */
@@ -134,11 +137,9 @@ export function validateProjectConfig(value: unknown): ProjectConfig {
   };
 }
 
-/** A lenient string->string map for the optional active-selection fields:
- *  absent or non-object => {}, and any non-string value is dropped. Mirrors
- *  config.ts `stringRecord` so the IPC boundary and the persistence normalizer
- *  agree on the shape. */
-function optionalStringRecord(value: unknown): Record<string, string> {
+/** A lenient string->string map for optional persisted selections:
+ *  absent or non-object => {}, and any non-string value is dropped. */
+export function sanitizeStringRecord(value: unknown): Record<string, string> {
   const out: Record<string, string> = {};
   if (isRecord(value)) {
     for (const [k, v] of Object.entries(value)) {
@@ -161,14 +162,14 @@ export function validateProjectCollectionState(
   // exactly the hand-built-subset bug that reset the active terminal on restart
   // (#18). Read this together with config.ts saveProjectState / normalizeProjectState.
   return {
-    version: 1,
+    version: PROJECT_STATE_VERSION,
     order: requireStringArray(value.order, "projects:save-state.order"),
     open: requireStringArray(value.open, "projects:save-state.open"),
     recent: requireStringArray(value.recent, "projects:save-state.recent"),
     activeProject:
       typeof value.activeProject === "string" ? value.activeProject : null,
-    activeTab: optionalStringRecord(value.activeTab),
-    singleView: optionalStringRecord(value.singleView),
+    activeTab: sanitizeStringRecord(value.activeTab),
+    singleView: sanitizeStringRecord(value.singleView),
   };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,17 @@ function dedupeSlugs(slugs: string[]): string[] {
   return out;
 }
 
+/** Drop null/undefined values so the persisted selection map only has live ids. */
+function compactRecord(
+  record: Record<string, string | null>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value) out[key] = value;
+  }
+  return out;
+}
+
 interface GitInfo {
   branch: string | null;
   dirty: number;
@@ -606,19 +617,52 @@ export function App() {
     setActiveTabByProject,
   });
 
-  const saveProjectCollectionState = useCallback(
+  // Update the order/open/recent collection state. Persistence is centralised in
+  // the single writer effect below, so this only updates in-memory state — it
+  // never writes to disk itself (no scattered saves that can race or drop
+  // fields). The active project / terminal / view live in their own state and
+  // are persisted by the same writer.
+  const updateProjectCollection = useCallback(
     (next: ProjectCollectionState) => {
-      const normalized: ProjectCollectionState = {
+      setProjectState({
         version: PROJECT_STATE_VERSION,
         order: dedupeSlugs(next.order),
         open: dedupeSlugs(next.open),
         recent: dedupeSlugs(next.recent),
-      };
-      setProjectState(normalized);
-      void window.aya.saveProjectState(normalized);
+      });
     },
     [],
   );
+
+  // === Single persistence owner for projects-state.json ===
+  // Everything that can change the persisted UI state — order/open/recent AND
+  // the active project / terminal / view — flows through here and nowhere else.
+  // Before this, the file was written from several places (bootstrap, the
+  // collection setter, per-feature handlers); they raced, and because each
+  // hand-built the payload, the active selections were dropped — that's the
+  // root of #18. One debounced writer, keyed on all the inputs, makes the disk
+  // a pure function of state and removes the race by construction.
+  useEffect(() => {
+    if (!didBootstrap) return;
+    const handle = window.setTimeout(() => {
+      void window.aya.saveProjectState({
+        version: PROJECT_STATE_VERSION,
+        order: projectState.order,
+        open: projectState.open,
+        recent: projectState.recent,
+        activeProject: activeProjectId,
+        activeTab: compactRecord(activeTabByProject),
+        singleView: compactRecord(singleViewByProject),
+      });
+    }, 150);
+    return () => window.clearTimeout(handle);
+  }, [
+    didBootstrap,
+    projectState,
+    activeProjectId,
+    activeTabByProject,
+    singleViewByProject,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Hydration helper — instantiates TerminalStates for a project's saved tabs.
@@ -643,10 +687,19 @@ export function App() {
         }
         return next;
       });
-      setActiveTabByProject((prev) => ({
-        ...prev,
-        [project.slug]: project.tabs[0]?.id ?? null,
-      }));
+      // Default the active tab to the first one ONLY when this project has no
+      // valid active tab yet. A restored selection (set from the persisted
+      // activeTab on boot) must survive hydration — clobbering it here is what
+      // reset the active terminal to the first tab on restart (#18).
+      setActiveTabByProject((prev) => {
+        const existing = prev[project.slug];
+        const stillValid =
+          !!existing && project.tabs.some((t) => t.id === existing);
+        return {
+          ...prev,
+          [project.slug]: stillValid ? existing : (project.tabs[0]?.id ?? null),
+        };
+      });
     },
     [],
   );
@@ -711,14 +764,43 @@ export function App() {
           : seededProjects.map((p) => p.slug);
       const recent =
         loadedProjectState.recent.length > 0 ? loadedProjectState.recent : order;
+      // Restore the persisted active selections, but validate them against the
+      // projects/terminals that actually exist now — a deleted project or tab
+      // must not leave the active pointer dangling (it would fall through to a
+      // stale id instead of the first tab).
+      const savedActiveTab = loadedProjectState.activeTab ?? {};
+      const savedSingleView = loadedProjectState.singleView ?? {};
+      const validActiveTab: Record<string, string> = {};
+      const validSingleView: Record<string, string> = {};
+      for (const p of seededProjects) {
+        const tabIds = new Set(p.tabs.map((t) => t.id));
+        if (tabIds.has(savedActiveTab[p.slug])) {
+          validActiveTab[p.slug] = savedActiveTab[p.slug];
+        }
+        if (tabIds.has(savedSingleView[p.slug])) {
+          validSingleView[p.slug] = savedSingleView[p.slug];
+        }
+      }
+      const savedActiveProject =
+        loadedProjectState.activeProject &&
+        seededSlugs.has(loadedProjectState.activeProject)
+          ? loadedProjectState.activeProject
+          : null;
+
       const normalizedState: ProjectCollectionState = {
         version: PROJECT_STATE_VERSION,
         order: dedupeSlugs(order).filter((slug) => seededSlugs.has(slug)),
         open: dedupeSlugs(open).filter((slug) => seededSlugs.has(slug)),
         recent: dedupeSlugs(recent).filter((slug) => seededSlugs.has(slug)),
+        activeProject: savedActiveProject,
+        activeTab: validActiveTab,
+        singleView: validSingleView,
       };
+      // Seed in-memory state; the single writer effect persists it once
+      // didBootstrap flips (no direct save here — that used to race the writer).
       setProjectState(normalizedState);
-      void window.aya.saveProjectState(normalizedState);
+      setActiveTabByProject(validActiveTab);
+      setSingleViewByProject(validSingleView);
       const openSlugSet = new Set(normalizedState.open);
       const openProjects = seededProjects.filter((p) => openSlugSet.has(p.slug));
       setProjects(openProjects);
@@ -746,7 +828,10 @@ export function App() {
 
       const cwdProject = openProjects.find((p) => p.directory === cwd);
       if (cwdProject) {
+        // An explicit `aya <dir>` launch still wins over the saved selection.
         setActiveProjectId(cwdProject.slug);
+      } else if (savedActiveProject && openSlugSet.has(savedActiveProject)) {
+        setActiveProjectId(savedActiveProject);
       } else if (openProjects.length > 0) {
         setActiveProjectId(openProjects[0].slug);
       } else {
@@ -1324,11 +1409,11 @@ export function App() {
       }
       return out;
     });
-    saveProjectCollectionState({
+    updateProjectCollection({
       ...projectStateRef.current,
       order: nextOrder,
     });
-  }, [saveProjectCollectionState]);
+  }, [updateProjectCollection]);
 
   /** Reorder a project's terminal tabs. Walks the terminals map and
    *  rebuilds it with the new key order — `project.tabs` is derived from
@@ -1401,7 +1486,7 @@ export function App() {
     });
     const remaining = projectsRef.current.filter((p) => p.slug !== slug);
     setProjects(remaining);
-    saveProjectCollectionState({
+    updateProjectCollection({
       ...projectStateRef.current,
       open: remaining.map((p) => p.slug),
       recent: dedupeSlugs([slug, ...projectStateRef.current.recent]),
@@ -1434,7 +1519,7 @@ export function App() {
       const nextProjects = [...projectsRef.current, project];
       setProjects(nextProjects);
       setActiveProjectId(project.slug);
-      saveProjectCollectionState({
+      updateProjectCollection({
         ...projectStateRef.current,
         order: dedupeSlugs([...projectStateRef.current.order, project.slug]),
         open: nextProjects.map((p) => p.slug),
@@ -1458,7 +1543,7 @@ export function App() {
         ]);
       }
     },
-    [hydrateProjectTerminals, saveProjectCollectionState],
+    [hydrateProjectTerminals, updateProjectCollection],
   );
 
   const onCreateProject = useCallback(
@@ -1476,7 +1561,7 @@ export function App() {
         setAllProjects((prev) => [...prev, withTabs]);
         const nextProjects = [...projectsRef.current, withTabs];
         setProjects(nextProjects);
-        saveProjectCollectionState({
+        updateProjectCollection({
           ...projectStateRef.current,
           order: dedupeSlugs([...projectStateRef.current.order, withTabs.slug]),
           open: nextProjects.map((p) => p.slug),
@@ -1509,7 +1594,7 @@ export function App() {
         alert(err instanceof Error ? err.message : String(err));
       }
     },
-    [saveProjectCollectionState],
+    [updateProjectCollection],
   );
 
   const onSavePresets = useCallback(async (next: Preset[]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,12 @@ export interface ProjectCollectionState {
   order: string[];
   open: string[];
   recent: string[];
+  /** Last active project (slug), restored on boot. Optional for back-compat. */
+  activeProject?: string | null;
+  /** Active terminal id per project slug, so the selection survives a restart. */
+  activeTab?: Record<string, string>;
+  /** Per-project single-terminal view: the shown terminal id (absent = all/split). */
+  singleView?: Record<string, string>;
 }
 
 export interface ProjectGitInfo {

--- a/tests/config-normalize.test.mjs
+++ b/tests/config-normalize.test.mjs
@@ -200,14 +200,25 @@ test("migrates project order/open files into projects-state.json", async () => {
       { cwd: process.cwd(), env: { ...process.env, AYA_HOME: dir } },
     );
     const { state, persisted } = JSON.parse(stdout);
-    const expected = {
+    // The in-memory migrated value carries only the legacy fields.
+    assert.deepEqual(state, {
       version: 1,
       order: ["a", "b"],
       open: ["b"],
       recent: ["a", "b"],
-    };
-    assert.deepEqual(state, expected);
-    assert.deepEqual(persisted, expected);
+    });
+    // On disk it is round-tripped through the normalizer, so it always carries
+    // the full schema (active fields default to empty) — single source of truth
+    // for read and write (#18).
+    assert.deepEqual(persisted, {
+      version: 1,
+      order: ["a", "b"],
+      open: ["b"],
+      recent: ["a", "b"],
+      activeProject: null,
+      activeTab: {},
+      singleView: {},
+    });
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -243,6 +254,9 @@ test("projects-state.json wins over legacy order/open files", async () => {
       order: ["new"],
       open: [],
       recent: ["new"],
+      activeProject: null,
+      activeTab: {},
+      singleView: {},
     });
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tests/ipc-validation.test.mjs
+++ b/tests/ipc-validation.test.mjs
@@ -194,6 +194,8 @@ test("validateProjectConfig accepts a max 5x5 split but rejects one beyond max",
 });
 
 test("validateProjectCollectionState accepts order/open/recent arrays", () => {
+  // Active-selection fields are optional; when absent they default to empty so
+  // the IPC boundary always emits the full schema (back-compat with old files).
   assert.deepEqual(
     validateProjectCollectionState({
       version: 1,
@@ -206,6 +208,9 @@ test("validateProjectCollectionState accepts order/open/recent arrays", () => {
       order: ["a", "b"],
       open: ["a"],
       recent: ["b", "a"],
+      activeProject: null,
+      activeTab: {},
+      singleView: {},
     },
   );
   assert.throws(
@@ -217,6 +222,57 @@ test("validateProjectCollectionState accepts order/open/recent arrays", () => {
         recent: [],
       }),
     /projects:save-state\.open/,
+  );
+});
+
+test("validateProjectCollectionState passes active selections through (not dropped)", () => {
+  // Regression guard for #18: the IPC validator used to hand-build a
+  // {version,order,open,recent} subset, silently dropping the active terminal /
+  // project / view — so the renderer's restored selection never reached disk.
+  assert.deepEqual(
+    validateProjectCollectionState({
+      version: 1,
+      order: ["a"],
+      open: ["a"],
+      recent: ["a"],
+      activeProject: "a",
+      activeTab: { a: "tab-2" },
+      singleView: { a: "tab-2" },
+    }),
+    {
+      version: 1,
+      order: ["a"],
+      open: ["a"],
+      recent: ["a"],
+      activeProject: "a",
+      activeTab: { a: "tab-2" },
+      singleView: { a: "tab-2" },
+    },
+  );
+});
+
+test("validateProjectCollectionState sanitizes malformed active fields leniently", () => {
+  // A malformed active entry must never block a save — it is coerced, not
+  // rejected (the renderer owns these fields and re-derives them on boot).
+  assert.deepEqual(
+    validateProjectCollectionState({
+      version: 1,
+      order: ["a"],
+      open: ["a"],
+      recent: ["a"],
+      activeProject: 42,
+      activeTab: { a: "tab-1", b: 99, c: null },
+      singleView: "not-an-object",
+    }),
+    {
+      version: 1,
+      order: ["a"],
+      open: ["a"],
+      recent: ["a"],
+      activeProject: null,
+      activeTab: { a: "tab-1" },
+      singleView: {},
+    },
   );
 });
 

--- a/tests/project-state-normalize.test.mjs
+++ b/tests/project-state-normalize.test.mjs
@@ -1,0 +1,49 @@
+// projects-state.json gained optional active-selection fields (activeProject /
+// activeTab / singleView). The loader must (a) accept an OLD file that has none
+// of them — backward compatibility — defaulting to "no selection", and (b)
+// preserve + sanitize them when present, so the active project / terminal / view
+// survive a restart.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeProjectState } from "../dist-electron/config.js";
+
+const base = { version: 1, order: ["a"], open: ["a"], recent: ["a"] };
+
+test("backward compatible: an old file with no active fields loads with empty defaults", () => {
+  const out = normalizeProjectState({ ...base });
+  assert.equal(out.activeProject, null);
+  assert.deepEqual(out.activeTab, {});
+  assert.deepEqual(out.singleView, {});
+  // the existing fields are untouched
+  assert.deepEqual(out.order, ["a"]);
+});
+
+test("preserves active selections when present", () => {
+  const out = normalizeProjectState({
+    ...base,
+    activeProject: "a",
+    activeTab: { a: "tab-2" },
+    singleView: { a: "tab-2" },
+  });
+  assert.equal(out.activeProject, "a");
+  assert.deepEqual(out.activeTab, { a: "tab-2" });
+  assert.deepEqual(out.singleView, { a: "tab-2" });
+});
+
+test("sanitizes: non-string activeProject -> null, non-string map values dropped", () => {
+  const out = normalizeProjectState({
+    ...base,
+    activeProject: 42,
+    activeTab: { a: "tab-1", b: 99, c: null },
+    singleView: "not-an-object",
+  });
+  assert.equal(out.activeProject, null);
+  assert.deepEqual(out.activeTab, { a: "tab-1" }); // numeric/null values dropped
+  assert.deepEqual(out.singleView, {});
+});
+
+test("still rejects a file missing the required arrays", () => {
+  assert.equal(normalizeProjectState({ version: 1, order: ["a"] }), null);
+  assert.equal(normalizeProjectState(null), null);
+});


### PR DESCRIPTION
Fixes #18 — after a restart Aya always selected the FIRST terminal instead of the one that was active when you quit.

## Why this is a bigger change than "save one more field"

The reset wasn't a single missing line. It was the same anti-pattern repeated independently in three persistence layers, plus a fourth bug that erased the restore. Each layer hand-built a {version, order, open, recent} subset of ProjectCollectionState — so even after I added the active fields to the type, every hop quietly dropped them again. Patching one layer just moved the data loss one step downstream (I watched the e2e go red at each layer while debugging).

So the fix is deliberately a small refactor toward a single source of truth, rather than four disconnected patches that would rot the next time someone adds a field.

## The four layers, and the fix in each

A. electron/config.ts saveProjectState — now persists THROUGH normalizeProjectState (the exact function the loader uses) instead of re-listing fields by hand. Read and write round-trip the identical schema, so a new field can never again be dropped by a stale write-side pick list.

B. src/App.tsx — single persistence owner. There is now exactly ONE writer of projects-state.json: a debounced useEffect keyed on order/open/recent + active project/tab/view. The previous scattered writers (the collection setter, a direct save in bootstrap, and a separate per-active-change effect) raced each other; whichever wrote last won, and the bootstrap one wrote empty selections. Collapsing them to one writer removes the race by construction.

C. electron/validation.ts validateProjectCollectionState — the IPC trust boundary now passes the active fields through (validated leniently: a malformed entry is coerced, never rejected, because the renderer owns these and re-derives them on boot). This validator was the layer actually erasing the renderer's already-correct payload — the renderer sent 7 fields, the validator returned 4.

D. src/App.tsx hydrateProjectTerminals — preserves the restored active tab instead of force-resetting it to tabs[0]. It now defaults to the first tab only when the project has no valid active tab yet. Without this, hydration ran after the restore and clobbered the just-restored selection back to shell 1.

## Persistence model / back-compat

ProjectCollectionState gains three OPTIONAL fields: activeProject, activeTab (per-project active terminal id), singleView (per-project single-terminal view id). Optional = an older projects-state.json with none of them loads cleanly with empty defaults, so upgrading users lose nothing and a downgrade just ignores the extra keys.

On boot the restored selections are validated against the projects and terminals that actually still exist, so a project or tab deleted between sessions can't leave a dangling active pointer (it falls back to the first tab, as before).

## Tests

- e2e/restart-active-terminal.spec.ts — flipped from test.fixme to a passing two-launch regression guard: launch, switch to shell 2 via the sidebar, SIGKILL, relaunch the same AYA_HOME, assert shell 2 is still the active row. Stable across repeat runs. This test fails if any one of A/B/C/D is reverted.
- tests/project-state-normalize.test.mjs (new) — normalizeProjectState back-compat: old file -> empty defaults; preserves + sanitizes active fields when present; still rejects files missing the required arrays.
- tests/ipc-validation.test.mjs — added pass-through + lenient-sanitize coverage for validateProjectCollectionState (regression guard for the dropped-fields bug at the IPC boundary).
- tests/config-normalize.test.mjs — updated the migration expectation: the on-disk file now always carries the full schema.

Full unit suite green (226 tests); typecheck clean; full e2e green.

## Review note for maintainers

The single-writer effect in src/App.tsx (search "Single persistence owner") is the load-bearing design choice here. If you later add another piece of persisted UI state, add it to that one effect's payload and deps — please don't reintroduce a second writer or a hand-built subset. The comments in saveProjectState / validateProjectCollectionState / hydrateProjectTerminals all cross-reference #18 to make that intent obvious at each site.
