### PR TITLE
fix(e2e): make restart-snippet readiness check prompt-agnostic (false failure on arrow prompts)

### DIFF
--- a/e2e/snippet-exited-terminal.spec.ts
+++ b/e2e/snippet-exited-terminal.spec.ts
@@ -74,7 +74,12 @@ test("snippet on a restarted (alive) terminal is not blocked as 'exited'", async
     .locator(".aya-context-menu-item", { hasText: "Restart terminal" })
     .click();
 
-  await expect(window.locator(firstPaneRows)).toContainText(/project\s*[%$#]/, {
+  // Wait for the restart to begin — but don't assume a particular prompt shape.
+  // Dev shells use arrow / powerline prompts (e.g. "➜  project") with no $/%/#
+  // suffix, so matching /project\s*[%$#]/ gave a false failure on those machines.
+  // The PTY buffers the marker typed below until the fresh shell reads it, and
+  // the alive assertion auto-retries, so no prompt-shape match is needed.
+  await expect(window.locator(firstPaneRows)).toContainText(/restarting/i, {
     timeout: 10000,
   });
 


### PR DESCRIPTION
## Problem

e2e/snippet-exited-terminal.spec.ts ("snippet on a restarted (alive) terminal is not blocked as 'exited'") waited for the post-restart prompt with:

    toContainText(/project\s*[%$#]/)

That assumes the prompt ends in `$` / `%` / `#`. On a dev machine using an arrow / powerline prompt (oh-my-zsh `➜  project`, starship, etc.) there is no such suffix, so the wait times out at 10s and the test fails **before reaching its actual assertion** — a false negative. The feature itself works.

Observed locally: the wait received `"➜  project  "` and never matched, so the test failed 3/3, even though bypassing the wait made it pass.

## Fix

Wait for the prompt-agnostic `[restarting…]` marker instead of a prompt shape. The PTY buffers the marker typed next until the fresh shell reads it, and the alive assertion below already auto-retries — so no prompt-shape match is needed.

Verified: failed 3/3 on an arrow prompt before; passes 3/3 (both tests in the file) after. No production code changes.

## Why it matters

CI uses a bash `$`-style prompt, so this passed in CI and was invisible there — but it gives a false failure to any contributor whose shell prompt isn't `$`/`%`/`#`-suffixed, which is extremely common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
