### PR TITLE
feat: add "Rename terminal" to the sidebar context menu

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -323,6 +323,16 @@ export function Sidebar({
           <button
             className="aya-context-menu-item"
             onClick={() => {
+              const terminal = terminals.find((t) => t.id === menu.terminalId);
+              if (terminal) startRename(terminal);
+              setMenu(null);
+            }}
+          >
+            Rename terminal
+          </button>
+          <button
+            className="aya-context-menu-item"
+            onClick={() => {
               onRestart(menu.terminalId);
               setMenu(null);
             }}


### PR DESCRIPTION
## What

Adds a **Rename terminal** item to the sidebar's right-click context menu.

This is a purely UX change — no behavior or persistence logic changes.

## Why

Renaming already worked, but it wasn't discoverable. I went looking for how to rename a terminal and only found the double-click affordance while writing this feature — which is exactly the point: if someone editing the code can't find it, neither can a user.

## Mechanism

Renaming already worked — double-clicking a terminal's name in the sidebar opens an inline editor and the new name persists. The only discovery hint was a `title` tooltip, so the feature was effectively hidden. The right-click menu exposed Restart / Show in active pane / Split / Close, but no rename.

This PR surfaces the existing flow: the new menu item looks up the terminal by id and calls the existing `startRename()`, which opens the same inline editor. Commit goes through the unchanged `onRename` -> `persistProject` path. No new state, props, or persistence logic.

## Tests

- `npm run typecheck:renderer` — clean
- `npm run build` — clean (renderer + electron)
- No e2e assertions depend on the sidebar menu's item count; existing menu specs select by item text, so they're unaffected.