### PR TITLE
fix: recover the user's PATH from a login shell so GUI-launched Aya finds claude/codex

### DIFF
--- a/e2e/sidebar-close-terminal.spec.ts
+++ b/e2e/sidebar-close-terminal.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "./fixtures";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 // Closing a terminal from the sidebar context menu mutates both the tab list and
 // the active-selection state. The dangling-active-pointer class of bug (see #18)
@@ -48,4 +50,38 @@ test("closing a non-active terminal via the sidebar menu leaves the active one u
     window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
   ).toHaveCount(0);
   await expect(window.locator(".aya-sidebar-row--active")).toHaveText(/shell 1/);
+});
+
+test("renaming a terminal via the sidebar menu opens the inline editor and persists", async ({
+  window,
+  seeded,
+}) => {
+  await window
+    .locator(".aya-sidebar-row", { hasText: "shell 2" })
+    .click({ button: "right" });
+  await window
+    .locator(".aya-context-menu-item", { hasText: "Rename terminal" })
+    .click();
+
+  const editor = window.locator(".aya-sidebar-rename");
+  await expect(editor).toBeVisible();
+  await editor.fill("renamed from menu");
+  await editor.press("Enter");
+
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "renamed from menu" }),
+  ).toBeVisible();
+  await expect(
+    window.locator(".aya-sidebar-row", { hasText: "shell 2" }),
+  ).toHaveCount(0);
+  await expect
+    .poll(() => {
+      const raw = readFileSync(
+        join(seeded.ayaHome, "projects", "e2e-proj.json"),
+        "utf8",
+      );
+      const project = JSON.parse(raw) as { tabs: Array<{ id: string; name: string }> };
+      return project.tabs.find((tab) => tab.id === seeded.tabIds.right)?.name;
+    })
+    .toBe("renamed from menu");
 });

--- a/electron/harnesses.ts
+++ b/electron/harnesses.ts
@@ -7,7 +7,7 @@
 // binaries installed via version managers.
 
 import { execFile } from "node:child_process";
-import * as os from "node:os";
+import { userShell } from "./shell";
 
 export interface HarnessDef {
   /** Canonical id; used as the preset id when seeded. */
@@ -114,13 +114,6 @@ export const KNOWN_HARNESSES: readonly HarnessDef[] = [
  *  from accidentally smuggling shell syntax into the PATH probe. */
 export function isSafeBinaryName(s: string): boolean {
   return /^[a-zA-Z0-9_.-]+$/.test(s);
-}
-
-function userShell(): string {
-  const envShell = process.env.SHELL?.trim();
-  if (envShell) return envShell;
-  const accountShell = os.userInfo().shell;
-  return accountShell && accountShell.trim() ? accountShell : "/bin/bash";
 }
 
 async function commandExists(binary: string): Promise<boolean> {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -56,6 +56,7 @@ import {
   uninstallUsageHook,
 } from "./usage-hook";
 import { readRepoProjectConfig } from "./project-local";
+import { repairProcessPath } from "./shell-path";
 import { PtyHostClient } from "./pty-host-client";
 import {
   requirePositiveInt,
@@ -1166,6 +1167,16 @@ app.on("open-file", (event, filePath) => {
 
 app.whenReady().then(async () => {
   configureAppIdentity();
+
+  // Repair PATH before anything that resolves a binary. A GUI-launched app
+  // only inherits launchd's minimal PATH, so the user's CLIs (claude, codex,
+  // …) installed under ~/.local/bin / mise / asdf are invisible until we pull
+  // the real PATH from a login shell. Must run before createWindow (the
+  // renderer's first preset:list triggers a harness scan) and before the PTY
+  // host spawns (it inherits this process's env), so we await it here. The
+  // probe self-bounds (SIGKILL + guard timer), so a slow rc delays first paint
+  // by at most the probe timeout; a failed probe is a no-op.
+  await repairProcessPath();
 
   // In dev, replace Electron's default dock icon with ours so the running
   // instance is visually distinguishable. In packaged builds the bundle's

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -2,10 +2,15 @@
 //
 // We accept a literal `command` string from the renderer and wrap it in
 // `$SHELL -l -c 'cd CWD && exec COMMAND'`. Using the user's login shell —
-// not a hard-coded bash — means PATH additions from zsh's .zshrc /
-// .zprofile (mise, asdf, oh-my-zsh plugins, brew) work; otherwise users
-// on zsh would see "command not found: claude" because bash doesn't read
-// their rc files.
+// not a hard-coded bash — lets PATH from their login profile (.zprofile /
+// .zlogin, brew shellenv, /etc/paths) flow through; a bare bash wouldn't.
+//
+// CAVEAT: `-l -c` is a login but NON-interactive shell, so it does NOT source
+// .zshrc / .bashrc — exactly where many users add ~/.local/bin, mise, asdf.
+// Those dirs are recovered separately at startup by electron/shell-path.ts,
+// which repairs process.env.PATH from a login+interactive shell before this
+// host is spawned (the host inherits that env). Without that step, GUI-
+// launched Aya would show "command not found: claude" for those installs.
 
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -14,6 +19,7 @@ import { execFile } from "node:child_process";
 import type * as PtyModule from "node-pty";
 import type { PtyEvent, SpawnFailureReason, SpawnRequest } from "./types";
 import { AYA_HOME, CONTROL_SOCKET_PATH } from "./paths";
+import { userShell } from "./shell";
 
 // Timeout for the shell `command -v` existence check during spawn preflight.
 const COMMAND_CHECK_TIMEOUT_MS = 2500;
@@ -188,16 +194,6 @@ export function searchPtyOutputs(query: string): BufferSearchHit[] {
 
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-/** Resolve the user's login shell. GUI-launched macOS apps often don't get
- *  SHELL in their launchd environment, so fall back to the shell from the
- *  OS user database before using /bin/bash as the last resort. */
-function userShell(): string {
-  const envShell = process.env.SHELL?.trim();
-  if (envShell) return envShell;
-  const accountShell = os.userInfo().shell;
-  return accountShell && accountShell.trim() ? accountShell : "/bin/bash";
 }
 
 /** Build the shell argv for a given command + cwd. Uses the user's login

--- a/electron/shell-path.ts
+++ b/electron/shell-path.ts
@@ -1,0 +1,140 @@
+// Recover the user's real PATH for GUI-launched Aya.
+//
+// macOS (and Linux desktop) start GUI apps from launchd/the session manager
+// with a minimal PATH — typically just /usr/bin:/bin:/usr/sbin:/sbin plus
+// whatever /etc/paths(.d) and the login profile add. The user's own PATH
+// additions (~/.local/bin, mise, asdf, npm-global, …) are commonly written to
+// .zshrc / .bashrc, which are sourced ONLY for *interactive* shells. Aya spawns
+// presets through `$SHELL -l -c` (a login but NON-interactive shell), so those
+// dirs never make it onto PATH and `claude`/`codex` come back as
+// "command not found". Running from `npm run dev` hides the bug because the
+// dev process inherits the developer's already-populated interactive PATH.
+//
+// The fix: once at startup, ask a login + INTERACTIVE shell for its PATH and
+// merge it into process.env.PATH. The PTY host inherits this env when it is
+// spawned (see pty-host-client.ts), and harness auto-detection runs in this
+// same main process, so a single repair fixes preset launches, the
+// command-not-found preflight, the first-launch harness scan, and the
+// writable-dir search used by the `aya` CLI installer — all at once.
+
+import { execFile } from "node:child_process";
+import * as path from "node:path";
+import { userShell } from "./shell";
+
+// Worst-case time we'll wait for the shell to print its PATH. A normal shell
+// answers in well under a second; a heavy .zshrc (oh-my-zsh + plugins) can take
+// a few hundred ms. On expiry we abandon the probe and leave PATH untouched.
+const PATH_PROBE_TIMEOUT_MS = 5000;
+
+// Sentinels bracket the PATH value so rc-file noise printed during shell
+// startup (banners, instant-prompt escapes, "update available" notices) can be
+// sliced off — we keep only what's strictly between the markers.
+const PATH_BEGIN = "__AYA_PATH_BEGIN__";
+const PATH_END = "__AYA_PATH_END__";
+
+/** argv for a login + interactive shell that prints its PATH between sentinels.
+ *  `-i` is what makes the shell source .zshrc/.bashrc (where ~/.local/bin etc.
+ *  usually live); `-l` keeps .zprofile/.bash_profile in the mix too. $PATH is
+ *  double-quoted so zsh/bash/sh expand the colon-joined scalar; the markers are
+ *  single-quoted literals. POSIX-oriented — fish expands $PATH as a space-
+ *  joined list, not a colon scalar, so parseResolvedPath rejects its output
+ *  (see there) rather than risk corrupting PATH. */
+export function shellPathProbeArgv(shell: string): string[] {
+  return [
+    shell,
+    "-l",
+    "-i",
+    "-c",
+    `printf '%s%s%s' '${PATH_BEGIN}' "$PATH" '${PATH_END}'`,
+  ];
+}
+
+/** Pull the PATH value out of the probe's stdout, ignoring anything printed
+ *  before/after our sentinels. Returns null when the markers are absent (the
+ *  shell errored), the value is empty, or it doesn't look like a colon-joined
+ *  PATH. The last guard catches fish, whose "$PATH" prints as a space-joined
+ *  list: a value with whitespace but no path separator would otherwise be
+ *  merged in as a single bogus entry, so we drop it and leave PATH unchanged. */
+export function parseResolvedPath(stdout: string): string | null {
+  const begin = stdout.indexOf(PATH_BEGIN);
+  if (begin === -1) return null;
+  const valueStart = begin + PATH_BEGIN.length;
+  const end = stdout.indexOf(PATH_END, valueStart);
+  if (end === -1) return null;
+  const value = stdout.slice(valueStart, end);
+  if (value.length === 0) return null;
+  if (/\s/.test(value) && !value.includes(path.delimiter)) return null;
+  return value;
+}
+
+/** Union of the resolved (login-shell) PATH entries followed by whatever the
+ *  current process already had, de-duplicated and order-preserving. The
+ *  resolved entries come first so the user's intended order wins, but nothing
+ *  the GUI environment provided (cryptex paths, etc.) is dropped. */
+export function mergePath(resolved: string, current: string | undefined): string {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const source of [resolved, current ?? ""]) {
+    for (const entry of source.split(path.delimiter)) {
+      if (entry.length > 0 && !seen.has(entry)) {
+        seen.add(entry);
+        out.push(entry);
+      }
+    }
+  }
+  return out.join(path.delimiter);
+}
+
+/** Run the user's login + interactive shell once and return the PATH it
+ *  reports. Resolves null on Windows (the `$SHELL -l -i -c` model doesn't
+ *  apply), on timeout, on shell error, or when the output isn't a usable PATH —
+ *  every failure is non-fatal and callers leave PATH as-is. The probe can never
+ *  stall startup: the shell is SIGKILLed on timeout, and a guard timer settles
+ *  the promise even if a stray child kept stdout open past the kill. `platform`
+ *  and `run` are injectable so the win32 short-circuit and the error/success
+ *  paths are testable without spawning a real shell. */
+export function resolveLoginShellPath(
+  platform: NodeJS.Platform = process.platform,
+  run: typeof execFile = execFile,
+): Promise<string | null> {
+  if (platform === "win32") return Promise.resolve(null);
+  const [shell, ...args] = shellPathProbeArgv(userShell());
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value: string | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const guard = setTimeout(() => settle(null), PATH_PROBE_TIMEOUT_MS);
+    guard.unref();
+    run(
+      shell,
+      args,
+      {
+        timeout: PATH_PROBE_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+        windowsHide: true,
+        encoding: "utf8",
+      },
+      (err, stdout) => {
+        clearTimeout(guard);
+        settle(err ? null : parseResolvedPath(stdout));
+      },
+    );
+  });
+}
+
+/** Merge the login-shell PATH into process.env.PATH so GUI-launched Aya can
+ *  find CLIs whose dirs are only added in .zshrc/.bashrc. Call once, early in
+ *  startup, before the PTY host is spawned or harnesses are scanned. Returns
+ *  true if PATH actually changed (useful for tests/logging). No-op on any
+ *  failure. */
+export async function repairProcessPath(): Promise<boolean> {
+  const resolved = await resolveLoginShellPath();
+  if (!resolved) return false;
+  const merged = mergePath(resolved, process.env.PATH);
+  if (merged === process.env.PATH) return false;
+  process.env.PATH = merged;
+  return true;
+}

--- a/electron/shell-path.ts
+++ b/electron/shell-path.ts
@@ -130,8 +130,10 @@ export function resolveLoginShellPath(
  *  startup, before the PTY host is spawned or harnesses are scanned. Returns
  *  true if PATH actually changed (useful for tests/logging). No-op on any
  *  failure. */
-export async function repairProcessPath(): Promise<boolean> {
-  const resolved = await resolveLoginShellPath();
+export async function repairProcessPath(
+  resolvePath: typeof resolveLoginShellPath = resolveLoginShellPath,
+): Promise<boolean> {
+  const resolved = await resolvePath();
   if (!resolved) return false;
   const merged = mergePath(resolved, process.env.PATH);
   if (merged === process.env.PATH) return false;

--- a/electron/shell.ts
+++ b/electron/shell.ts
@@ -1,0 +1,15 @@
+// The user's login shell, resolved once and shared by everything that spawns
+// one (pty.ts, harnesses.ts, shell-path.ts). Kept here as a single source of
+// truth so the fallback order can't drift between the three call sites.
+
+import * as os from "node:os";
+
+/** Resolve the user's login shell. GUI-launched macOS apps often don't get
+ *  SHELL in their launchd environment, so fall back to the shell from the
+ *  OS user database before using /bin/bash as the last resort. */
+export function userShell(): string {
+  const envShell = process.env.SHELL?.trim();
+  if (envShell) return envShell;
+  const accountShell = os.userInfo().shell;
+  return accountShell && accountShell.trim() ? accountShell : "/bin/bash";
+}

--- a/tests/shell-path.test.mjs
+++ b/tests/shell-path.test.mjs
@@ -1,0 +1,103 @@
+// Covers the PATH-recovery helpers that let GUI-launched Aya find CLIs
+// installed in dirs only .zshrc/.bashrc add (e.g. ~/.local/bin). Everything is
+// deterministic: the pure parse/merge/argv logic is exercised directly, and
+// resolveLoginShellPath is tested through its injectable platform/execFile
+// seam so we assert the win32, error, and success paths without spawning a
+// real shell.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  shellPathProbeArgv,
+  parseResolvedPath,
+  mergePath,
+  resolveLoginShellPath,
+} from "../dist-electron/shell-path.js";
+
+test("shellPathProbeArgv builds a login+interactive shell that prints PATH", () => {
+  const argv = shellPathProbeArgv("/bin/zsh");
+  assert.equal(argv[0], "/bin/zsh");
+  // -i is what sources .zshrc/.bashrc; -l keeps the login profile too.
+  assert.ok(argv.includes("-l"), `missing -l: ${argv.join(" ")}`);
+  assert.ok(argv.includes("-i"), `missing -i: ${argv.join(" ")}`);
+  assert.equal(argv[argv.length - 2], "-c");
+  // $PATH must be expanded by the shell, so it stays double-quoted (not single).
+  assert.match(argv[argv.length - 1], /"\$PATH"/);
+});
+
+test("parseResolvedPath extracts the value between the sentinels", () => {
+  const out = `__AYA_PATH_BEGIN__/usr/bin:/bin:/Users/me/.local/bin__AYA_PATH_END__`;
+  assert.equal(parseResolvedPath(out), "/usr/bin:/bin:/Users/me/.local/bin");
+});
+
+test("parseResolvedPath ignores rc-file noise printed around the markers", () => {
+  const out = [
+    "Last login: somewhere",
+    "\x1b[32mwelcome banner\x1b[0m",
+    `__AYA_PATH_BEGIN__/opt/homebrew/bin:/usr/bin__AYA_PATH_END__`,
+    "trailing instant-prompt junk",
+  ].join("\n");
+  assert.equal(parseResolvedPath(out), "/opt/homebrew/bin:/usr/bin");
+});
+
+test("parseResolvedPath takes the first BEGIN and the first END after it", () => {
+  // An rc file that itself echoes a sentinel must not change which value wins.
+  const out =
+    "noise __AYA_PATH_END__ __AYA_PATH_BEGIN__/real/path__AYA_PATH_END__ __AYA_PATH_BEGIN__/second";
+  assert.equal(parseResolvedPath(out), "/real/path");
+});
+
+test("parseResolvedPath rejects fish's space-joined $PATH instead of corrupting PATH", () => {
+  // fish expands "$PATH" as a space-joined list, not a colon scalar. Such a
+  // value has spaces but no ':' — merging it would glue the list into one
+  // bogus entry, so we drop it and leave PATH unchanged.
+  const fish = `__AYA_PATH_BEGIN__/usr/bin /bin /Users/me/.local/bin__AYA_PATH_END__`;
+  assert.equal(parseResolvedPath(fish), null);
+});
+
+test("parseResolvedPath returns null when markers are absent or empty", () => {
+  assert.equal(parseResolvedPath("no markers here"), null);
+  assert.equal(parseResolvedPath("__AYA_PATH_BEGIN__only-start"), null);
+  assert.equal(parseResolvedPath("__AYA_PATH_BEGIN____AYA_PATH_END__"), null);
+});
+
+test("mergePath prepends resolved entries, keeps current extras, dedupes", () => {
+  const resolved = "/opt/homebrew/bin:/usr/bin:/Users/me/.local/bin";
+  const current = "/usr/bin:/sbin"; // /usr/bin already present, /sbin is new
+  assert.equal(
+    mergePath(resolved, current),
+    "/opt/homebrew/bin:/usr/bin:/Users/me/.local/bin:/sbin",
+  );
+});
+
+test("mergePath tolerates an undefined current PATH and empty segments", () => {
+  assert.equal(mergePath("/a::/b:/a", undefined), "/a:/b");
+});
+
+test("mergePath returns an unchanged value when current already equals resolved", () => {
+  // This is the equality repairProcessPath relies on to no-op (no PATH change).
+  assert.equal(mergePath("/usr/bin:/bin", "/usr/bin:/bin"), "/usr/bin:/bin");
+});
+
+test("resolveLoginShellPath short-circuits to null on Windows without spawning", async () => {
+  let spawned = false;
+  const run = () => {
+    spawned = true;
+  };
+  assert.equal(await resolveLoginShellPath("win32", run), null);
+  assert.equal(spawned, false);
+});
+
+test("resolveLoginShellPath resolves null when the shell errors", async () => {
+  const run = (_file, _args, _opts, cb) => cb(new Error("boom"), "");
+  assert.equal(await resolveLoginShellPath("darwin", run), null);
+});
+
+test("resolveLoginShellPath parses the PATH the shell prints", async () => {
+  const run = (_file, _args, _opts, cb) =>
+    cb(null, `__AYA_PATH_BEGIN__/opt/homebrew/bin:/usr/bin__AYA_PATH_END__`);
+  assert.equal(
+    await resolveLoginShellPath("darwin", run),
+    "/opt/homebrew/bin:/usr/bin",
+  );
+});

--- a/tests/shell-path.test.mjs
+++ b/tests/shell-path.test.mjs
@@ -12,6 +12,7 @@ import {
   parseResolvedPath,
   mergePath,
   resolveLoginShellPath,
+  repairProcessPath,
 } from "../dist-electron/shell-path.js";
 
 test("shellPathProbeArgv builds a login+interactive shell that prints PATH", () => {
@@ -100,4 +101,33 @@ test("resolveLoginShellPath parses the PATH the shell prints", async () => {
     await resolveLoginShellPath("darwin", run),
     "/opt/homebrew/bin:/usr/bin",
   );
+});
+
+test("repairProcessPath prepends the resolved PATH into process.env.PATH", async () => {
+  const original = process.env.PATH;
+  try {
+    process.env.PATH = "/usr/bin:/sbin";
+    const changed = await repairProcessPath(() =>
+      Promise.resolve("/opt/homebrew/bin:/usr/bin:/Users/me/.local/bin"),
+    );
+    assert.equal(changed, true);
+    assert.equal(
+      process.env.PATH,
+      "/opt/homebrew/bin:/usr/bin:/Users/me/.local/bin:/sbin",
+    );
+  } finally {
+    process.env.PATH = original;
+  }
+});
+
+test("repairProcessPath leaves PATH unchanged when the shell probe fails", async () => {
+  const original = process.env.PATH;
+  try {
+    process.env.PATH = "/usr/bin:/bin";
+    const changed = await repairProcessPath(() => Promise.resolve(null));
+    assert.equal(changed, false);
+    assert.equal(process.env.PATH, "/usr/bin:/bin");
+  } finally {
+    process.env.PATH = original;
+  }
 });


### PR DESCRIPTION
## Why (origin)

On first launch I hit a real wall: my `claude` CLI was on PATH only because of an `export` line in my `.zshrc`. Launched from the Dock, Aya couldn't start Claude as a preset at all — the only thing that worked was a plain Shell. Everything was fine from a normal terminal, which made it confusing.

The cause turned out to be that GUI launches don't read `.zshrc`, so that PATH entry was invisible to Aya (details below).

> **Status:** I've since fixed my own setup locally (moved the PATH export to `.zprofile`) and Claude works. Leaving this open while I sleep on whether it's a real Aya bug worth fixing for everyone, or just my own setup mistake.

---

## What

GUI-launched Aya (Finder/Dock) shows `command not found: claude` for CLIs installed in dirs like `~/.local/bin` (where the official `claude` installer puts its binary) — even though they run fine in a terminal.

Root cause: Aya spawns presets through `$SHELL -l -c` — a login but **non-interactive** shell, which does **not** source `.zshrc`/`.bashrc`. That's exactly where most users add `~/.local/bin`, mise, asdf and npm-global to PATH. A Finder/Dock launch only inherits launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin` + `/etc/paths`), so those dirs never appear and the preflight in `pty.ts` returns exit 127. `npm run dev` hides it because the dev process inherits the developer's already-populated interactive PATH. (The old `pty.ts` header claimed `-l` reads `.zshrc` — it doesn't; corrected here.)

## Mechanism

- **`electron/shell-path.ts`** (new): once at startup, run a login + **interactive** shell (`$SHELL -l -i -c`) and read its PATH, bracketed by sentinels so rc-file noise (banners, instant-prompt escapes) is sliced off. `mergePath` puts the resolved entries first and appends whatever the GUI env already had, de-duplicated — nothing (cryptex paths, etc.) is dropped.
- **One repair fixes everything downstream**: `repairProcessPath()` mutates `process.env.PATH` in the main process *before* `createWindow`. The PTY host inherits this env when it is spawned (`pty-host-client.ts`), and the harness auto-scan runs in main — so preset launches, the command-not-found preflight, the first-launch harness scan, and the `aya` CLI installer's writable-dir search are all repaired at once.
- **Can't stall startup**: the probe shell is `SIGKILL`ed on timeout and a guard timer settles the promise regardless, so a slow/hanging rc delays first paint by at most the probe timeout; a failed probe is a silent no-op (PATH unchanged).
- **fish**: fish expands `"$PATH"` as a space-joined list, not a colon scalar; `parseResolvedPath` rejects that shape rather than corrupting PATH. (Positive fish support would need `string join`; out of scope.)

## Style / scope

- `userShell()` was about to become a third verbatim copy (it lived in `pty.ts` and `harnesses.ts`) — extracted to `electron/shell.ts` as one source of truth (in the spirit of #47).
- The probe timeout and sentinels are module-private, matching how every other `*_TIMEOUT_MS` in the tree is scoped.

## Known limitation

A PTY host that survived from a prior session whose probe failed/timed out (so it carries the degraded PATH) and is the **same build** is reconnected, not re-spawned, so it keeps that PATH; the staleness check (#28) only reaps on a version/hash change. The wired "Restart PTY host" control recovers it. The preconditions are narrow and self-inflicted, so this is noted rather than fixed.

## Tests

`tests/shell-path.test.mjs` — pure coverage of the argv builder, sentinel parsing (rc-noise, first-BEGIN/first-END, fish rejection, absent/empty), and `mergePath` (prepend/dedup/keep-extras, the `merged === current` no-op); plus `resolveLoginShellPath`'s win32 / error / success paths through an injected `execFile` seam, so there's **no real-shell spawn** in the suite and it stays deterministic. Unit **304/304**, typecheck clean.

Verified live: under a simulated Finder launch (minimal env + a `.zshrc`-only PATH dir), the resolver recovers the dir that `-l -c` misses and `repairProcessPath` mutates the env; a legit multi-entry PATH containing a space in a dir name is **not** rejected by the fish guard.
