### PR TITLE
test(e2e): cover untested core flows — project creation, search, terminal close

### DIFF
--- a/e2e/new-project.spec.ts
+++ b/e2e/new-project.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Creating a project via the top-bar "+" had no e2e coverage at all, even though
+// it is a core flow. These cover the happy path (a real directory becomes a new
+// active project tab named after its basename) and the validation guard (a
+// non-existent directory is rejected inline, not silently turned into a broken
+// project).
+
+test("the + button opens a real directory as a new active project", async ({
+  window,
+  seeded,
+}) => {
+  // A real directory the app's dirExists check will accept.
+  const dir = join(seeded.root, "freshproj");
+  mkdirSync(dir);
+
+  await window.locator(".aya-tab-new").click();
+  const input = window.locator(".aya-modal-input");
+  await expect(input).toBeVisible();
+  await input.fill(dir);
+  await window.locator(".aya-modal-btn--primary").click();
+
+  // A new project tab named after the directory's basename becomes active.
+  await expect(
+    window.locator(".aya-tab--active .aya-tab-name"),
+  ).toHaveText(/freshproj/);
+  // The modal closed (no input left on screen).
+  await expect(window.locator(".aya-modal-input")).toHaveCount(0);
+});
+
+test("a non-existent directory is rejected inline, no project is created", async ({
+  window,
+  seeded,
+}) => {
+  const missing = join(seeded.root, "does-not-exist-xyz");
+
+  await window.locator(".aya-tab-new").click();
+  const input = window.locator(".aya-modal-input");
+  await expect(input).toBeVisible();
+  await input.fill(missing);
+  await window.locator(".aya-modal-btn--primary").click();
+
+  // Inline error, modal stays open, no new project tab appears.
+  await expect(window.locator(".aya-modal-error")).toContainText(
+    /directory does not exist/i,
+  );
+  await expect(window.locator(".aya-modal-input")).toBeVisible();
+  await expect(
+    window.locator(".aya-tab-name", { hasText: "does-not-exist-xyz" }),
+  ).toHaveCount(0);
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "./fixtures";
+import { test, expect } from "./fixtures";
+import type { Page, Locator } from "@playwright/test";
 
 // Buffer-content search (Cmd/Ctrl+K, ptySearch over each PTY's output buffer)
 // had no behavioural e2e — only focus-on-close was covered. Search reads the
@@ -9,6 +10,15 @@ test.use({ seedOptions: { split: false } }); // single-view: one active terminal
 
 async function typeInActiveTerminal(window: Page, text: string) {
   await window.locator(".aya-pane .xterm-screen").first().click();
+  // Wait for the textarea to actually hold focus before typing, so insertText
+  // can't race the focus and get dropped (race A).
+  await expect
+    .poll(() =>
+      window.evaluate(
+        () => document.activeElement?.tagName.toLowerCase() === "textarea",
+      ),
+    )
+    .toBe(true);
   await window.keyboard.insertText(text);
   await window.keyboard.press("Enter");
 }
@@ -16,6 +26,26 @@ async function typeInActiveTerminal(window: Page, text: string) {
 async function openSearch(window: Page) {
   await window.locator('button[title^="Search"]').click();
   await expect(window.locator(".aya-search-input")).toBeVisible();
+}
+
+// Open-search + query until the just-typed output is indexed. ptySearch queries
+// the buffer once per query change and does NOT re-run when the buffer fills
+// later, so a query issued before the shell flushed its echo would miss with no
+// retry (race B). Re-issuing the query (clear + refill changes the value, which
+// re-triggers ptySearch) converges deterministically without a fixed sleep.
+async function searchForHit(
+  window: Page,
+  query: string,
+  hitPattern: RegExp,
+): Promise<Locator> {
+  const input = window.locator(".aya-search-input");
+  const hit = window.locator(".aya-search-row", { hasText: hitPattern });
+  await expect(async () => {
+    await input.fill("");
+    await input.fill(query);
+    await expect(hit).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 10000 });
+  return hit;
 }
 
 // Failure mode: selecting a content hit navigates to the WRONG terminal (or
@@ -31,9 +61,7 @@ test("selecting a content match switches the active terminal to the one whose bu
   await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
 
   await openSearch(window);
-  await window.locator(".aya-search-input").fill("NAV_MARKER_BRAVO");
-  const hit = window.locator(".aya-search-row", { hasText: /NAV_MARKER_BRAVO/ });
-  await expect(hit).toBeVisible();
+  const hit = await searchForHit(window, "NAV_MARKER_BRAVO", /NAV_MARKER_BRAVO/);
   await hit.click();
 
   // The hit lived in shell 2's buffer, so selecting it must make shell 2 active.
@@ -48,10 +76,7 @@ test("a lowercase query matches uppercase terminal output (search is case-insens
   await typeInActiveTerminal(window, "echo CASEFOLD_UPPER");
 
   await openSearch(window);
-  await window.locator(".aya-search-input").fill("casefold_upper");
-  await expect(
-    window.locator(".aya-search-row", { hasText: /CASEFOLD_UPPER/i }),
-  ).toBeVisible();
+  await searchForHit(window, "casefold_upper", /CASEFOLD_UPPER/i);
 });
 
 // Failure mode: a no-match query shows stale rows from a previous query instead
@@ -63,13 +88,9 @@ test("changing to a never-present query replaces stale results with the empty st
   await typeInActiveTerminal(window, "echo TRANSIENT_HIT");
 
   await openSearch(window);
-  const input = window.locator(".aya-search-input");
-  await input.fill("TRANSIENT_HIT");
-  await expect(
-    window.locator(".aya-search-row", { hasText: /TRANSIENT_HIT/ }),
-  ).toBeVisible();
+  await searchForHit(window, "TRANSIENT_HIT", /TRANSIENT_HIT/);
 
-  await input.fill("zzqq_absent_token_9137");
+  await window.locator(".aya-search-input").fill("zzqq_absent_token_9137");
   await expect(window.locator(".aya-search-empty")).toBeVisible();
   await expect(window.locator(".aya-search-row")).toHaveCount(0);
 });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type Page } from "./fixtures";
+
+// Buffer-content search (Cmd/Ctrl+K, ptySearch over each PTY's output buffer)
+// had no behavioural e2e — only focus-on-close was covered. Search reads the
+// raw PTY buffer, not the DOM, so it works in single-view despite WebGL. Each
+// test below probes ONE distinct behaviour / failure mode.
+
+test.use({ seedOptions: { split: false } }); // single-view: one active terminal at a time
+
+async function typeInActiveTerminal(window: Page, text: string) {
+  await window.locator(".aya-pane .xterm-screen").first().click();
+  await window.keyboard.insertText(text);
+  await window.keyboard.press("Enter");
+}
+
+async function openSearch(window: Page) {
+  await window.locator('button[title^="Search"]').click();
+  await expect(window.locator(".aya-search-input")).toBeVisible();
+}
+
+// Failure mode: selecting a content hit navigates to the WRONG terminal (or
+// nowhere). Type a marker into the SECOND terminal, search it from the FIRST,
+// select the hit, and assert the active terminal became the second one.
+test("selecting a content match switches the active terminal to the one whose buffer contains it", async ({
+  window,
+}) => {
+  await window.locator(".aya-sidebar-row", { hasText: "shell 2" }).click();
+  await typeInActiveTerminal(window, "echo NAV_MARKER_BRAVO");
+
+  await window.locator(".aya-sidebar-row", { hasText: "shell 1" }).click();
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+
+  await openSearch(window);
+  await window.locator(".aya-search-input").fill("NAV_MARKER_BRAVO");
+  const hit = window.locator(".aya-search-row", { hasText: /NAV_MARKER_BRAVO/ });
+  await expect(hit).toBeVisible();
+  await hit.click();
+
+  // The hit lived in shell 2's buffer, so selecting it must make shell 2 active.
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
+});
+
+// Failure mode: search becomes case-sensitive (a lowercase query stops matching
+// uppercase output, or vice versa). searchPtyOutputs lowercases both sides.
+test("a lowercase query matches uppercase terminal output (search is case-insensitive)", async ({
+  window,
+}) => {
+  await typeInActiveTerminal(window, "echo CASEFOLD_UPPER");
+
+  await openSearch(window);
+  await window.locator(".aya-search-input").fill("casefold_upper");
+  await expect(
+    window.locator(".aya-search-row", { hasText: /CASEFOLD_UPPER/i }),
+  ).toBeVisible();
+});
+
+// Failure mode: a no-match query shows stale rows from a previous query instead
+// of the empty state. Match something first, then change to a never-present
+// token and assert the list collapses to "No matches".
+test("changing to a never-present query replaces stale results with the empty state", async ({
+  window,
+}) => {
+  await typeInActiveTerminal(window, "echo TRANSIENT_HIT");
+
+  await openSearch(window);
+  const input = window.locator(".aya-search-input");
+  await input.fill("TRANSIENT_HIT");
+  await expect(
+    window.locator(".aya-search-row", { hasText: /TRANSIENT_HIT/ }),
+  ).toBeVisible();
+
+  await input.fill("zzqq_absent_token_9137");
+  await expect(window.locator(".aya-search-empty")).toBeVisible();
+  await expect(window.locator(".aya-search-row")).toHaveCount(0);
+});

--- a/e2e/sidebar-close-terminal.spec.ts
+++ b/e2e/sidebar-close-terminal.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "./fixtures";
+
+// Closing a terminal from the sidebar context menu mutates both the tab list and
+// the active-selection state. The dangling-active-pointer class of bug (see #18)
+// is exactly what these guard: closing must never leave the active pane pointing
+// at a terminal that no longer exists. Placement = sidebar close behaviour; each
+// test names the one invariant it checks.
+
+test.use({ seedOptions: { split: false } }); // single-view, two terminals, one active
+
+async function closeViaMenu(window: import("@playwright/test").Page, name: string) {
+  await window
+    .locator(".aya-sidebar-row", { hasText: name })
+    .click({ button: "right" });
+  await window
+    .locator(".aya-context-menu-item", { hasText: "Close terminal" })
+    .click();
+}
+
+// Invariant: closing the CURRENTLY ACTIVE terminal hands active state to the
+// surviving terminal (not a dangling id / blank pane).
+test("closing the active terminal via the sidebar menu activates the surviving terminal", async ({
+  window,
+}) => {
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+
+  await closeViaMenu(window, "shell 1");
+
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 1" }),
+  ).toHaveCount(0);
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 2/);
+  await expect(
+    window.locator(".aya-pane-header-title").filter({ hasText: /shell 2/ }),
+  ).toBeVisible();
+});
+
+// Invariant: closing a NON-active terminal removes only that row and leaves the
+// active selection untouched.
+test("closing a non-active terminal via the sidebar menu leaves the active one untouched", async ({
+  window,
+}) => {
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+
+  await closeViaMenu(window, "shell 2");
+
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toHaveCount(0);
+  await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+});


### PR DESCRIPTION
Fills e2e coverage on core flows that had none, with tests written to catch real failure modes (not happy-path filler). Each test is named for the single behaviour/invariant it guards; placement (file) names the flow.

## Project creation — e2e/new-project.spec.ts
- the top-bar "+" opens a real directory as a new active project tab named after its basename, and closes the modal;
- a non-existent directory is rejected inline ("Directory does not exist"), the modal stays open, and no broken project is created.

## Buffer-content search — e2e/search.spec.ts
ptySearch (Cmd/Ctrl+K over each PTY's output buffer) only had focus-on-close coverage:
- selecting a content hit switches the active terminal to the one whose buffer matched (navigation correctness);
- a lowercase query matches uppercase output (case-insensitivity);
- changing to a never-present query replaces stale rows with the empty state.

These specs are deterministic, not timing-based: the helper waits for the terminal textarea to hold focus before typing, and re-issues the query until the typed output is indexed by ptySearch (which only searches the buffer once per query change, not when the buffer fills later). No fixed sleeps; stable at --repeat-each=6.

## Closing terminals — e2e/sidebar-close-terminal.spec.ts
Closing mutates the tab list AND the active selection — the dangling-active-pointer class (#18):
- closing the ACTIVE terminal hands active state to the surviving terminal (never a dangling id / blank pane);
- closing a NON-active terminal removes only that row and leaves the active one untouched.

All DOM-asserted (work headless); typecheck clean. No production code changes — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
