### PR TITLE
feat: watch projects/*.json - external edits hot-reload without killing terminals (#4)

### DIFF
--- a/e2e/project-config-watch.spec.ts
+++ b/e2e/project-config-watch.spec.ts
@@ -1,0 +1,112 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "./fixtures";
+
+// Hot-reload of externally-edited project configs (#4). The watcher on
+// AYA_HOME/projects pushes a "projects" config-changed event; the renderer
+// merges disk state in WITHOUT touching live terminals. The project NAME in
+// the top bar doubles as the "reload landed" observable in every test, so no
+// sleeps are needed - each assertion waits on the visible effect itself.
+//
+// The invariant behind all three tests (maintainer decision on #4): editing a
+// file must never unexpectedly kill running terminals.
+
+function projectFile(ayaHome: string): string {
+  return join(ayaHome, "projects", "e2e-proj.json");
+}
+
+function readProject(ayaHome: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(projectFile(ayaHome), "utf8"));
+}
+
+// Plain (non-atomic) write - exactly what an external editor does.
+function writeProject(ayaHome: string, config: Record<string, unknown>): void {
+  writeFileSync(projectFile(ayaHome), JSON.stringify(config, null, 2) + "\n");
+}
+
+test("external tab rename shows up in the sidebar without a restart", async ({
+  window,
+  seeded,
+}) => {
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toBeVisible();
+
+  const config = readProject(seeded.ayaHome);
+  config.name = "e2e renamed";
+  (config.tabs as Array<{ name: string }>)[1].name = "renamed outside";
+  writeProject(seeded.ayaHome, config);
+
+  // Project name change proves the reload reached the renderer...
+  await expect(window.locator(".aya-tab-name")).toHaveText("e2e renamed");
+  // ...and the live terminal's row now carries the externally-edited name.
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "renamed outside" }),
+  ).toBeVisible();
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toHaveCount(0);
+});
+
+test("a tab removed on disk keeps its live terminal row (#4 decision 1)", async ({
+  window,
+  seeded,
+}) => {
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toBeVisible();
+
+  const config = readProject(seeded.ayaHome);
+  config.name = "e2e shrunk";
+  config.tabs = [(config.tabs as unknown[])[0]];
+  // Keep the file self-consistent: the split no longer references the removed tab.
+  delete config.splitLayout;
+  writeProject(seeded.ayaHome, config);
+
+  await expect(window.locator(".aya-tab-name")).toHaveText("e2e shrunk");
+  // The removed-from-disk tab still has a live PTY -> its row must survive.
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toBeVisible();
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 1" }),
+  ).toBeVisible();
+});
+
+test("a tab added on disk appears in the sidebar without spawning (#4 decision 2)", async ({
+  window,
+  seeded,
+}) => {
+  // Gate on boot having hydrated the ORIGINAL 2-tab config: writing earlier
+  // would race bootstrap, which would then hydrate (and spawn) the third tab
+  // as if it had been there all along.
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toBeVisible();
+
+  const config = readProject(seeded.ayaHome);
+  config.name = "e2e grown";
+  (config.tabs as unknown[]).push({
+    id: "tab-added",
+    presetId: "shell",
+    name: "added outside",
+  });
+  writeProject(seeded.ayaHome, config);
+
+  await expect(window.locator(".aya-tab-name")).toHaveText("e2e grown");
+  const addedRow = window.locator(".aya-sidebar-row", {
+    hasText: "added outside",
+  });
+  await expect(addedRow).toBeVisible();
+  // No PTY was spawned: the dot stays idle until the user activates the tab.
+  await expect(addedRow.locator(".aya-sidebar-statusdot")).toHaveClass(
+    /aya-sidebar-statusdot--idle/,
+  );
+
+  // Activation is what starts the process: select the tab and the spawned
+  // shell's output flips the dot to running.
+  await addedRow.click();
+  await expect(addedRow.locator(".aya-sidebar-statusdot")).toHaveClass(
+    /aya-sidebar-statusdot--running/,
+  );
+});

--- a/electron/config-watcher-pure.ts
+++ b/electron/config-watcher-pure.ts
@@ -2,10 +2,12 @@
 // Kept separate from config-watcher so it can be unit-tested on its own,
 // without fs.watch or Electron (same idea as window-state-pure.ts).
 //
-// For now only the files the user is meant to edit by hand live here:
-// snippets, presets and themes. projects/*.json and projects-state.json are
-// left out on purpose: they hold live terminal state and the app rewrites them
-// all the time, so reloading those safely would need more care.
+// Top-level files (snippets, presets, themes) map by exact filename below.
+// projects/*.json live in their own subfolder and get their own predicate
+// (isProjectConfigFilename) because fs.watch is non-recursive on Linux, so the
+// projects dir carries its own watcher. projects-state.json stays out on
+// purpose: it is app-owned live state and needs separate conflict semantics
+// (see #4).
 
 import type { ConfigSlice } from "./types";
 
@@ -26,4 +28,11 @@ export function sliceForFilename(filename: string): ConfigSlice | null {
   return Object.hasOwn(WATCHED_CONFIG_FILES, filename)
     ? WATCHED_CONFIG_FILES[filename]
     : null;
+}
+
+/** True for a project config inside AYA_HOME/projects: `<slug>.json`. The
+ *  `.tmp` files atomic writes create end in `.tmp`, so the suffix check
+ *  excludes them already; dotfiles are skipped for editor swap files. */
+export function isProjectConfigFilename(filename: string): boolean {
+  return filename.endsWith(".json") && !filename.startsWith(".");
 }

--- a/electron/config-watcher.ts
+++ b/electron/config-watcher.ts
@@ -1,74 +1,109 @@
 // Watches AYA_HOME for edits made to the user-editable config files
-// (snippets/presets/themes) from outside the app, and tells the renderer to
-// reload that slice, so an edit made by hand while Aya is running isn't
-// quietly overwritten by the next save the app makes.
+// (snippets/presets/themes, and project configs under projects/) from outside
+// the app, and tells the renderer to reload that slice, so an edit made by
+// hand while Aya is running isn't quietly overwritten by the next save the
+// app makes.
 //
-// We watch the AYA_HOME folder rather than the files themselves: the rename
-// done by an atomic write replaces the file, and a watch on the file itself
-// would lose track of it. The folder is watched non-recursively (recursive
-// watching isn't supported on Linux), which is fine since all three files sit
-// directly in AYA_HOME.
+// We watch folders rather than the files themselves: the rename done by an
+// atomic write replaces the file, and a watch on the file itself would lose
+// track of it. Folders are watched non-recursively (recursive watching isn't
+// supported on Linux), which is why the projects/ subfolder carries its own
+// watcher alongside the AYA_HOME one (#4).
 
 import { mkdirSync, watch, type FSWatcher } from "node:fs";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import type { BrowserWindow } from "electron";
 import { isEcho, recordWrite } from "./config-echo";
-import { sliceForFilename } from "./config-watcher-pure";
-import { AYA_HOME } from "./paths";
+import {
+  isProjectConfigFilename,
+  sliceForFilename,
+} from "./config-watcher-pure";
+import { AYA_HOME, PROJECTS_DIR } from "./paths";
 import type { ConfigSlice } from "./types";
 
 // A single save can fire a burst of file events, wait a moment so it becomes one reload.
 const WATCH_DEBOUNCE_MS = 200;
 
-/** Start watching AYA_HOME and send "config:changed" to the renderer when a
- *  file is edited from outside the app. Returns a function that stops the
- *  watcher and clears any pending timers. */
+/** Start watching AYA_HOME (and AYA_HOME/projects) and send "config:changed"
+ *  to the renderer when a file is edited from outside the app. Returns a
+ *  function that stops the watchers and clears any pending timers. */
 export function startConfigWatcher(win: BrowserWindow): () => void {
-  const timers = new Map<ConfigSlice, NodeJS.Timeout>();
-  let watcher: FSWatcher | null = null;
+  // Keyed by debounce identity: the slice name for top-level files, the
+  // individual filename for project configs (so edits to two different
+  // projects don't swallow each other's reload).
+  const timers = new Map<string, NodeJS.Timeout>();
+  const watchers: FSWatcher[] = [];
 
-  const emitIfExternal = async (slice: ConfigSlice, filePath: string) => {
+  const send = (slice: ConfigSlice) => {
+    if (!win.isDestroyed()) win.webContents.send("config:changed", { slice });
+  };
+
+  const emitIfExternal = async (
+    slice: ConfigSlice,
+    filePath: string,
+    // Project configs treat a missing file as meaningful (an external delete
+    // must reach the renderer so a closed project can drop off the list);
+    // top-level slices keep the old "ignore, next save syncs" behavior.
+    emitWhenMissing: boolean,
+  ) => {
     let content: string;
     try {
       content = await fs.readFile(filePath, "utf-8");
     } catch {
-      // If we can't read the file right now, ignore it; the next save will sync it.
+      if (emitWhenMissing) send(slice);
       return;
     }
     if (isEcho(filePath, content)) return;
     // Keep track what values the renderer was last given to distinguish in-app and manual edits.
     recordWrite(filePath, content);
-    if (!win.isDestroyed()) win.webContents.send("config:changed", { slice });
+    send(slice);
   };
 
-  const handle = (filename: string | null) => {
-    if (!filename) return; // some platforms don't give a name; nothing to do
-    const slice = sliceForFilename(filename);
-    if (!slice) return; // a .tmp file, projects-state, or something we don't reload
-    const filePath = path.join(AYA_HOME, filename);
-    const existing = timers.get(slice);
+  const debounce = (key: string, run: () => void) => {
+    const existing = timers.get(key);
     if (existing) clearTimeout(existing);
     timers.set(
-      slice,
+      key,
       setTimeout(() => {
-        timers.delete(slice);
-        void emitIfExternal(slice, filePath);
+        timers.delete(key);
+        run();
       }, WATCH_DEBOUNCE_MS),
     );
   };
 
+  const handleHome = (filename: string | null) => {
+    if (!filename) return; // some platforms don't give a name; nothing to do
+    const slice = sliceForFilename(filename);
+    if (!slice) return; // a .tmp file, projects-state, or something we don't reload
+    const filePath = path.join(AYA_HOME, filename);
+    debounce(slice, () => void emitIfExternal(slice, filePath, false));
+  };
+
+  const handleProjects = (filename: string | null) => {
+    if (!filename || !isProjectConfigFilename(filename)) return;
+    const filePath = path.join(PROJECTS_DIR, filename);
+    debounce(`projects:${filename}`, () =>
+      void emitIfExternal("projects", filePath, true),
+    );
+  };
+
   try {
-    mkdirSync(AYA_HOME, { recursive: true });
-    watcher = watch(AYA_HOME, { persistent: false }, (_event, filename) =>
-      handle(typeof filename === "string" ? filename : null),
+    mkdirSync(PROJECTS_DIR, { recursive: true });
+    watchers.push(
+      watch(AYA_HOME, { persistent: false }, (_event, filename) =>
+        handleHome(typeof filename === "string" ? filename : null),
+      ),
+      watch(PROJECTS_DIR, { persistent: false }, (_event, filename) =>
+        handleProjects(typeof filename === "string" ? filename : null),
+      ),
     );
   } catch {
     // Ignore outside edits causing exceptions.
   }
 
   return () => {
-    if (watcher) watcher.close();
+    for (const w of watchers) w.close();
     for (const timer of timers.values()) clearTimeout(timer);
     timers.clear();
   };

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -144,7 +144,7 @@ export interface ControlStatusUpdate {
 
 /** A config file the user can edit, which the renderer reloads when it changes
  *  on disk under ~/.aya/. */
-export type ConfigSlice = "snippets" | "presets" | "themes";
+export type ConfigSlice = "snippets" | "presets" | "themes" | "projects";
 
 export interface ConfigChange {
   slice: ConfigSlice;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
 import { clearedTerminalStatus } from "./pty-event-reducer";
 import {
+  applyExternalProjectEdits,
   mergeProjectsFromDisk,
-  terminalsForNewTabs,
-  withTabUpdatesFromDisk,
 } from "./project-reload";
 import { AttentionCenter } from "./components/AttentionCenter";
 import { EmptyState } from "./components/EmptyState";
@@ -613,18 +612,9 @@ export function App() {
                 (p) => merged.find((m) => m.slug === p.slug) ?? p,
               ),
             );
-            setTerminals((prev) => {
-              let next = prev;
-              for (const project of merged) {
-                if (!openSlugs.has(project.slug)) continue;
-                next = withTabUpdatesFromDisk(next, project);
-                for (const t of terminalsForNewTabs(project, next)) {
-                  if (next === prev) next = { ...prev };
-                  next[t.id] = t;
-                }
-              }
-              return next;
-            });
+            setTerminals((prev) =>
+              applyExternalProjectEdits(prev, merged, openSlugs),
+            );
           })
           .catch((e) =>
             console.warn(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
 import { clearedTerminalStatus } from "./pty-event-reducer";
+import {
+  mergeProjectsFromDisk,
+  terminalsForNewTabs,
+  withTabUpdatesFromDisk,
+} from "./project-reload";
 import { AttentionCenter } from "./components/AttentionCenter";
 import { EmptyState } from "./components/EmptyState";
 import { MissingDirModal } from "./components/MissingDirModal";
@@ -583,6 +588,47 @@ export function App() {
           .catch((e) =>
             console.warn(
               "config hot-reload (themes) failed; keeping current state",
+              e,
+            ),
+          );
+      } else if (slice === "projects") {
+        // External edit to projects/*.json (#4). Disk wins for config, but the
+        // merge never kills running terminals: removed tabs keep their live
+        // rows, added tabs appear without spawning, a deleted file of an OPEN
+        // project leaves it in place as unsaved.
+        void window.aya
+          .listProjects()
+          .then((disk) => {
+            const openSlugs = new Set(
+              projectsRef.current.map((p) => p.slug),
+            );
+            const merged = mergeProjectsFromDisk(
+              disk,
+              allProjectsRef.current,
+              openSlugs,
+            );
+            setAllProjects(merged);
+            setProjects((prev) =>
+              prev.map(
+                (p) => merged.find((m) => m.slug === p.slug) ?? p,
+              ),
+            );
+            setTerminals((prev) => {
+              let next = prev;
+              for (const project of merged) {
+                if (!openSlugs.has(project.slug)) continue;
+                next = withTabUpdatesFromDisk(next, project);
+                for (const t of terminalsForNewTabs(project, next)) {
+                  if (next === prev) next = { ...prev };
+                  next[t.id] = t;
+                }
+              }
+              return next;
+            });
+          })
+          .catch((e) =>
+            console.warn(
+              "config hot-reload (projects) failed; keeping current state",
               e,
             ),
           );
@@ -1965,12 +2011,32 @@ export function App() {
       ? [activeTabId]
       : [];
   const visibleTerminalIdSet = new Set(visibleTerminalIds);
+  // spawnDeferred tabs (added by an external config edit, #4) stay out of the
+  // hidden pool: a hidden TerminalView mounts an xterm and spawns the PTY,
+  // and those tabs must not get a process until first activated.
   const hiddenTerminals = Object.values(terminals).filter(
-    (terminal) => !visibleTerminalIdSet.has(terminal.id),
+    (terminal) => !visibleTerminalIdSet.has(terminal.id) && !terminal.spawnDeferred,
   );
   const assignableProjectTerminals = projectTerminals.filter(
     (terminal) => !visibleTerminalIdSet.has(terminal.id),
   );
+
+  // The first time a deferred tab becomes visible (sidebar activation or
+  // split assignment), drop the flag - from then on it mounts and spawns like
+  // any other terminal, including via the hidden pool.
+  const visibleTerminalsKey = visibleTerminalIds.join("\n");
+  useEffect(() => {
+    setTerminals((prev) => {
+      let next = prev;
+      for (const id of visibleTerminalsKey.split("\n")) {
+        const t = next[id];
+        if (!t?.spawnDeferred) continue;
+        if (next === prev) next = { ...prev };
+        next[id] = { ...t, spawnDeferred: undefined };
+      }
+      return next;
+    });
+  }, [visibleTerminalsKey]);
 
   const projectBadges: Record<
     string,

--- a/src/project-reload.ts
+++ b/src/project-reload.ts
@@ -1,0 +1,71 @@
+// Pure merge for hot-reloading project configs edited outside the app (#4).
+// Extracted from App.tsx's config-changed handler so the conflict semantics
+// can be tested without React (same pattern as pty-event-reducer).
+//
+// The one UX rule behind every branch here (maintainer decision on #4):
+// editing a file must never unexpectedly kill running terminals. Live
+// TerminalStates are therefore never removed by a reload - the sidebar renders
+// from the terminals map, so a tab deleted on disk keeps its live row until
+// the user closes it.
+
+import type { ProjectConfig, TerminalState } from "./types";
+
+/** Disk wins for every project it still contains; a project missing from disk
+ *  survives only while it is open (it becomes "unsaved" - the next in-app save
+ *  recreates the file). Closed projects missing from disk drop off the list.
+ *  Disk order is kept; open survivors append in their current order. */
+export function mergeProjectsFromDisk(
+  disk: ProjectConfig[],
+  current: ProjectConfig[],
+  openSlugs: ReadonlySet<string>,
+): ProjectConfig[] {
+  const diskSlugs = new Set(disk.map((p) => p.slug));
+  const survivors = current.filter(
+    (p) => !diskSlugs.has(p.slug) && openSlugs.has(p.slug),
+  );
+  return [...disk, ...survivors];
+}
+
+/** TerminalState entries for tabs that exist in an (open) project's config but
+ *  not in the terminals map yet - i.e. tabs added by an external edit. They
+ *  start as "idle" and WITHOUT a PTY: the process spawns only when the pane
+ *  becomes visible / the user activates it (decision 2 on #4). Existing
+ *  entries are never touched here - removal/cwd conflicts are resolved by
+ *  keeping the live terminal as-is (decisions 1 and 3). */
+export function terminalsForNewTabs(
+  project: ProjectConfig,
+  existing: Readonly<Record<string, TerminalState>>,
+): TerminalState[] {
+  return project.tabs
+    .filter((tab) => !existing[tab.id])
+    .map((tab) => ({
+      id: tab.id,
+      projectSlug: project.slug,
+      presetId: tab.presetId,
+      name: tab.name,
+      cwd: project.directory,
+      status: "idle" as const,
+      bell: false,
+      exitCode: null,
+      spawnDeferred: true,
+    }));
+}
+
+/** Apply non-destructive per-tab updates from disk to live terminals: an
+ *  external rename (or preset change) shows up immediately, but status,
+ *  exitCode, cwd and the PTY itself stay untouched. Returns the same reference
+ *  when nothing changed so React can skip the re-render. */
+export function withTabUpdatesFromDisk(
+  terminals: Readonly<Record<string, TerminalState>>,
+  project: ProjectConfig,
+): Record<string, TerminalState> {
+  let next: Record<string, TerminalState> | null = null;
+  for (const tab of project.tabs) {
+    const t = terminals[tab.id];
+    if (!t || t.projectSlug !== project.slug) continue;
+    if (t.name === tab.name && t.presetId === tab.presetId) continue;
+    if (!next) next = { ...terminals };
+    next[tab.id] = { ...t, name: tab.name, presetId: tab.presetId };
+  }
+  return next ?? (terminals as Record<string, TerminalState>);
+}

--- a/src/project-reload.ts
+++ b/src/project-reload.ts
@@ -51,6 +51,27 @@ export function terminalsForNewTabs(
     }));
 }
 
+/** One-call application of an external edit to the terminals map: per-tab
+ *  non-destructive updates plus entries for newly-added tabs, across all OPEN
+ *  projects. Pure and reference-stable (same map back when nothing changed),
+ *  so the App handler stays a single line instead of a clone-tracking loop. */
+export function applyExternalProjectEdits(
+  terminals: Readonly<Record<string, TerminalState>>,
+  projects: ProjectConfig[],
+  openSlugs: ReadonlySet<string>,
+): Record<string, TerminalState> {
+  let next = terminals as Record<string, TerminalState>;
+  for (const project of projects) {
+    if (!openSlugs.has(project.slug)) continue;
+    next = withTabUpdatesFromDisk(next, project);
+    const added = terminalsForNewTabs(project, next);
+    if (added.length === 0) continue;
+    if (next === terminals) next = { ...terminals };
+    for (const t of added) next[t.id] = t;
+  }
+  return next;
+}
+
 /** Apply non-destructive per-tab updates from disk to live terminals: an
  *  external rename (or preset change) shows up immediately, but status,
  *  exitCode, cwd and the PTY itself stay untouched. Returns the same reference

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,7 +215,7 @@ export interface BufferSearchHit {
 
 /** A config file the user can edit, which the renderer reloads when it changes
  *  on disk under ~/.aya/. */
-export type ConfigSlice = "snippets" | "presets" | "themes";
+export type ConfigSlice = "snippets" | "presets" | "themes" | "projects";
 
 export interface ConfigChange {
   slice: ConfigSlice;
@@ -333,6 +333,10 @@ export interface TerminalState {
     text: string;
     updatedAt: number;
   };
+  /** Tab added by an external config edit (#4): kept out of the hidden
+   *  TerminalView pool so no PTY spawns until the terminal first becomes
+   *  visible (sidebar activation or split assignment clears the flag). */
+  spawnDeferred?: boolean;
 }
 
 export type ProjectEventLevel = "info" | "active" | "waiting" | "done" | "error";

--- a/tests/config-watcher-pure.test.mjs
+++ b/tests/config-watcher-pure.test.mjs
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   WATCHED_CONFIG_FILES,
+  isProjectConfigFilename,
   sliceForFilename,
 } from "../dist-electron/config-watcher-pure.js";
 
@@ -47,4 +48,17 @@ test("WATCHED_CONFIG_FILES covers exactly the minimal slices", () => {
     "snippets",
     "themes",
   ]);
+});
+
+// --- isProjectConfigFilename (the projects/ watcher predicate, #4) ----------
+
+test("isProjectConfigFilename accepts <slug>.json only", () => {
+  assert.equal(isProjectConfigFilename("e2e-proj.json"), true);
+  assert.equal(isProjectConfigFilename("my.project.json"), true);
+});
+
+test("isProjectConfigFilename rejects atomic-write temps and editor files", () => {
+  assert.equal(isProjectConfigFilename("e2e-proj.json.123.abc.tmp"), false);
+  assert.equal(isProjectConfigFilename(".e2e-proj.json.swp"), false);
+  assert.equal(isProjectConfigFilename("notes.txt"), false);
 });

--- a/tests/project-reload.test.mjs
+++ b/tests/project-reload.test.mjs
@@ -5,6 +5,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  applyExternalProjectEdits,
   mergeProjectsFromDisk,
   terminalsForNewTabs,
   withTabUpdatesFromDisk,
@@ -116,6 +117,29 @@ test("no changes -> same reference back (React can skip the re-render)", () => {
     "a-tab1": termState("a-tab1", "a", { name: "shell 1" }),
   };
   assert.equal(withTabUpdatesFromDisk(existing, p), existing);
+});
+
+// --- applyExternalProjectEdits (the composer the App handler calls) ---------
+
+test("composer applies rename + added tab in one pass; closed projects skipped", () => {
+  const open = project("a", {
+    tabs: [
+      { id: "a-tab1", presetId: "shell", name: "renamed" },
+      { id: "a-tab2", presetId: "shell", name: "fresh" },
+    ],
+  });
+  const closed = project("b");
+  const prev = { "a-tab1": termState("a-tab1", "a", { name: "old" }) };
+  const next = applyExternalProjectEdits(prev, [open, closed], new Set(["a"]));
+  assert.equal(next["a-tab1"].name, "renamed");
+  assert.equal(next["a-tab2"].spawnDeferred, true);
+  assert.equal(next["b-tab1"], undefined);
+});
+
+test("composer returns the same reference when nothing changed", () => {
+  const p = project("a");
+  const prev = { "a-tab1": termState("a-tab1", "a", { name: "shell 1" }) };
+  assert.equal(applyExternalProjectEdits(prev, [p], new Set(["a"])), prev);
 });
 
 test("a tab belonging to another project's terminal id is not touched", () => {

--- a/tests/project-reload.test.mjs
+++ b/tests/project-reload.test.mjs
@@ -1,0 +1,127 @@
+// Conflict semantics for hot-reloading externally-edited project configs (#4).
+// Each test encodes one maintainer decision from the issue; the overarching
+// rule is "editing a file must never unexpectedly kill running terminals".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mergeProjectsFromDisk,
+  terminalsForNewTabs,
+  withTabUpdatesFromDisk,
+} from "../dist-test/project-reload.js";
+
+function project(slug, overrides = {}) {
+  return {
+    slug,
+    name: slug,
+    directory: `/tmp/${slug}`,
+    tabs: [{ id: `${slug}-tab1`, presetId: "shell", name: "shell 1" }],
+    ...overrides,
+  };
+}
+
+function termState(id, slug, overrides = {}) {
+  return {
+    id,
+    projectSlug: slug,
+    presetId: "shell",
+    name: id,
+    cwd: `/tmp/${slug}`,
+    status: "running",
+    bell: false,
+    exitCode: null,
+    ...overrides,
+  };
+}
+
+// --- mergeProjectsFromDisk ---------------------------------------------------
+
+test("disk wins for projects it contains (name/directory/tabs replaced)", () => {
+  const disk = [project("a", { name: "renamed", directory: "/new" })];
+  const current = [project("a")];
+  const merged = mergeProjectsFromDisk(disk, current, new Set(["a"]));
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].name, "renamed");
+  assert.equal(merged[0].directory, "/new");
+});
+
+test("an OPEN project deleted on disk survives as unsaved (decision 4)", () => {
+  const merged = mergeProjectsFromDisk([], [project("a")], new Set(["a"]));
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].slug, "a");
+});
+
+test("a CLOSED project deleted on disk drops off the list (decision 4)", () => {
+  const merged = mergeProjectsFromDisk([], [project("a")], new Set());
+  assert.equal(merged.length, 0);
+});
+
+test("a project added on disk appears; disk order kept, survivors appended", () => {
+  const disk = [project("b"), project("c")];
+  const current = [project("a"), project("b")];
+  const merged = mergeProjectsFromDisk(disk, current, new Set(["a", "b"]));
+  assert.deepEqual(
+    merged.map((p) => p.slug),
+    ["b", "c", "a"],
+  );
+});
+
+// --- terminalsForNewTabs -----------------------------------------------------
+
+test("externally-added tab gets a TerminalState without a PTY (idle, decision 2)", () => {
+  const p = project("a", {
+    tabs: [
+      { id: "a-tab1", presetId: "shell", name: "shell 1" },
+      { id: "a-tab2", presetId: "claude", name: "added outside" },
+    ],
+  });
+  const existing = { "a-tab1": termState("a-tab1", "a") };
+  const created = terminalsForNewTabs(p, existing);
+  assert.equal(created.length, 1);
+  assert.equal(created[0].id, "a-tab2");
+  assert.equal(created[0].status, "idle");
+  assert.equal(created[0].presetId, "claude");
+  assert.equal(created[0].cwd, "/tmp/a");
+  // spawnDeferred keeps the tab out of the hidden TerminalView pool, which is
+  // what would otherwise mount an xterm and spawn the PTY immediately.
+  assert.equal(created[0].spawnDeferred, true);
+});
+
+test("existing terminals are never recreated (no respawn, decision 1)", () => {
+  const p = project("a");
+  const existing = { "a-tab1": termState("a-tab1", "a", { status: "error" }) };
+  assert.equal(terminalsForNewTabs(p, existing).length, 0);
+});
+
+// --- withTabUpdatesFromDisk --------------------------------------------------
+
+test("external tab rename reaches the live terminal; status/cwd untouched", () => {
+  const p = project("a", {
+    directory: "/elsewhere",
+    tabs: [{ id: "a-tab1", presetId: "shell", name: "renamed tab" }],
+  });
+  const existing = {
+    "a-tab1": termState("a-tab1", "a", { status: "running", cwd: "/tmp/a" }),
+  };
+  const next = withTabUpdatesFromDisk(existing, p);
+  assert.equal(next["a-tab1"].name, "renamed tab");
+  assert.equal(next["a-tab1"].status, "running");
+  // decision 3: a directory change applies to future terminals only
+  assert.equal(next["a-tab1"].cwd, "/tmp/a");
+});
+
+test("no changes -> same reference back (React can skip the re-render)", () => {
+  const p = project("a");
+  const existing = {
+    "a-tab1": termState("a-tab1", "a", { name: "shell 1" }),
+  };
+  assert.equal(withTabUpdatesFromDisk(existing, p), existing);
+});
+
+test("a tab belonging to another project's terminal id is not touched", () => {
+  const p = project("a", {
+    tabs: [{ id: "shared-id", presetId: "shell", name: "from a" }],
+  });
+  const existing = { "shared-id": termState("shared-id", "b") };
+  assert.equal(withTabUpdatesFromDisk(existing, p), existing);
+});

--- a/tsconfig.test-src.json
+++ b/tsconfig.test-src.json
@@ -16,6 +16,7 @@
     "src/bell.ts",
     "src/double-shift.ts",
     "src/focus-reporting.ts",
+    "src/project-reload.ts",
     "src/pty-event-reducer.ts",
     "src/terminal-option-key.ts",
     "src/terminal-keys.ts",


### PR DESCRIPTION
## What

Implements the remaining slice of #4 with exactly the semantics you decided on the issue. The governing rule everywhere: **editing a file must never unexpectedly kill running terminals.**

| Your decision | Implementation |
|---|---|
| 1. Removed tab with running PTY -> keep the live terminal | The reload never deletes from the terminals map; the sidebar renders from it, so the row survives until the user closes it |
| 2. Added tab -> show, but spawn only on activation | New `spawnDeferred` TerminalState: kept out of the hidden TerminalView pool (which mounts an xterm and spawns immediately); flag drops the first time the tab becomes visible |
| 3. `directory` change -> future terminals only | Config replaced from disk; live terminals keep their cwd |
| 4. File deleted: open project -> unsaved; closed -> drops off | `mergeProjectsFromDisk` keeps open survivors, drops closed ones |
| 5. `projects-state.json` stays out | Untouched (still skipped by the watcher) |

## How

- **Main:** a second non-recursive watcher on `AYA_HOME/projects` (fs.watch can't recurse on Linux), same 200ms debounce and echo suppression - project writes already go through `writeFileAtomic -> recordWrite`, so the app's own saves were suppressed for free. Debounce is keyed per project file. ENOENT **emits** for this slice (an external delete must reach the renderer).
- **Renderer:** `slice === "projects"` -> `listProjects()` -> pure merge (`src/project-reload.ts`, tested without React, same pattern as `pty-event-reducer`). External tab renames/preset changes reach live terminals without touching status/cwd/PTY.

## Tests

- `tests/project-reload.test.mjs` - 9 unit tests, one per decision branch.
- `e2e/project-config-watch.spec.ts` - three live-app scenarios driven by plain `writeFileSync` (exactly what an external editor does): rename shows up live; removed tab keeps its live row; **added tab appears idle without spawning and spawns on first activation**. The project name in the top bar doubles as the "reload landed" observable - no sleeps.

## Verification

- typecheck clean; unit 264/264; e2e full suite 49/49 locally (and this PR's CI).

## Note on merge order

#45 (the stranded-commits restore) touches the same import region of `App.tsx` - if it lands first I'll rebase this in a minute; the overlap is trivial.

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
