### PR TITLE
test(e2e): hide Electron window by default

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -39,6 +39,7 @@ export const test = base.extend<{
       }
     }
     env.AYA_HOME = seeded.ayaHome;
+    env.AYA_E2E_HEADLESS = process.env.AYA_E2E_HEADLESS ?? "1";
     // Isolate Codex usage too: point CODEX_HOME at an empty dir so the Codex
     // chip never picks up the real machine's ~/.codex rollout logs.
     env.CODEX_HOME = join(seeded.root, "codex-home");

--- a/e2e/restart-active-terminal.spec.ts
+++ b/e2e/restart-active-terminal.spec.ts
@@ -26,6 +26,7 @@ function launch(
     }
   }
   env.AYA_HOME = ayaHome;
+  env.AYA_E2E_HEADLESS = process.env.AYA_E2E_HEADLESS ?? "1";
   env.CODEX_HOME = join(root, "codex-home");
   const args = [
     join(APP_ROOT, "dist-electron", "main.js"),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -61,6 +61,7 @@ import type { CliStatus } from "./types";
 
 const DEV_SERVER_URL = "http://localhost:5183";
 const WINDOW_TITLE = IS_DEV ? "Aya Dev" : "Aya";
+const E2E_HEADLESS = process.env.AYA_E2E_HEADLESS === "1";
 
 // Filesystem mode for the installed CLI executable (rwxr-xr-x)
 const CLI_EXECUTABLE_MODE = 0o755;
@@ -622,7 +623,9 @@ function createWindow(initial: WindowGeometry): BrowserWindow {
   // and reload that slice in the renderer. Stopped when the window closes.
   const stopConfigWatcher = startConfigWatcher(win);
 
-  win.once("ready-to-show", () => win.show());
+  win.once("ready-to-show", () => {
+    if (!E2E_HEADLESS) win.show();
+  });
   win.on("closed", () => {
     stopConfigWatcher();
     // Keep the module-level ref in sync so second-instance handlers don't

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "build:test-src": "tsc -p tsconfig.test-src.json",
     "build": "npm run build:renderer && npm run build:electron",
     "test": "npm run typecheck:renderer && npm run build:electron && npm run build:test-src && node --test \"tests/**/*.test.mjs\"",
-    "test:e2e": "npm run build && playwright test",
-    "test:e2e:headed": "npm run build && playwright test --headed",
+    "test:e2e": "npm run build && cross-env AYA_E2E_HEADLESS=1 playwright test",
+    "test:e2e:headed": "npm run build && cross-env AYA_E2E_HEADLESS=0 playwright test --headed",
     "package": "npm run build && electron-builder",
     "postinstall": "electron-builder install-app-deps"
   },


### PR DESCRIPTION
## Summary
- run default e2e scripts with AYA_E2E_HEADLESS=1
- keep test:e2e:headed available for visible debug runs
- pass the headless flag through both e2e launch paths and skip win.show() in that mode

## Tests
- npm run build
- npx cross-env AYA_E2E_HEADLESS=1 playwright test e2e/restart-active-terminal.spec.ts
- npx cross-env AYA_E2E_HEADLESS=1 playwright test e2e/smoke.spec.ts