### PR TITLE
Move shell as the first default preset

### DIFF
--- a/electron/presets.ts
+++ b/electron/presets.ts
@@ -27,6 +27,14 @@ export interface Preset {
 
 export const DEFAULT_PRESETS: readonly Preset[] = [
   {
+    id: "shell",
+    name: "Shell",
+    icon: "$",
+    color: "",
+    // The literal $SHELL — the PTY wrapper expands this to the user's shell.
+    command: "$SHELL",
+  },
+  {
     id: "claude",
     name: "Claude Code",
     icon: "✻",
@@ -41,14 +49,6 @@ export const DEFAULT_PRESETS: readonly Preset[] = [
     icon: "◆",
     color: "#10a37f",
     command: "codex",
-  },
-  {
-    id: "shell",
-    name: "Shell",
-    icon: "$",
-    color: "",
-    // The literal $SHELL — the PTY wrapper expands this to the user's shell.
-    command: "$SHELL",
   },
 ];
 


### PR DESCRIPTION
This PR modifies `DEFAULT_PRESETS` so when you run `npm run dev` without having `claude` installed, the terminal does not break.