### PR TITLE
refactor: clearer shim health check + cover the default-path seam (KISS/YAGNI, #48 follow-up)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -109,6 +109,18 @@ function findExecutableOnPath(name: string): string | null {
   return null;
 }
 
+async function anyExecutable(paths: string[]): Promise<boolean> {
+  for (const p of paths) {
+    try {
+      await fs.access(p, fsConstants.X_OK);
+      return true;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return false;
+}
+
 function writableDirOnPath(): string | null {
   for (const entry of pathEntries()) {
     try {
@@ -134,18 +146,7 @@ async function cliStatus(): Promise<CliStatus> {
   if (installed) {
     try {
       const targets = parseShimTargets(await fs.readFile(installed, "utf-8"));
-      broken =
-        targets.length > 0 &&
-        !(
-          await Promise.all(
-            targets.map((t) =>
-              fs.access(t, fsConstants.X_OK).then(
-                () => true,
-                () => false,
-              ),
-            ),
-          )
-        ).some(Boolean);
+      broken = targets.length > 0 && !(await anyExecutable(targets));
     } catch {
       // unreadable or not our script - leave it alone
     }

--- a/tests/cli-shim.test.mjs
+++ b/tests/cli-shim.test.mjs
@@ -7,6 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  defaultInstallAyaCliPath,
   parseShimTargets,
   renderCliShim,
 } from "../dist-electron/cli-shim.js";
@@ -72,4 +73,20 @@ test("parseShimTargets understands the legacy #42 shim format", () => {
 test("parseShimTargets returns [] for scripts that are not our shim", () => {
   assert.deepEqual(parseShimTargets("#!/bin/bash\necho hello\n"), []);
   assert.deepEqual(parseShimTargets(""), []);
+});
+
+// defaultInstallAyaCliPath: the macOS self-heal target (and "none" elsewhere).
+// The platform param keeps it a pure, testable seam rather than reading
+// process.platform directly.
+
+test("defaultInstallAyaCliPath points at /Applications on macOS", () => {
+  assert.equal(
+    defaultInstallAyaCliPath("darwin"),
+    "/Applications/Aya.app/Contents/Resources/app.asar.unpacked/bin/aya",
+  );
+});
+
+test("defaultInstallAyaCliPath has no well-known location off macOS", () => {
+  assert.equal(defaultInstallAyaCliPath("linux"), null);
+  assert.equal(defaultInstallAyaCliPath("win32"), null);
 });


### PR DESCRIPTION
## What

Re-delivers the KISS/YAGNI polish from #48 that got left out of the squash merge (the maintainer merged at the quoting-fix commit; this last commit landed just after and was stranded when the branch was deleted). **No bug in main** - the merged code is correct (the critical single-quote fix and its tests are in); this is the quality pass on top.

- **KISS**: replace the clever `!(await Promise.all(targets.map(t => fs.access(t,X_OK).then(()=>true,()=>false)))).some(Boolean)` in `cliStatus` with a named `anyExecutable(paths)` predicate (sequential short-circuit - at most two candidates, so parallelism was noise). Behavior-identical (confirmed by Grok during #48 review).
- **YAGNI**: `defaultInstallAyaCliPath(platform)` had a platform param for testability but no test -> added darwin/linux/win32 cases so the seam is earned.

## Verification

- typecheck clean; unit 282/282
- behavior unchanged (pure readability + test coverage)
- the diff is byte-identical to the already-Grok-reviewed commit `db82a4e` from #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
