### PR TITLE
feat: create missing project directories from open modal

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -97,6 +97,7 @@ export const test = base.extend<{
     // Isolate Codex usage too: point CODEX_HOME at an empty dir so the Codex
     // chip never picks up the real machine's ~/.codex rollout logs.
     env.CODEX_HOME = join(seeded.root, "codex-home");
+    Object.assign(env, seeded.launchEnv);
 
     // Point Electron at the built main entry, NOT the app root: a bare
     // directory arg is interpreted by main.ts as "open this project", which

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +12,8 @@ export interface SeededEnv {
   userDataDir: string;
   /** Working directory of the seeded project (must exist for terminals). */
   projectDir: string;
+  /** Extra environment variables used when launching Electron for this seed. */
+  launchEnv?: Record<string, string>;
   tabIds: { left: string; right: string };
 }
 
@@ -27,6 +29,16 @@ export interface SeedOptions {
    *  token_count event carrying this rate_limits object, so the Codex chip
    *  renders. */
   codexRateLimits?: Record<string, unknown>;
+  /** When false, leave presets.json absent so first-launch PATH scanning runs. */
+  presets?: boolean;
+  /** Extra environment variables for the Electron process. */
+  launchEnv?: Record<string, string>;
+  /** Create a fake shell/bin setup where interactive shell PATH reveals claude. */
+  pathRepairHarness?: boolean;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 /** Build a throwaway, deterministic environment for one Electron launch:
@@ -43,14 +55,16 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
   mkdirSync(userDataDir, { recursive: true });
   mkdirSync(projectDir, { recursive: true });
 
-  writeFileSync(
-    join(ayaHome, "presets.json"),
-    JSON.stringify(
-      { presets: [{ id: "shell", name: "Shell", icon: "$", color: "", command: "$SHELL" }] },
-      null,
-      2,
-    ),
-  );
+  if (opts.presets !== false) {
+    writeFileSync(
+      join(ayaHome, "presets.json"),
+      JSON.stringify(
+        { presets: [{ id: "shell", name: "Shell", icon: "$", color: "", command: "$SHELL" }] },
+        null,
+        2,
+      ),
+    );
+  }
 
   const left = "tab-left";
   const right = "tab-right";
@@ -102,5 +116,51 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
     );
   }
 
-  return { root, ayaHome, userDataDir, projectDir, tabIds: { left, right } };
+  let launchEnv = opts.launchEnv;
+  if (opts.pathRepairHarness) {
+    const fakeBin = join(root, "interactive-bin");
+    const fakeShell = join(root, "fake-login-shell");
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(join(fakeBin, "claude"), "#!/bin/sh\nexit 0\n", {
+      mode: 0o755,
+    });
+    writeFileSync(
+      fakeShell,
+      [
+        "#!/bin/sh",
+        "interactive=0",
+        "cmd=",
+        'while [ "$#" -gt 0 ]; do',
+        '  case "$1" in',
+        "    -i) interactive=1; shift ;;",
+        "    -l) shift ;;",
+        '    -c) shift; cmd="$1"; break ;;',
+        "    *) shift ;;",
+        "  esac",
+        "done",
+        'if [ "$interactive" = "1" ]; then',
+        `  PATH=${shellQuote(fakeBin)}:$PATH`,
+        "  export PATH",
+        "fi",
+        'exec /bin/sh -c "$cmd"',
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    chmodSync(fakeShell, 0o755);
+    launchEnv = {
+      ...launchEnv,
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      SHELL: fakeShell,
+    };
+  }
+
+  return {
+    root,
+    ayaHome,
+    userDataDir,
+    projectDir,
+    launchEnv,
+    tabIds: { left, right },
+  };
 }

--- a/e2e/new-project.spec.ts
+++ b/e2e/new-project.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from "./fixtures";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // Creating a project via the top-bar "+" had no e2e coverage at all, even though
 // it is a core flow. These cover the happy path (a real directory becomes a new
-// active project tab named after its basename) and the validation guard (a
-// non-existent directory is rejected inline, not silently turned into a broken
-// project).
+// active project tab named after its basename) and the missing-directory path
+// where Aya offers to create the folder before opening it.
 
 test("the + button opens a real directory as a new active project", async ({
   window,
@@ -30,24 +29,48 @@ test("the + button opens a real directory as a new active project", async ({
   await expect(window.locator(".aya-modal-input")).toHaveCount(0);
 });
 
-test("a non-existent directory is rejected inline, no project is created", async ({
+test("a non-existent directory can be created and opened as a project", async ({
   window,
   seeded,
 }) => {
   const missing = join(seeded.root, "does-not-exist-xyz");
+  expect(existsSync(missing)).toBe(false);
 
   await window.locator(".aya-tab-new").click();
   const input = window.locator(".aya-modal-input");
+  const primary = window.locator(".aya-modal-btn--primary");
   await expect(input).toBeVisible();
   await input.fill(missing);
-  await window.locator(".aya-modal-btn--primary").click();
+  await expect(primary).toHaveText("Create folder");
+  await expect(window.getByText("Folder will be created.")).toBeVisible();
+  await primary.click();
 
-  // Inline error, modal stays open, no new project tab appears.
-  await expect(window.locator(".aya-modal-error")).toContainText(
-    /directory does not exist/i,
-  );
-  await expect(window.locator(".aya-modal-input")).toBeVisible();
+  await expect
+    .poll(() => existsSync(missing), { message: "created project directory" })
+    .toBe(true);
   await expect(
     window.locator(".aya-tab-name", { hasText: "does-not-exist-xyz" }),
-  ).toHaveCount(0);
+  ).toBeVisible();
+  await expect(window.locator(".aya-modal-input")).toHaveCount(0);
+});
+
+test("the primary action returns to Open when the directory changes to an existing one", async ({
+  window,
+  seeded,
+}) => {
+  const missing = join(seeded.root, "missing-then-existing");
+  const existing = join(seeded.root, "already-there");
+  mkdirSync(existing);
+
+  await window.locator(".aya-tab-new").click();
+  const input = window.locator(".aya-modal-input");
+  const primary = window.locator(".aya-modal-btn--primary");
+  await expect(input).toBeVisible();
+
+  await input.fill(missing);
+  await expect(primary).toHaveText("Create folder");
+
+  await input.fill(existing);
+  await expect(primary).toHaveText("Open");
+  await expect(window.getByText("Folder will be created.")).toHaveCount(0);
 });

--- a/e2e/path-repair.spec.ts
+++ b/e2e/path-repair.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "./fixtures";
+
+test.use({
+  seedOptions: {
+    presets: false,
+    pathRepairHarness: true,
+  },
+});
+
+test("GUI-style launch repairs PATH before first-launch harness scan", async ({
+  window,
+}) => {
+  await expect(window.locator(".aya-launcher-btn", { hasText: "Claude Code" }))
+    .toBeVisible();
+  await expect(window.locator(".aya-launcher-btn", { hasText: "Shell" }))
+    .toBeVisible();
+});

--- a/e2e/settings-path-suggestions.spec.ts
+++ b/e2e/settings-path-suggestions.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "./fixtures";
+import { fireShortcut } from "./helpers/shortcut";
+
+test.use({
+  seedOptions: {
+    pathRepairHarness: true,
+  },
+});
+
+test("Settings suggests harnesses found after GUI-launch PATH repair", async ({
+  window,
+  app,
+}) => {
+  await fireShortcut(app, "open-settings");
+  const settings = window.locator(".aya-modal--settings");
+  await expect(settings).toBeVisible();
+
+  await settings.getByTestId("settings-tab").filter({ hasText: "Presets" }).click();
+
+  await expect(
+    settings.locator(".aya-settings-section-title", {
+      hasText: "Suggested (found on your PATH)",
+    }),
+  ).toBeVisible();
+  await expect(
+    settings.locator(".aya-settings-suggested-btn", { hasText: "Add Claude Code" }),
+  ).toBeVisible();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2535,6 +2535,8 @@ export function App() {
           pathHint={newProjectModal.pathHint}
           onPickDirectory={window.aya.pickDirectory}
           onCompletePath={window.aya.completePath}
+          onDirectoryExists={window.aya.dirExists}
+          onCreateDirectory={window.aya.createDir}
           onSubmit={submitProjectFromModal}
           onCancel={() => {
             setNewProjectModal(null);

--- a/src/components/NewProjectModal.tsx
+++ b/src/components/NewProjectModal.tsx
@@ -8,9 +8,13 @@ interface Props {
   pathHint?: string;
   onPickDirectory?: () => Promise<string | null>;
   onCompletePath?: (pathPrefix: string) => Promise<string[]>;
+  onDirectoryExists?: (directory: string) => Promise<boolean>;
+  onCreateDirectory?: (directory: string) => Promise<void>;
   onSubmit: (directory: string) => Promise<void> | void;
   onCancel: () => void;
 }
+
+type DirectoryStatus = "unknown" | "checking" | "exists" | "missing";
 
 export function NewProjectModal({
   defaultDirectory = "~/",
@@ -20,13 +24,18 @@ export function NewProjectModal({
   pathHint,
   onPickDirectory,
   onCompletePath,
+  onDirectoryExists,
+  onCreateDirectory,
   onSubmit,
   onCancel,
 }: Props) {
   const [directory, setDirectory] = useState(defaultDirectory || "~/");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [directoryStatus, setDirectoryStatus] =
+    useState<DirectoryStatus>("unknown");
   const directoryRef = useRef<HTMLInputElement>(null);
+  const directoryCheckRef = useRef(0);
   const completionRef = useRef<{
     source: string;
     matches: string[];
@@ -51,8 +60,35 @@ export function NewProjectModal({
   const setDirectoryAndMaybeName = (next: string) => {
     setDirectory(next);
     setError(null);
+    setDirectoryStatus("unknown");
     completionRef.current = null;
   };
+
+  useEffect(() => {
+    if (lockDirectory || !onDirectoryExists) return;
+    const current = directory.trim();
+    const token = directoryCheckRef.current + 1;
+    directoryCheckRef.current = token;
+    if (!current) {
+      setDirectoryStatus("unknown");
+      return;
+    }
+    setDirectoryStatus("checking");
+    const timer = window.setTimeout(() => {
+      void onDirectoryExists(current)
+        .then((exists) => {
+          if (directoryCheckRef.current === token) {
+            setDirectoryStatus(exists ? "exists" : "missing");
+          }
+        })
+        .catch(() => {
+          if (directoryCheckRef.current === token) {
+            setDirectoryStatus("unknown");
+          }
+        });
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, [directory, lockDirectory, onDirectoryExists]);
 
   const pickDirectory = async () => {
     if (!onPickDirectory || submitting) return;
@@ -89,6 +125,15 @@ export function NewProjectModal({
     setSubmitting(true);
     setError(null);
     try {
+      let status = directoryStatus;
+      if (onDirectoryExists) {
+        const exists = await onDirectoryExists(d);
+        status = exists ? "exists" : "missing";
+        setDirectoryStatus(status);
+      }
+      if (status === "missing" && onCreateDirectory) {
+        await onCreateDirectory(d);
+      }
       await onSubmit(d);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -144,6 +189,11 @@ export function NewProjectModal({
         )}
 
         {error && <div className="aya-modal-error">{error}</div>}
+        {!error && directoryStatus === "missing" && onCreateDirectory && (
+          <div className="aya-modal-hint aya-modal-hint--path">
+            Folder will be created.
+          </div>
+        )}
 
         <div className="aya-modal-actions">
           <button
@@ -156,9 +206,20 @@ export function NewProjectModal({
           <button
             className="aya-modal-btn aya-modal-btn--primary"
             onClick={submit}
-            disabled={submitting || !directory.trim()}
+            disabled={
+              submitting ||
+              !directory.trim() ||
+              directoryStatus === "checking" ||
+              (directoryStatus === "missing" && !onCreateDirectory)
+            }
           >
-            {submitting ? "Opening..." : "Open"}
+            {submitting
+              ? directoryStatus === "missing"
+                ? "Creating..."
+                : "Opening..."
+              : directoryStatus === "missing" && onCreateDirectory
+                ? "Create folder"
+                : "Open"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## What

- Changes the Open project modal so a missing directory is treated as a createable state, not an error.
- Shows "Create folder" instead of "Open" when the typed directory does not exist.
- Switches back to "Open" when the path changes to an existing directory.
- Creates the folder with the existing createDir IPC path before continuing through the normal project-open flow.

## Tests

- npm run typecheck
- npm test — 364/364
- npx playwright test e2e/new-project.spec.ts e2e/path-repair.spec.ts e2e/settings-path-suggestions.spec.ts — 5/5
- git diff --check

Also ran full npx playwright test locally. The new tests passed there too; the full run still hit unrelated existing terminal-output/PTY flakes in older specs.