### PR TITLE
fix: guard JSON.parse crash + fix finally-lie in restart IPC (#28/#52 follow-up)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -917,13 +917,12 @@ function registerIpc(win: BrowserWindow): void {
     ptyHost.search(requireString(query, "pty:search.query")),
   );
   ipcMain.handle("pty-host:restart", async () => {
-    try {
-      await ptyHost.restart();
-    } finally {
-      staleHostDetected = false;
-      const item = Menu.getApplicationMenu()?.getMenuItemById("restart-aya");
-      if (item) item.icon = nativeImage.createEmpty();
-    }
+    await ptyHost.restart();
+    // Clear only on success: if restart() throws, the stale state is still
+    // true and the amber icon must stay so the user can retry.
+    staleHostDetected = false;
+    const item = Menu.getApplicationMenu()?.getMenuItemById("restart-aya");
+    if (item) item.icon = nativeImage.createEmpty();
   });
 
   ipcMain.handle("projects:list", async () => listProjects());

--- a/electron/pty-host-client.ts
+++ b/electron/pty-host-client.ts
@@ -204,7 +204,15 @@ export class PtyHostClient {
       const line = this.buffer.slice(0, idx).trim();
       this.buffer = this.buffer.slice(idx + 1);
       if (!line) continue;
-      const message = JSON.parse(line) as PtyHostMessage;
+      let message: PtyHostMessage;
+      try {
+        message = JSON.parse(line) as PtyHostMessage;
+      } catch {
+        // Malformed line from a stale/crashing host - skip rather than
+        // letting the SyntaxError escape the event listener and become an
+        // uncaughtException that would crash the Electron main process.
+        continue;
+      }
       if ("type" in message && message.type === "event") {
         if (this.webContents && !this.webContents.isDestroyed()) {
           this.webContents.send("pty:event", message.event);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1232,7 +1232,14 @@ export function App() {
   // leave tabs stopped; the user restarts each with Shift+Enter). Used by both
   // the stale-host banner and the Settings action.
   const restartPtyHost = useCallback(async () => {
-    await window.aya.restartPtyHost();
+    try {
+      await window.aya.restartPtyHost();
+    } catch {
+      // Restart failed (host unreachable or already dead). The IPC handler
+      // only clears the stale flag on success, so the amber icon stays and
+      // the user can retry via "Restart Aya" from the menu.
+      return;
+    }
     setTerminals((prev) => {
       const next: typeof prev = {};
       for (const [id, t] of Object.entries(prev)) {


### PR DESCRIPTION
## Summary

Two critical bugs found by adversarial tribunal audit on the stale-PTY-host changeset (builds on #51).

### Bug 1 - JSON.parse crash in socket data listener (CRITICAL)

**File:** `electron/pty-host-client.ts:204`

`PtyHostClient.onData()` called `JSON.parse(line)` inside a `net.Socket 'data'` event listener with no surrounding `try/catch`. A `SyntaxError` from a malformed or truncated line (e.g. from a crashing stale host mid-handshake) escapes the listener, becomes an `uncaughtException`, and **crashes the Electron main process** - taking all open windows with it.

Fix: wrap in `try { } catch { continue; }`, skipping unparseable lines. Mirrors the identical guard already present on the server side in `pty-host.ts`.

### Bug 2 - `finally` block cleared stale indicator on failed restart (FIX-FIRST)

**Files:** `electron/main.ts:919`, `src/App.tsx:1232`

The `pty-host:restart` IPC handler cleared `staleHostDetected` and removed the amber icon in a `finally` block. A failed `ptyHost.restart()` would silently erase the warning even though the old host was never replaced - leaving the user with no indicator and no way to retry.

Fix:
- `main.ts`: move `staleHostDetected = false` and icon reset to the success path only (after `await`).
- `App.tsx`: add `try/catch` in `restartPtyHost` - on IPC rejection, bail out without calling `setTerminals`, so the amber icon stays visible for retry.

## Files changed

| File | Change |
|------|--------|
| `electron/pty-host-client.ts` | `try/catch` around `JSON.parse` in `onData()` |
| `electron/main.ts` | Move stale-flag clear + icon reset to success-only path |
| `src/App.tsx` | `try/catch` in `restartPtyHost` callback |

## Test plan

- [ ] Stale host sends malformed JSON - main process stays up
- [ ] Settings -> Restart PTY host fails (e.g. host already dead) - amber dot stays, terminals unchanged
- [ ] Settings -> Restart PTY host succeeds - amber dot clears, terminals marked stopped
- [ ] `npm test` passes (292/292)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
