### PR TITLE
feat: click the status dot to dismiss a stuck agent status (#34, Part 1)

### DIFF
--- a/e2e/status-clear.spec.ts
+++ b/e2e/status-clear.spec.ts
@@ -98,3 +98,37 @@ test("aya status clear keeps a red dot for a genuinely failed terminal (#34)", a
   await window.waitForTimeout(1000);
   await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
 });
+
+// Part 1 of #34: a user can dismiss a stuck agent status by clicking the dot.
+// The dot is only interactive while an agent overlay is present, and clicking
+// it must clear both the red colour and the clickable affordance.
+test("clicking the status dot clears a stuck agent error (#34, Part 1)", async ({
+  window,
+  seeded,
+}) => {
+  const dot = window
+    .locator(".aya-sidebar-row", { hasText: "shell 1" })
+    .locator(".aya-sidebar-statusdot");
+
+  // No agent overlay yet -> the dot is not interactive.
+  await expect(dot).toBeVisible();
+  await expect(dot).not.toHaveClass(/aya-sidebar-statusdot--clearable/);
+
+  // Drain startup output (see the first test for why) then report an error.
+  await window.waitForTimeout(2000);
+  await sendControl(seeded.ayaHome, {
+    type: "status",
+    level: "error",
+    text: "boom",
+    terminalId: seeded.tabIds.left,
+  });
+  await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
+  await expect(dot).toHaveClass(/aya-sidebar-statusdot--clearable/);
+  await window.waitForTimeout(1500);
+  await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
+
+  // Click the dot -> the overlay is dropped: no longer red, no longer clickable.
+  await dot.click();
+  await expect(dot).not.toHaveClass(/aya-sidebar-statusdot--error/);
+  await expect(dot).not.toHaveClass(/aya-sidebar-statusdot--clearable/);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
-import { deriveLifecycleStatus } from "./pty-event-reducer";
+import { clearedTerminalStatus } from "./pty-event-reducer";
 import { AttentionCenter } from "./components/AttentionCenter";
 import { EmptyState } from "./components/EmptyState";
 import { MissingDirModal } from "./components/MissingDirModal";
@@ -926,18 +926,10 @@ export function App() {
         if (!entry) return prev;
         const [id, terminal] = entry;
         if (update.level === "clear") {
-          const { externalStatus, ...rest } = terminal;
-          return {
-            ...prev,
-            [id]: {
-              ...rest,
-              // Fall back to PTY-lifecycle truth, not the stale agent status.
-              // Keeping `terminal.status` left an agent-set "error" stuck
-              // forever, so `aya status clear` could never clear a red dot (#34).
-              status: deriveLifecycleStatus(rest),
-              bell: externalStatus?.level === "waiting" ? false : terminal.bell,
-            },
-          };
+          // Fall back to PTY-lifecycle truth, not the stale agent status.
+          // Keeping `terminal.status` left an agent-set "error" stuck forever,
+          // so `aya status clear` could never clear a red dot (#34).
+          return { ...prev, [id]: clearedTerminalStatus(terminal) };
         }
         const text = update.text?.trim();
         if (!text) return prev;
@@ -1177,6 +1169,18 @@ export function App() {
     },
     [appendProjectEvent, persistProject],
   );
+
+  // User dismisses a stuck agent status by clicking the sidebar dot (#34,
+  // Part 1). Same fall-back-to-PTY-truth as the control-socket `clear`; a real
+  // exit/spawn error has no overlay and stays untouched. Returns `prev` when
+  // there is nothing to clear so React can skip the re-render.
+  const clearTerminalStatus = useCallback((id: string) => {
+    setTerminals((prev) => {
+      const t = prev[id];
+      if (!t || !t.externalStatus) return prev;
+      return { ...prev, [id]: clearedTerminalStatus(t) };
+    });
+  }, []);
 
   const renameTerminal = useCallback(
     (id: string, name: string) => {
@@ -2161,6 +2165,7 @@ export function App() {
               }
             }}
             onRestart={forceRestartTerminal}
+            onClearStatus={clearTerminalStatus}
             canSplitRight={canSplitRight}
             canSplitBelow={canSplitBelow}
             onAssignToSplit={assignTerminalToActiveSplitCell}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,8 @@ interface Props {
   onReorder: (orderedIds: string[]) => void;
   /** Kill + re-spawn the PTY for this terminal (right-click → Restart). */
   onRestart: (id: string) => void;
+  /** Dismiss a stuck agent-reported status (click the status dot). */
+  onClearStatus: (id: string) => void;
   splitAssignments?: Record<string, number>;
   canSplitRight: boolean;
   canSplitBelow: boolean;
@@ -51,6 +53,7 @@ export function Sidebar({
   onResize,
   onReorder,
   onRestart,
+  onClearStatus,
   splitAssignments = {},
   canSplitRight,
   canSplitBelow,
@@ -221,12 +224,46 @@ export function Sidebar({
               >
                 {preset.icon}
               </span>
+              {/* Clickable only while an agent overlay is present, so the dot
+                  becomes a recovery affordance for a stuck status (#34, Part 1)
+                  without hijacking row-select for ordinary lifecycle dots. */}
               <span
                 className={`aya-sidebar-statusdot aya-sidebar-statusdot--${t.status} ${
                   recentlyActiveIds.has(t.id)
                     ? "aya-sidebar-statusdot--blinking"
                     : ""
-                }`}
+                } ${t.externalStatus ? "aya-sidebar-statusdot--clearable" : ""}`}
+                role={t.externalStatus ? "button" : undefined}
+                tabIndex={t.externalStatus ? 0 : undefined}
+                aria-label={
+                  t.externalStatus
+                    ? `Clear status: ${t.externalStatus.text}`
+                    : undefined
+                }
+                title={
+                  t.externalStatus
+                    ? `Click to clear: ${t.externalStatus.text}`
+                    : undefined
+                }
+                onClick={
+                  t.externalStatus
+                    ? (e) => {
+                        e.stopPropagation();
+                        onClearStatus(t.id);
+                      }
+                    : undefined
+                }
+                onKeyDown={
+                  t.externalStatus
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onClearStatus(t.id);
+                        }
+                      }
+                    : undefined
+                }
               />
               {renamingId === t.id ? (
                 <input

--- a/src/pty-event-reducer.ts
+++ b/src/pty-event-reducer.ts
@@ -23,6 +23,20 @@ export function deriveLifecycleStatus(t: {
   return t.exitCode === null || t.exitCode === 0 ? "idle" : "error";
 }
 
+/** Drop the agent-reported status overlay and fall back to PTY-lifecycle truth.
+ *  Shared by the control-socket `clear` and by the user clicking the status dot
+ *  to dismiss a stuck status (#34). A real PTY condition (spawn failure /
+ *  non-zero exit) is preserved by deriveLifecycleStatus, so it cannot be
+ *  dismissed this way - only an agent overlay can. */
+export function clearedTerminalStatus(terminal: TerminalState): TerminalState {
+  const { externalStatus, ...rest } = terminal;
+  return {
+    ...rest,
+    status: deriveLifecycleStatus(rest),
+    bell: externalStatus?.level === "waiting" ? false : terminal.bell,
+  };
+}
+
 export function applyPtyEvent(
   prev: Record<string, TerminalState>,
   event: PtyEvent,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -407,6 +407,13 @@ body {
 .aya-sidebar-statusdot--idle    { background: var(--fg-tertiary); opacity: 0.5; }
 .aya-sidebar-statusdot--waiting { background: #f0ad4e; }
 .aya-sidebar-statusdot--error   { background: #c01c28; }
+/* A dot carrying an agent overlay is dismissable: invite the click (#34). */
+.aya-sidebar-statusdot--clearable { cursor: pointer; transition: transform 0.1s ease; }
+.aya-sidebar-statusdot--clearable:hover { transform: scale(1.5); }
+.aya-sidebar-statusdot--clearable:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
 
 @keyframes aya-pulse {
   0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 60%, transparent); }

--- a/tests/pty-event-reducer.test.mjs
+++ b/tests/pty-event-reducer.test.mjs
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   applyPtyEvent,
+  clearedTerminalStatus,
   deriveLifecycleStatus,
   eventTouchesActivity,
 } from "../dist-test/pty-event-reducer.js";
@@ -268,4 +269,40 @@ test("deriveLifecycleStatus: spawn failure wins over an otherwise-clean exit", (
     }),
     "error",
   );
+});
+
+// --- clearedTerminalStatus ----------------------------------------------
+// Shared by the control-socket `clear` and the clickable status dot (#34).
+// Reuses the termState() helper declared at the top of this file.
+
+test("clearedTerminalStatus: drops the agent overlay and reverts a live error to idle", () => {
+  const t = termState("t1", {
+    status: "error",
+    externalStatus: { level: "error", text: "boom", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.externalStatus, undefined);
+  assert.equal(next.status, "idle");
+});
+
+test("clearedTerminalStatus: keeps error for a genuinely failed (exited) terminal", () => {
+  const t = termState("t1", {
+    status: "error",
+    exitCode: 1,
+    externalStatus: { level: "error", text: "boom", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.externalStatus, undefined);
+  assert.equal(next.status, "error");
+});
+
+test("clearedTerminalStatus: clears the bell left by a waiting overlay", () => {
+  const t = termState("t1", {
+    status: "waiting",
+    bell: true,
+    externalStatus: { level: "waiting", text: "needs input", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.bell, false);
+  assert.equal(next.status, "idle");
 });


### PR DESCRIPTION
## What

Part 1 of #34: a **user-side recovery path** for a stuck agent status.

A sticky agent status (`aya status error/waiting/done`) only clears when the agent calls `aya status clear` or pushes a new status. If the agent goes away, the dot stays red forever with no way for the user to dismiss it. This makes the sidebar status dot clickable to clear it.

> Stacked on #35 (Part 0). Base this PR on `fix/status-clear-stale-error`; the diff here is Part 1 only. Merge #35 first (or retarget to `main` after it lands).

## How

- The dot is interactive **only while `externalStatus` is present**, so ordinary lifecycle dots still pass clicks through to row-select and don't become accidental buttons.
- A real exit/spawn error has no overlay, so it cannot be dismissed this way (you restart instead) - consistent with Part 0.
- Clearing reuses the same fall-back-to-PTY-truth logic as the control-socket `clear`, extracted into a shared, tested `clearedTerminalStatus(terminal)` helper (also closes the "no pure test for the clear path" gap).

### Accessibility / affordance
- `role="button"`, `tabIndex=0`, `aria-label` + `title` ("Click to clear: <text>")
- keyboard activation (Enter / Space)
- hover scale + `:focus-visible` outline; `cursor: pointer`

## Tests

- `e2e/status-clear.spec.ts`: clicking the dot clears both the red colour and the `--clearable` affordance (same drain + stability guards as the sibling tests to avoid the PTY-output race). Without the feature the `--clearable` class never appears, so the test genuinely guards it.
- `tests/pty-event-reducer.test.mjs`: 3 unit tests for `clearedTerminalStatus` (live error -> idle, genuine exit error stays error, waiting bell cleared).

## Verification

- typecheck: clean
- unit: 251/251 (+3)
- e2e: all 3 status-clear tests pass; the rest are unaffected (two unrelated full-suite flakes - #32 prompt detection and a search timing test - both pass in isolation).

## Remaining in #34

Part 2 (agent skill convention: harnesses should call `aya status clear` after handling an error / at end of turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
