### PR TITLE
fix: route control-status updates by exact terminalId first (#40)

### DIFF
--- a/e2e/status-clear.spec.ts
+++ b/e2e/status-clear.spec.ts
@@ -167,3 +167,38 @@ test("project badge persists until every flagged terminal is visited (#34, Part 
   await window.locator(".aya-sidebar-row", { hasText: "shell 1" }).click();
   await expect(badge).toHaveCount(0);
 });
+
+// Regression for #40: a status carrying an explicit terminalId must land on
+// THAT terminal. bin/aya always sends projectSlug + cwd alongside terminalId,
+// and both match every sibling terminal in the project - the old single-pass
+// matcher let the FIRST sibling (shell 1) win before the exact-id terminal
+// (shell 2) was ever considered.
+test("status with terminalId targets that terminal, not the project's first (#40)", async ({
+  window,
+  seeded,
+}) => {
+  const dotFor = (name: string) =>
+    window
+      .locator(".aya-sidebar-row", { hasText: name })
+      .locator(".aya-sidebar-statusdot");
+  const dot1 = dotFor("shell 1");
+  const dot2 = dotFor("shell 2");
+
+  // Drain startup output + let bootstrap settle (see the sibling tests).
+  await window.waitForTimeout(2000);
+
+  // Mimic the full bin/aya payload: terminalId AND projectSlug AND cwd.
+  await sendControl(seeded.ayaHome, {
+    type: "status",
+    level: "error",
+    text: "boom",
+    terminalId: seeded.tabIds.right,
+    projectSlug: "e2e-proj",
+    cwd: seeded.projectDir,
+  });
+
+  // The exact-id terminal (shell 2) gets the error...
+  await expect(dot2).toHaveClass(/aya-sidebar-statusdot--error/);
+  // ...and the first project sibling (shell 1) must NOT be painted instead.
+  await expect(dot1).not.toHaveClass(/aya-sidebar-statusdot--error/);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
+import { findStatusTarget } from "./control-status-target";
 import { clearedTerminalStatus } from "./pty-event-reducer";
 import { AttentionCenter } from "./components/AttentionCenter";
 import { EmptyState } from "./components/EmptyState";
@@ -915,14 +916,7 @@ export function App() {
   useEffect(() => {
     return window.aya.onControlStatus((update) => {
       setTerminals((prev) => {
-        const entry = Object.entries(prev).find(([, terminal]) => {
-          if (update.terminalId && terminal.id === update.terminalId) return true;
-          if (update.projectSlug && terminal.projectSlug === update.projectSlug) {
-            return true;
-          }
-          if (update.cwd && terminal.cwd === update.cwd) return true;
-          return false;
-        });
+        const entry = findStatusTarget(prev, update);
         if (!entry) return prev;
         const [id, terminal] = entry;
         if (update.level === "clear") {

--- a/src/control-status-target.ts
+++ b/src/control-status-target.ts
@@ -1,0 +1,32 @@
+// Pure matcher: which terminal should a control-status update apply to?
+// Extracted from App.tsx's onControlStatus handler so the precedence rules can
+// be tested without React (same pattern as pty-event-reducer).
+
+import type { ControlStatusUpdate, TerminalState } from "./types";
+
+/** Resolve the target terminal for a control-status update.
+ *
+ *  An exact terminalId match always wins. bin/aya sends terminalId AND
+ *  projectSlug AND cwd whenever the AYA_* env vars are present, and the
+ *  slug/cwd match every sibling terminal in the project - a single-pass
+ *  "any field matches" search let the project's first terminal shadow the
+ *  real sender, so per-terminal statuses always landed on the first tab (#40).
+ *
+ *  projectSlug/cwd remain as fallbacks for senders without AYA_TERMINAL_ID
+ *  (e.g. `aya status` run from a plain shell in the project directory). */
+export function findStatusTarget(
+  terminals: Record<string, TerminalState>,
+  update: Pick<ControlStatusUpdate, "terminalId" | "projectSlug" | "cwd">,
+): [string, TerminalState] | undefined {
+  const entries = Object.entries(terminals);
+  if (update.terminalId) {
+    const exact = entries.find(([, t]) => t.id === update.terminalId);
+    if (exact) return exact;
+  }
+  return entries.find(
+    ([, t]) =>
+      (update.projectSlug !== undefined &&
+        t.projectSlug === update.projectSlug) ||
+      (update.cwd !== undefined && t.cwd === update.cwd),
+  );
+}

--- a/tests/control-status-target.test.mjs
+++ b/tests/control-status-target.test.mjs
@@ -1,0 +1,73 @@
+// Precedence rules for routing a control-status update to a terminal. The
+// regression behind #40: bin/aya sends terminalId + projectSlug + cwd, and the
+// slug/cwd match every project sibling, so a single-pass matcher let the
+// project's FIRST terminal shadow the exact-id target.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findStatusTarget } from "../dist-test/control-status-target.js";
+
+function termState(id, overrides = {}) {
+  return {
+    id,
+    projectSlug: "demo",
+    presetId: "claude",
+    name: id,
+    cwd: "/tmp/demo",
+    status: "running",
+    bell: false,
+    exitCode: null,
+    ...overrides,
+  };
+}
+
+// Two terminals in the same project, same cwd - the bin/aya scenario.
+const twoSiblings = () => ({
+  first: termState("first"),
+  second: termState("second"),
+});
+
+test("exact terminalId wins even when projectSlug and cwd match the first sibling (#40)", () => {
+  const entry = findStatusTarget(twoSiblings(), {
+    terminalId: "second",
+    projectSlug: "demo",
+    cwd: "/tmp/demo",
+  });
+  assert.equal(entry?.[0], "second");
+});
+
+test("terminalId alone targets the right terminal", () => {
+  const entry = findStatusTarget(twoSiblings(), { terminalId: "second" });
+  assert.equal(entry?.[0], "second");
+});
+
+test("no terminalId falls back to projectSlug (first match)", () => {
+  const entry = findStatusTarget(twoSiblings(), { projectSlug: "demo" });
+  assert.equal(entry?.[0], "first");
+});
+
+test("no terminalId falls back to cwd", () => {
+  const terminals = {
+    a: termState("a", { projectSlug: "p1", cwd: "/x" }),
+    b: termState("b", { projectSlug: "p2", cwd: "/y" }),
+  };
+  const entry = findStatusTarget(terminals, { cwd: "/y" });
+  assert.equal(entry?.[0], "b");
+});
+
+test("unknown terminalId falls back to projectSlug/cwd (sender's tab was closed)", () => {
+  const entry = findStatusTarget(twoSiblings(), {
+    terminalId: "gone",
+    projectSlug: "demo",
+  });
+  assert.equal(entry?.[0], "first");
+});
+
+test("nothing matches -> undefined", () => {
+  const entry = findStatusTarget(twoSiblings(), {
+    terminalId: "gone",
+    projectSlug: "other",
+    cwd: "/elsewhere",
+  });
+  assert.equal(entry, undefined);
+});

--- a/tsconfig.test-src.json
+++ b/tsconfig.test-src.json
@@ -14,6 +14,7 @@
   },
   "include": [
     "src/bell.ts",
+    "src/control-status-target.ts",
     "src/double-shift.ts",
     "src/focus-reporting.ts",
     "src/pty-event-reducer.ts",


### PR DESCRIPTION
## What

Fixes #40: `aya status` run inside a specific terminal landed on the **wrong** terminal - the project's first tab, not the sender.

Reproduced live: a status sent from a "Claude YOLO" tab (`AYA_TERMINAL_ID` set) painted the **shell** tab's dot instead.

## Why it happened

`bin/aya` always sends `terminalId` + `projectSlug` + `cwd` when the `AYA_*` env vars are present (`bin/aya:66-68`), and slug/cwd match **every** sibling terminal in the project. The single-pass "any field matches" search in `onControlStatus` returned the first project sibling before the exact-id terminal was ever considered - so per-terminal targeting was effectively broken in every multi-terminal project.

## Fix

Matching extracted into a pure `findStatusTarget()` helper (`src/control-status-target.ts`) with explicit precedence:

1. exact `terminalId` match always wins;
2. `projectSlug` / `cwd` remain as fallbacks for senders without `AYA_TERMINAL_ID` (e.g. `aya status` from a plain shell in the project directory) or when the sender's tab has been closed.

Same extract-pure-and-test pattern as `pty-event-reducer`.

## Tests (red -> green, proven)

- `e2e/status-clear.spec.ts`: new repro mimicking the **full** bin/aya payload (`terminalId` + `projectSlug` + `cwd`). On the unfixed code the error landed on shell 1 and the test failed; after the fix shell 2 (exact id) gets it and shell 1 stays clean. (The existing tests sent only `terminalId`, which is why they passed despite the bug.)
- `tests/control-status-target.test.mjs`: 6 unit tests for the precedence rules.

## Verification

- typecheck: clean
- unit: 257/257 (+6)
- e2e: all 5 status-clear tests pass; full suite 46/47 - the one failure is the old prompt-detection flake whose fix (#32, `7e9973e`) is already in `main` but not yet in this branch's base.

## Stacking

Based on `fix/status-clear-stale-error` (PR #35, which now carries Part 0 + Part 1 of #34) because it touches the same `onControlStatus` handler - this avoids a guaranteed merge conflict. Merge #35 first; this can then be retargeted to `main` (or merged into the same branch like #37 was).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
