### PR TITLE
Specify Node.js in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "typescript": "^5.6.3",
         "vite": "^8.0.14",
         "wait-on": "^9.0.10"
+      },
+      "engines": {
+        "node": ">=24 <25"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -350,38 +353,12 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
+      "optional": true
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+      "optional": true
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.0",
   "private": true,
   "description": "Agentic terminal manager — Claude Code / Codex / shell sessions organized across projects.",
+  "engines": {
+    "node": ">=24 <25"
+  },
   "homepage": "https://github.com/khasinski/aya",
   "author": {
     "name": "Chris Hasiński",


### PR DESCRIPTION
I initially tried in build it with Node.js 26 but it's does not seem to be fully compatible with electron - `npm run dev` didn't work.

Let me know if you use mise or any other version manager than I can add either `NODE_VERSION`, `mise.toml` or both.