### PR TITLE
feat: clear a stuck agent status when its terminal gains focus (#34, Part 1)

### DIFF
--- a/e2e/status-clear.spec.ts
+++ b/e2e/status-clear.spec.ts
@@ -98,3 +98,72 @@ test("aya status clear keeps a red dot for a genuinely failed terminal (#34)", a
   await window.waitForTimeout(1000);
   await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
 });
+
+// Part 1 of #34: focusing a terminal acknowledges its stuck agent status -
+// there is no separate dismiss control. Reported on the NON-active terminal
+// (shell 2) so selecting it is a real focus transition.
+test("focusing a terminal clears its stuck agent error (#34, Part 1)", async ({
+  window,
+  seeded,
+}) => {
+  const dot = window
+    .locator(".aya-sidebar-row", { hasText: "shell 2" })
+    .locator(".aya-sidebar-statusdot");
+
+  // Drain startup output (see the first test for why) then report an error on
+  // the non-active terminal.
+  await window.waitForTimeout(2000);
+  await sendControl(seeded.ayaHome, {
+    type: "status",
+    level: "error",
+    text: "boom",
+    terminalId: seeded.tabIds.right,
+  });
+  await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
+  // Stable (PTY quiet) - not masked by the output race.
+  await window.waitForTimeout(1500);
+  await expect(dot).toHaveClass(/aya-sidebar-statusdot--error/);
+
+  // Visit the terminal -> the overlay is acknowledged and the dot clears.
+  await window.locator(".aya-sidebar-row", { hasText: "shell 2" }).click();
+  await expect(dot).not.toHaveClass(/aya-sidebar-statusdot--error/);
+});
+
+// The project-tab badge is a pure aggregate: it stays red while ANY terminal in
+// the project is flagged, and only clears once every flagged terminal has been
+// visited. The badge reads externalStatus, so it is immune to the PTY-output
+// race (no drain needed).
+test("project badge persists until every flagged terminal is visited (#34, Part 1)", async ({
+  window,
+  seeded,
+}) => {
+  const badge = window.locator(".aya-tab-bell");
+
+  // Let bootstrap settle so the active-tab is stable; otherwise the late
+  // activation would fire clear-on-focus and wipe the flag we set on the
+  // active terminal before we can assert on it.
+  await window.waitForTimeout(2000);
+
+  // Flag BOTH terminals (shell 1 is the active one, shell 2 is not).
+  await sendControl(seeded.ayaHome, {
+    type: "status",
+    level: "error",
+    text: "boom 1",
+    terminalId: seeded.tabIds.left,
+  });
+  await sendControl(seeded.ayaHome, {
+    type: "status",
+    level: "error",
+    text: "boom 2",
+    terminalId: seeded.tabIds.right,
+  });
+  await expect(badge).toHaveClass(/aya-tab-bell--error/);
+
+  // Visit shell 2 -> its flag clears, but shell 1 still holds the badge red.
+  await window.locator(".aya-sidebar-row", { hasText: "shell 2" }).click();
+  await expect(badge).toHaveClass(/aya-tab-bell--error/);
+
+  // Visit shell 1 -> the last flag clears, so the aggregate badge disappears.
+  await window.locator(".aya-sidebar-row", { hasText: "shell 1" }).click();
+  await expect(badge).toHaveCount(0);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
-import { deriveLifecycleStatus } from "./pty-event-reducer";
+import { clearedTerminalStatus } from "./pty-event-reducer";
 import { AttentionCenter } from "./components/AttentionCenter";
 import { EmptyState } from "./components/EmptyState";
 import { MissingDirModal } from "./components/MissingDirModal";
@@ -926,18 +926,10 @@ export function App() {
         if (!entry) return prev;
         const [id, terminal] = entry;
         if (update.level === "clear") {
-          const { externalStatus, ...rest } = terminal;
-          return {
-            ...prev,
-            [id]: {
-              ...rest,
-              // Fall back to PTY-lifecycle truth, not the stale agent status.
-              // Keeping `terminal.status` left an agent-set "error" stuck
-              // forever, so `aya status clear` could never clear a red dot (#34).
-              status: deriveLifecycleStatus(rest),
-              bell: externalStatus?.level === "waiting" ? false : terminal.bell,
-            },
-          };
+          // Fall back to PTY-lifecycle truth, not the stale agent status.
+          // Keeping `terminal.status` left an agent-set "error" stuck forever,
+          // so `aya status clear` could never clear a red dot (#34).
+          return { ...prev, [id]: clearedTerminalStatus(terminal) };
         }
         const text = update.text?.trim();
         if (!text) return prev;
@@ -1178,6 +1170,32 @@ export function App() {
     [appendProjectEvent, persistProject],
   );
 
+  // Drop a terminal's agent status overlay once the user attends to it (#34,
+  // Part 1). The overlay is an attention signal for terminals you are NOT
+  // looking at, so the act of focusing the terminal IS the acknowledgement -
+  // there is deliberately no separate "dismiss" control. Same
+  // fall-back-to-PTY-truth as the control-socket `clear`; a real exit/spawn
+  // error has no overlay and stays untouched. Returns `prev` when there is
+  // nothing to clear so React can skip the re-render. The project-tab badge is
+  // a pure aggregate over its terminals, so it keeps glowing until the last
+  // flagged terminal is visited - no separate project-level clear needed.
+  const clearTerminalStatus = useCallback((id: string) => {
+    setTerminals((prev) => {
+      const t = prev[id];
+      if (!t || !t.externalStatus) return prev;
+      return { ...prev, [id]: clearedTerminalStatus(t) };
+    });
+  }, []);
+
+  // Switching to a terminal (sidebar click, keyboard tab-switch, split-pane
+  // focus) acknowledges its overlay. Keyed on the active-tab map, so it fires
+  // on the transition TO a terminal; clearTerminalStatus no-ops when there is
+  // no overlay. Does not depend on `terminals`, so clearing can't re-trigger it.
+  useEffect(() => {
+    const id = activeProjectId ? activeTabByProject[activeProjectId] : null;
+    if (id) clearTerminalStatus(id);
+  }, [activeProjectId, activeTabByProject, clearTerminalStatus]);
+
   const renameTerminal = useCallback(
     (id: string, name: string) => {
       setTerminals((prev) => {
@@ -1354,8 +1372,27 @@ export function App() {
         ...layout,
         activeCell: Math.max(0, Math.min(layout.cells.length - 1, cellIndex)),
       }));
+      // Keep the active terminal in sync with the focused cell, so the sidebar
+      // highlight and the clear-on-focus effect both track a mouse click on a
+      // pane (not just keyboard/sidebar navigation). Read the layout outside
+      // the updater (mirrors focusSplitPane) to avoid a setState-in-updater.
+      const project = projectsRef.current.find((p) => p.slug === slug);
+      if (!project?.splitLayout) return;
+      const layout = normalizeSplitLayoutForTabs(
+        project.splitLayout,
+        project.tabs,
+        activeTabByProject[slug] ?? project.tabs[0]?.id ?? null,
+      );
+      const activeCell = Math.max(
+        0,
+        Math.min(layout.cells.length - 1, cellIndex),
+      );
+      const focusedId = layout.cells[activeCell];
+      if (focusedId) {
+        setActiveTabByProject((prev) => ({ ...prev, [slug]: focusedId }));
+      }
     },
-    [updateProjectSplitLayout],
+    [activeTabByProject, updateProjectSplitLayout],
   );
 
   const resizeSplit = useCallback(

--- a/src/pty-event-reducer.ts
+++ b/src/pty-event-reducer.ts
@@ -23,6 +23,20 @@ export function deriveLifecycleStatus(t: {
   return t.exitCode === null || t.exitCode === 0 ? "idle" : "error";
 }
 
+/** Drop the agent-reported status overlay and fall back to PTY-lifecycle truth.
+ *  Shared by the control-socket `clear` and by the user clicking the status dot
+ *  to dismiss a stuck status (#34). A real PTY condition (spawn failure /
+ *  non-zero exit) is preserved by deriveLifecycleStatus, so it cannot be
+ *  dismissed this way - only an agent overlay can. */
+export function clearedTerminalStatus(terminal: TerminalState): TerminalState {
+  const { externalStatus, ...rest } = terminal;
+  return {
+    ...rest,
+    status: deriveLifecycleStatus(rest),
+    bell: externalStatus?.level === "waiting" ? false : terminal.bell,
+  };
+}
+
 export function applyPtyEvent(
   prev: Record<string, TerminalState>,
   event: PtyEvent,

--- a/tests/pty-event-reducer.test.mjs
+++ b/tests/pty-event-reducer.test.mjs
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   applyPtyEvent,
+  clearedTerminalStatus,
   deriveLifecycleStatus,
   eventTouchesActivity,
 } from "../dist-test/pty-event-reducer.js";
@@ -268,4 +269,40 @@ test("deriveLifecycleStatus: spawn failure wins over an otherwise-clean exit", (
     }),
     "error",
   );
+});
+
+// --- clearedTerminalStatus ----------------------------------------------
+// Shared by the control-socket `clear` and the clickable status dot (#34).
+// Reuses the termState() helper declared at the top of this file.
+
+test("clearedTerminalStatus: drops the agent overlay and reverts a live error to idle", () => {
+  const t = termState("t1", {
+    status: "error",
+    externalStatus: { level: "error", text: "boom", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.externalStatus, undefined);
+  assert.equal(next.status, "idle");
+});
+
+test("clearedTerminalStatus: keeps error for a genuinely failed (exited) terminal", () => {
+  const t = termState("t1", {
+    status: "error",
+    exitCode: 1,
+    externalStatus: { level: "error", text: "boom", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.externalStatus, undefined);
+  assert.equal(next.status, "error");
+});
+
+test("clearedTerminalStatus: clears the bell left by a waiting overlay", () => {
+  const t = termState("t1", {
+    status: "waiting",
+    bell: true,
+    externalStatus: { level: "waiting", text: "needs input", updatedAt: 1 },
+  });
+  const next = clearedTerminalStatus(t);
+  assert.equal(next.bell, false);
+  assert.equal(next.status, "idle");
 });


### PR DESCRIPTION
## What

Part 1 of #34: a **user-side recovery path** for a stuck agent status - by **focusing the terminal**, not a separate dismiss control.

A status overlay (`aya status error/waiting/done`) is an attention signal for terminals you are *not* looking at. So the act of visiting the terminal *is* the acknowledgement. A manual "dismiss" button would be incoherent - dismissing something you haven't looked at defeats the whole point of the signal.

> Replaces the earlier clickable-dot approach (#36, closed). Stacked on #35 (Part 0); base is `fix/status-clear-stale-error`. Retarget to `main` after #35 lands.

## Behaviour

- **Per-terminal dot** clears when you switch to that terminal (sidebar click, keyboard tab-switch, or split-pane focus).
- **Project-tab badge** is a pure aggregate: it stays red while *any* terminal in the project is flagged, and only disappears once the **last** flagged terminal has been visited. No special project-level clear - it follows the per-terminal state for free.
- A **real** exit/spawn error has no overlay, so focus does not clear it (you restart instead) - consistent with Part 0.
- Errored-while-already-active edge: the overlay shows until the next focus transition (you see the error directly in the terminal you're on anyway).

## How

- New effect keyed on the active-tab map: switching to a terminal calls `clearTerminalStatus(id)`. It no-ops when there's no overlay and does not depend on `terminals`, so clearing can't re-trigger it.
- Reuses the shared, tested `clearedTerminalStatus` helper (same fall-back-to-PTY-truth as the control-socket `clear`).
- **Latent bug fixed:** a mouse click on a split pane updated the focused cell but not the active terminal, so the sidebar highlight (and the new effect) ignored it. `setActiveSplitCell` now keeps the active terminal in sync with the focused cell (mirrors `focusSplitPane`).

## Tests

- `e2e/status-clear.spec.ts`:
  - focusing a flagged (non-active) terminal clears its dot (drain + stability guards vs the PTY-output race);
  - **project badge persists until every flagged terminal is visited**, then clears - directly encodes the aggregate requirement. The badge reads `externalStatus`, so it's immune to the output race.
- `tests/pty-event-reducer.test.mjs`: 3 unit tests for `clearedTerminalStatus`.

## Verification

- typecheck: clean
- unit: 251/251 (+3)
- e2e: 4/4 status-clear; full suite 45/46 (the one failure is the pre-existing #32 prompt-detection flake, unrelated - all focus/split specs pass).

## Remaining in #34

Part 2 (agent skill convention: harnesses should call `aya status clear` after handling an error / at end of turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
