### PR TITLE
fix: ship the aya CLI as a real executable - unpack bin/ from the asar (#39)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,17 @@ jobs:
       - name: Package Linux artifacts
         run: npx electron-builder --linux AppImage deb --x64 --publish never
 
+      # The aya CLI shipped broken in v0.4.0 because nothing ever exercised the
+      # PACKAGED artifact: unit/e2e run on the dev build (no asar), and this job
+      # only produced files. The shim exec'd a path inside app.asar -> "Not a
+      # directory" on every user machine, invisible to CI (#39). Assert the
+      # unpacked CLI is a real executable and actually runs from the artifact.
+      - name: Smoke-check bundled aya CLI in the packaged artifact
+        run: |
+          cli=release/linux-unpacked/resources/app.asar.unpacked/bin/aya
+          test -x "$cli"
+          "$cli" help
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/electron/cli-path.ts
+++ b/electron/cli-path.ts
@@ -1,0 +1,19 @@
+import * as path from "node:path";
+
+/** Absolute path to the bundled `bin/aya` CLI script, given the __dirname of
+ *  the running main module.
+ *
+ *  In a packaged app __dirname lives inside app.asar - a virtual filesystem
+ *  that Node can read but the OS cannot exec from, so a shim pointing there
+ *  fails with "Not a directory" (#39). The asarUnpack build rule materializes
+ *  bin/ next to the archive as app.asar.unpacked/bin/aya; rewrite the exact
+ *  app.asar path segment to target that real file. Dev runs (dist-electron in
+ *  the repo, no asar anywhere in the path) pass through untouched. */
+export function bundledAyaCliPath(mainDirname: string): string {
+  const inside = path.join(mainDirname, "..", "bin", "aya");
+  const parts = inside.split(path.sep);
+  const asarIndex = parts.lastIndexOf("app.asar");
+  if (asarIndex === -1) return inside;
+  parts[asarIndex] = "app.asar.unpacked";
+  return parts.join(path.sep);
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,6 +32,7 @@ import {
   saveProjectState,
   updateProject,
 } from "./config";
+import { bundledAyaCliPath } from "./cli-path";
 import { startConfigWatcher } from "./config-watcher";
 import { startControlServer } from "./control";
 import { getGitChangedFiles, getGitDiff, getGitInfo } from "./git";
@@ -117,10 +118,6 @@ function writableDirOnPath(): string | null {
   return null;
 }
 
-function bundledAyaCliPath(): string {
-  return path.join(__dirname, "..", "bin", "aya");
-}
-
 async function cliStatus(): Promise<CliStatus> {
   const installed = findExecutableOnPath("aya");
   const installDir =
@@ -149,7 +146,22 @@ async function installCli(): Promise<CliStatus> {
     };
   }
   await fs.mkdir(installDir, { recursive: true });
-  const source = bundledAyaCliPath();
+  const source = bundledAyaCliPath(__dirname);
+  // Refuse to install a shim that cannot work. The asar path bug (#39) made
+  // Install report success while the written shim exec'd a file inside the
+  // archive; verifying the exec bit up front turns any future packaging
+  // regression into a visible error instead of a silently broken CLI.
+  try {
+    await fs.access(source, fsConstants.X_OK);
+  } catch {
+    return {
+      installed: false,
+      path: null,
+      installDir,
+      installable: false,
+      message: `Bundled aya CLI is not executable at ${source}`,
+    };
+  }
   const target = path.join(installDir, "aya");
   const script = `#!/bin/sh\nexec ${JSON.stringify(source)} "$@"\n`;
   await fs.writeFile(target, script, { mode: CLI_EXECUTABLE_MODE });

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
       "dist-electron/**",
       "package.json"
     ],
+    "asarUnpack": [
+      "bin/**"
+    ],
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",

--- a/tests/cli-path.test.mjs
+++ b/tests/cli-path.test.mjs
@@ -1,0 +1,53 @@
+// The bundled aya CLI must resolve to a real, executable file in packaged
+// builds. #39: the installed shim exec'd .../app.asar/bin/aya - a path inside
+// the asar archive, which the OS cannot execute ("Not a directory") - because
+// bin/ was packed into the asar and the resolver never pointed at the
+// app.asar.unpacked copy.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { bundledAyaCliPath } from "../dist-electron/cli-path.js";
+
+test("packaged build: app.asar dirname resolves to the app.asar.unpacked copy", () => {
+  const dirname = "/Applications/Aya.app/Contents/Resources/app.asar/dist-electron";
+  assert.equal(
+    bundledAyaCliPath(dirname),
+    "/Applications/Aya.app/Contents/Resources/app.asar.unpacked/bin/aya",
+  );
+});
+
+test("dev build: repo dist-electron resolves to the repo's real bin/aya", () => {
+  const dirname = "/Users/dev/Projects/aya/dist-electron";
+  assert.equal(bundledAyaCliPath(dirname), "/Users/dev/Projects/aya/bin/aya");
+});
+
+test("only an exact app.asar path segment is rewritten, not a lookalike", () => {
+  // A directory NAMED like the archive but not the archive itself must not be
+  // touched - rewriting it would point at a path that does not exist.
+  const dirname = "/data/app.asar-backup/aya/dist-electron";
+  assert.equal(
+    bundledAyaCliPath(dirname),
+    "/data/app.asar-backup/aya/bin/aya",
+  );
+});
+
+// Config-presence check, same rationale as entitlements.test.mjs: the unpack
+// rule is a packaging detail no unit can exercise, so assert it exists. Without
+// asarUnpack the rewritten path points at a directory electron-builder never
+// materializes, and the shim is broken all the same.
+test("electron-builder config unpacks bin/ out of the asar", () => {
+  const pkg = JSON.parse(
+    readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json"),
+      "utf8",
+    ),
+  );
+  assert.ok(
+    Array.isArray(pkg.build.asarUnpack) &&
+      pkg.build.asarUnpack.includes("bin/**"),
+    "package.json build.asarUnpack must include bin/** so the aya CLI is a real file",
+  );
+});


### PR DESCRIPTION
## What

Fixes #39: the `aya` CLI installed from Settings was broken on every packaged build.

```
$ ~/.local/bin/aya status waiting "x"
.../app.asar/bin/aya: Not a directory
```

`installCli()` wrote a shim exec'ing `bundledAyaCliPath()` = `__dirname/../bin/aya`, which in production resolves **inside the asar archive** - readable by Node, not executable by the OS. `bin/**` was packed into the asar with no `asarUnpack`, so no real file ever existed. The whole CLI surface (`status` / `focus` / `notify` / `open`) was unavailable, while Install still reported success.

## Fix

- **`package.json`**: `asarUnpack: ["bin/**"]` - electron-builder materializes `bin/aya` next to the archive as a real `+x` file (`after-pack-prune.cjs` only touches locales + node-pty, so it stays).
- **`electron/cli-path.ts`** (new, pure): `bundledAyaCliPath(mainDirname)` rewrites the exact `app.asar` path segment to `app.asar.unpacked`; dev paths (no asar) pass through untouched; lookalike segments (`app.asar-backup`) are not rewritten.
- **`electron/main.ts`**: uses the helper; `installCli()` now preflights the target with `X_OK` and returns an error status instead of writing a knowingly-broken shim (per review note on #39 - no more false "Installed at ...").

## Verification (empirical, on a real package run)

Ran `CSC_IDENTITY_AUTO_DISCOVERY=false npm run package` and checked the artifact:

- `Aya.app/Contents/Resources/app.asar.unpacked/bin/aya` exists, `-rwxr-xr-x` (exec bit survives packing - the other review concern on #39);
- it **executes from the packaged location** (prints usage);
- the resolver maps the packaged `__dirname` exactly onto that file (`X_OK` confirmed).

## Tests

`tests/cli-path.test.mjs` (red -> green: failed with module-not-found before the implementation existed):
- packaged-path rewrite (`/Applications/...app.asar/dist-electron` -> `app.asar.unpacked/bin/aya`)
- dev passthrough (repo `dist-electron` -> repo `bin/aya`)
- lookalike segment not rewritten
- config-presence assert that `build.asarUnpack` covers `bin/**` (same rationale as `entitlements.test.mjs`: packaging details need honest config asserts)

unit: 247/247, typecheck clean.

## Out of scope (noted on #39)

The shim bakes an absolute path to the specific `Aya.app` at install time - moving/renaming the app still requires a reinstall. Left as a follow-up; the Settings button now correctly offers Reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
