### PR TITLE
fix: strip ST-terminated OSC sequences (search snippets + bell detection), order DCS before OSC

### DIFF
--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -93,10 +93,12 @@ export function getBufferedOutput(ptyId: string): string {
 export function stripAnsi(s: string): string {
   return s
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    // DCS / PM / APC / SOS (ESC P/X/^/_ … ST) BEFORE OSC, so the OSC rule below
+    // can't steal a DCS string's ST terminator and orphan its introducer.
+    .replace(/\x1b[PX^_][\s\S]*?\x1b\\/g, "")
     // OSC: terminated by BEL or ST (ESC \). Matching only BEL leaked the title
     // payload of ST-terminated sequences into search snippets.
     .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "")
-    .replace(/\x1b[PX^_].*?\x1b\\/g, "")
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -89,11 +89,13 @@ export function getBufferedOutput(ptyId: string): string {
 }
 
 /** Strip ANSI escape sequences and control chars so search snippets are
- *  readable. Keeps newlines so line context survives. */
-function stripAnsi(s: string): string {
+ *  readable. Keeps newlines so line context survives. Exported for unit tests. */
+export function stripAnsi(s: string): string {
   return s
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
-    .replace(/\x1b\][^\x07]*\x07/g, "")
+    // OSC: terminated by BEL or ST (ESC \). Matching only BEL leaked the title
+    // payload of ST-terminated sequences into search snippets.
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "")
     .replace(/\x1b[PX^_].*?\x1b\\/g, "")
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -89,7 +89,13 @@ export function getBufferedOutput(ptyId: string): string {
 }
 
 /** Strip ANSI escape sequences and control chars so search snippets are
- *  readable. Keeps newlines so line context survives. Exported for unit tests. */
+ *  readable. Keeps newlines so line context survives. Exported for unit tests.
+ *
+ *  DUPLICATE: a near-identical copy lives in src/bell.ts (renderer process,
+ *  which can't import this main-process module). Keep the escape-sequence rules
+ *  in sync — the only intended difference is the trailing control-char strip,
+ *  which bell.ts omits. (The ST-OSC leak this fixes had to be patched in both;
+ *  one was nearly missed.) */
 export function stripAnsi(s: string): string {
   return s
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")

--- a/src/bell.ts
+++ b/src/bell.ts
@@ -23,8 +23,10 @@ const APPROVAL_PATTERNS: RegExp[] = [
 // the same approval box with different cursor positions.
 
 function stripAnsi(s: string): string {
-  // Drop CSI / OSC escape sequences and the standalone ESC codes the screen
-  // repaint cycle emits.
+  // Drop CSI / OSC / DCS escape sequences the screen repaint cycle emits.
+  // DUPLICATE: a near-identical copy lives in electron/pty.ts (main process).
+  // Keep the escape-sequence rules in sync — the only intended difference is
+  // that pty.ts also strips stray control chars (for readable search snippets).
   return s
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
     // DCS / PM / APC / SOS before OSC (so OSC can't steal a DCS string's ST);

--- a/src/bell.ts
+++ b/src/bell.ts
@@ -27,8 +27,10 @@ function stripAnsi(s: string): string {
   // repaint cycle emits.
   return s
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
-    .replace(/\x1b\][^\x07]*\x07/g, "")
-    .replace(/\x1b[PX^_].*?\x1b\\/g, "");
+    // DCS / PM / APC / SOS before OSC (so OSC can't steal a DCS string's ST);
+    // OSC terminated by BEL or ST (matching only BEL leaked ST-OSC payloads).
+    .replace(/\x1b[PX^_][\s\S]*?\x1b\\/g, "")
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "");
 }
 
 export function detectApproval(chunk: string): boolean {

--- a/tests/strip-ansi.test.mjs
+++ b/tests/strip-ansi.test.mjs
@@ -1,0 +1,26 @@
+// Verifies stripAnsi (cleans search snippets). It must strip OSC sequences
+// terminated by ST (ESC \) as well as by BEL — matching only BEL leaked the
+// title payload of ST-terminated sequences into snippets.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripAnsi } from "../dist-electron/pty.js";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const ST = `${ESC}\\`;
+
+test("strips a BEL-terminated OSC title sequence completely", () => {
+  const out = stripAnsi(`before${ESC}]0;my title${BEL}after`);
+  assert.equal(out, "beforeafter");
+});
+
+test("strips CSI color sequences", () => {
+  const out = stripAnsi(`${ESC}[1;31mRED${ESC}[0m`);
+  assert.equal(out, "RED");
+});
+
+test("strips an ST-terminated OSC title sequence completely (no payload leak)", () => {
+  const out = stripAnsi(`before${ESC}]0;my title${ST}after`);
+  assert.equal(out, "beforeafter");
+});

--- a/tests/strip-ansi.test.mjs
+++ b/tests/strip-ansi.test.mjs
@@ -24,3 +24,17 @@ test("strips an ST-terminated OSC title sequence completely (no payload leak)", 
   const out = stripAnsi(`before${ESC}]0;my title${ST}after`);
   assert.equal(out, "beforeafter");
 });
+
+// Regression guard (grok review): a DCS string whose payload contains an OSC
+// start must be stripped whole. With OSC handled before DCS, the OSC rule stole
+// the DCS string's ST terminator and orphaned its introducer ("Pdcsdata after").
+// DCS is now stripped first.
+test("strips a DCS string whose payload contains an OSC start (no orphaned introducer)", () => {
+  const out = stripAnsi(`${ESC}Pdcsdata ${ESC}]0;t${ST}after`);
+  assert.equal(out, "after");
+});
+
+test("strips a multi-line OSC payload (clipboard-style) across newlines", () => {
+  const out = stripAnsi(`a${ESC}]52;c;line1\nline2${BEL}b`);
+  assert.equal(out, "ab");
+});


### PR DESCRIPTION
## Bug (empirically confirmed)

stripAnsi cleans PTY output for search snippets (electron/pty.ts) and for approval/busy detection (src/bell.ts). Both only stripped OSC sequences terminated by BEL (`\x07`). An OSC terminated by ST (`ESC \`) — a valid, commonly-emitted form for setting the window/title — was not matched, so its payload leaked: e.g. `stripAnsi("before\x1b]0;my title\x1b\\after")` returned `"before]0;my title\\after"` instead of `"beforeafter"`.

## Fix + grok review

Initial fix: match OSC content up to either terminator. A grok review then caught two real follow-ups, both verified before applying:

1. **Regression** — with OSC stripped before DCS, the new ST-aware OSC rule stole a DCS/PM/APC/SOS string's ST terminator and orphaned its introducer: `"\x1bPdcsdata \x1b]0;t\x1b\\after"` → `"Pdcsdata after"` (was `"after"` under the old BEL-only rule). Fixed by stripping DCS **before** OSC; both rules are now multi-line (`[\s\S]`) so payloads spanning newlines are handled.
2. **Duplicate** — `src/bell.ts` had its own `stripAnsi` with the same BEL-only OSC rule, leaking ST-OSC payloads into approval/busy detection text. Same fix applied.

## Tests

tests/strip-ansi.test.mjs (stripAnsi exported per the repo's pure-function test convention): BEL-OSC, CSI, ST-OSC, DCS-with-embedded-OSC-start (regression guard), multi-line OSC. 243 unit tests pass; bell tests green; typecheck clean.

Known pre-existing limitation (not introduced here, not addressed): a truly unterminated OSC at a buffer boundary still leaks its `]`+payload, since no rule matches without a terminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
