### PR TITLE
Show a stopped state when a re-mounted tab's PTY is gone (no silent respawn)

### DIFF
--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -387,6 +387,15 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     }
     return;
   }
+  if (req.attachOnly) {
+    // Re-mount of a tab that already ran this session, but its PTY is gone (the
+    // process died while the host stayed up). Don't silently start a fresh
+    // process - tell the renderer so it can show a stopped/restartable state.
+    if (!sink.isDestroyed()) {
+      sink.sendPtyEvent({ type: "no-session", ptyId: req.ptyId });
+    }
+    return;
+  }
   const cwd = path.resolve(req.cwd.replace(/^~/, os.homedir()));
 
   try {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -79,6 +79,10 @@ export interface SpawnRequest {
   cwd: string;
   cols: number;
   rows: number;
+  // Attach to an existing PTY only - if the host has no session for this id, do
+  // NOT spawn a fresh process; emit a `no-session` event instead. Set by the
+  // renderer when re-mounting a tab that already ran this session.
+  attachOnly?: boolean;
 }
 
 export interface ProjectGitInfo {
@@ -162,7 +166,10 @@ export type PtyEvent =
       ptyId: string;
       reason: SpawnFailureReason;
       detail: string;
-    };
+    }
+  // Host had no live session for an attach-only spawn (process died while the
+  // host stayed up). The tab becomes stopped/restartable, not respawned.
+  | { type: "no-session"; ptyId: string };
 
 export interface WaitingNotificationRequest {
   projectSlug: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1196,7 +1196,7 @@ export function App() {
         });
         return;
       }
-      if (detectApproval(event.chunk)) {
+      if (event.type === "data" && detectApproval(event.chunk)) {
         appendProjectEvent({
           projectSlug: terminal.projectSlug,
           terminalId: terminal.id,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { detectApproval } from "./bell";
 import { findStatusTarget } from "./control-status-target";
 import { clearedTerminalStatus } from "./pty-event-reducer";
+import { forgetSpawn } from "./spawnSession";
 import {
   applyExternalProjectEdits,
   mergeProjectsFromDisk,
@@ -1917,6 +1918,9 @@ export function App() {
     (id: string) => {
       const t = terminalsRef.current[id];
       if (!t) return;
+    // Drop the confirmed-session marker so the id doesn't linger (and can't be
+    // mistaken for a re-mount if the id were ever reused).
+    forgetSpawn(id);
     void window.aya.ptyKill(id);
     appendProjectEvent({
       projectSlug: t.projectSlug,
@@ -2653,6 +2657,11 @@ export function App() {
   const forceRestartTerminal = useCallback(async (id: string) => {
     const t = terminalsRef.current[id];
     if (!t) return;
+    // Explicit restart: forget the confirmed-session marker so that if the tab
+    // is currently UNMOUNTED, its next mount spawns fresh instead of attaching-
+    // only (which would no-session the PTY we just killed and leave the
+    // requested restart stuck as stopped).
+    forgetSpawn(id);
     // Await the kill so the main-side ptys map is empty by the time the
     // new spawn IPC arrives — otherwise spawnPty treats it as a re-mount
     // and replays the old buffer instead of starting fresh.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2657,11 +2657,6 @@ export function App() {
   const forceRestartTerminal = useCallback(async (id: string) => {
     const t = terminalsRef.current[id];
     if (!t) return;
-    // Explicit restart: forget the confirmed-session marker so that if the tab
-    // is currently UNMOUNTED, its next mount spawns fresh instead of attaching-
-    // only (which would no-session the PTY we just killed and leave the
-    // requested restart stuck as stopped).
-    forgetSpawn(id);
     // Await the kill so the main-side ptys map is empty by the time the
     // new spawn IPC arrives — otherwise spawnPty treats it as a re-mount
     // and replays the old buffer instead of starting fresh.
@@ -2670,6 +2665,12 @@ export function App() {
     } catch {
       /* ignore — best effort */
     }
+    // Forget the confirmed-session marker AFTER the kill: a still-alive process
+    // can emit output between the request and the kill landing, which would
+    // re-mark the id; clearing it last (once the PTY is dead, no more output)
+    // ensures an UNMOUNTED tab's next mount spawns fresh instead of attaching-
+    // only to a killed PTY (which would no-session it and stick it as stopped).
+    forgetSpawn(id);
     setTerminals((prev) => {
       const cur = prev[id];
       if (!cur) return prev;

--- a/src/components/AttentionCenter.tsx
+++ b/src/components/AttentionCenter.tsx
@@ -81,7 +81,7 @@ function attentionFor(
       title: `${terminal.name} is idle`,
       detail:
         terminal.stopped
-          ? "Stopped by PTY host restart"
+          ? "Stopped - press Shift+Enter to restart"
           : terminal.exitCode !== null
             ? `Exited with code ${terminal.exitCode}`
             : "No active process",

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -29,6 +29,7 @@ import {
   stripScrollbackErase,
 } from "../terminal-rendering";
 import { snippetPtyPayload } from "../snippet-payload";
+import { wasSpawned } from "../spawnSession";
 import { SnippetBar } from "./SnippetBar";
 
 // Terminal sizing + timing constants. The fallback cols/rows are the standard
@@ -50,14 +51,6 @@ const FOCUS_RETRY_DELAY_MS = 60;
 // arrived (or there was nothing to replay).
 const RESTORE_FALLBACK_MS = 2_500;
 const INPUT_LOG_MAX_CHARS = 240;
-
-// Terminal ids that already had their initial mount-spawn THIS renderer session.
-// A LATER re-mount of one of these (tab re-activation, warm-pool churn) spawns
-// attach-only: if the host lost the PTY (process died while the host stayed up)
-// it surfaces a stopped/restartable state instead of silently starting a fresh
-// process. The set lives at module scope so it survives a TerminalView remount
-// but resets on a full renderer reload - so first-boot auto-start is unaffected.
-const spawnedThisSession = new Set<string>();
 const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`]+/i;
 const URL_TRAILING_PUNCTUATION_RE = /[),.;\]]+$/;
 const EXTERNAL_LINK_PROTOCOLS = new Set([
@@ -681,11 +674,12 @@ function TerminalViewComponent({
 
     if (!spawnedRef.current) {
       spawnedRef.current = true;
-      // First mount this session -> normal spawn (boot auto-start). A later
-      // re-mount of the same id -> attach-only, so a tab whose PTY died shows
-      // a stopped state rather than a silent fresh process.
-      const attachOnly = spawnedThisSession.has(terminal.id);
-      spawnedThisSession.add(terminal.id);
+      // First mount this session -> normal spawn (boot auto-start). A re-mount
+      // of an id that already produced a confirmed session -> attach-only, so a
+      // tab whose PTY died shows a stopped state rather than a silent fresh
+      // process. Keyed on confirmed output (not the request), so an in-flight
+      // first spawn that re-mounts is not mistaken for a dead session.
+      const attachOnly = wasSpawned(terminal.id);
       const { cols, rows } = term;
       void window.aya.ptySpawn({
         ptyId: terminal.id,

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -50,6 +50,14 @@ const FOCUS_RETRY_DELAY_MS = 60;
 // arrived (or there was nothing to replay).
 const RESTORE_FALLBACK_MS = 2_500;
 const INPUT_LOG_MAX_CHARS = 240;
+
+// Terminal ids that already had their initial mount-spawn THIS renderer session.
+// A LATER re-mount of one of these (tab re-activation, warm-pool churn) spawns
+// attach-only: if the host lost the PTY (process died while the host stayed up)
+// it surfaces a stopped/restartable state instead of silently starting a fresh
+// process. The set lives at module scope so it survives a TerminalView remount
+// but resets on a full renderer reload - so first-boot auto-start is unaffected.
+const spawnedThisSession = new Set<string>();
 const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`]+/i;
 const URL_TRAILING_PUNCTUATION_RE = /[),.;\]]+$/;
 const EXTERNAL_LINK_PROTOCOLS = new Set([
@@ -518,6 +526,12 @@ function TerminalViewComponent({
         term.write(
           `\r\n\x1b[2m[process exited with code ${event.exitCode}${restartHint}]\x1b[0m\r\n`,
         );
+      } else if (event.type === "no-session") {
+        // Attach-only re-mount with no live PTY: the process ended while we were
+        // away. Show a restartable hint instead of a fresh, contextless session.
+        term.write(
+          `\r\n\x1b[2m[session ended - press Shift+Enter to restart]\x1b[0m\r\n`,
+        );
       }
     });
 
@@ -667,6 +681,11 @@ function TerminalViewComponent({
 
     if (!spawnedRef.current) {
       spawnedRef.current = true;
+      // First mount this session -> normal spawn (boot auto-start). A later
+      // re-mount of the same id -> attach-only, so a tab whose PTY died shows
+      // a stopped state rather than a silent fresh process.
+      const attachOnly = spawnedThisSession.has(terminal.id);
+      spawnedThisSession.add(terminal.id);
       const { cols, rows } = term;
       void window.aya.ptySpawn({
         ptyId: terminal.id,
@@ -676,6 +695,7 @@ function TerminalViewComponent({
         cwd,
         cols: Math.max(cols, TERMINAL_FALLBACK_COLS),
         rows: Math.max(rows, TERMINAL_FALLBACK_ROWS),
+        attachOnly,
       });
     }
 

--- a/src/hooks/usePtyEventRouter.ts
+++ b/src/hooks/usePtyEventRouter.ts
@@ -17,13 +17,22 @@ export function usePtyEventRouter({
   useEffect(() => {
     return window.aya.onPtyEvent((event) => {
       onPtyEvent?.(event);
-      // A data event confirms this id has a live PTY session - so a later
-      // re-mount can attach-only and surface "stopped" if the process is gone.
-      if (event.type === "data") markSpawned(event.ptyId);
       if (eventTouchesActivity(event)) {
         lastActivityRef.current[event.ptyId] = Date.now();
       }
-      setTerminals((prev) => applyPtyEvent(prev, event));
+      setTerminals((prev) => {
+        // Mark a CONFIRMED live session only on genuine live output, so a later
+        // re-mount attaches (and surfaces "stopped" if the process is gone).
+        // Skip when the terminal: is spawn-failed (the synthetic failure banner
+        // is also a data event but no PTY exists), has already exited (a
+        // straggler chunk after a kill must not re-mark), or is gone (closed).
+        // Set.add is idempotent, so running inside the updater is safe.
+        const t = prev[event.ptyId];
+        if (event.type === "data" && t && !t.spawnFailure && t.exitCode === null) {
+          markSpawned(event.ptyId);
+        }
+        return applyPtyEvent(prev, event);
+      });
     });
   }, [lastActivityRef, onPtyEvent, setTerminals]);
 }

--- a/src/hooks/usePtyEventRouter.ts
+++ b/src/hooks/usePtyEventRouter.ts
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { applyPtyEvent, eventTouchesActivity } from "../pty-event-reducer";
+import { markSpawned } from "../spawnSession";
 import type { PtyEvent, TerminalState } from "../types";
 
 interface Options {
@@ -16,6 +17,9 @@ export function usePtyEventRouter({
   useEffect(() => {
     return window.aya.onPtyEvent((event) => {
       onPtyEvent?.(event);
+      // A data event confirms this id has a live PTY session - so a later
+      // re-mount can attach-only and surface "stopped" if the process is gone.
+      if (event.type === "data") markSpawned(event.ptyId);
       if (eventTouchesActivity(event)) {
         lastActivityRef.current[event.ptyId] = Date.now();
       }

--- a/src/pty-event-reducer.ts
+++ b/src/pty-event-reducer.ts
@@ -65,6 +65,19 @@ export function applyPtyEvent(
     };
   }
 
+  if (event.type === "no-session") {
+    // Attach-only re-mount found no live PTY: mark the tab stopped/restartable
+    // (like a host-restart) instead of letting it look running. exitCode stays
+    // null so it never reads as a clean "done" finish.
+    const t = prev[event.ptyId];
+    if (!t) return prev;
+    const next = { ...t, bell: false, stopped: true };
+    return {
+      ...prev,
+      [event.ptyId]: { ...next, status: deriveLifecycleStatus(next) },
+    };
+  }
+
   // event.type === "data"
   const t = prev[event.ptyId];
   if (!t) return prev;

--- a/src/spawnSession.ts
+++ b/src/spawnSession.ts
@@ -1,0 +1,31 @@
+// Tracks terminal ids that have produced a CONFIRMED live PTY session in this
+// renderer session. Drives attach-only re-mounts: a tab that already ran and
+// whose process is now gone surfaces a stopped state instead of silently
+// spawning a fresh (contextless) process.
+//
+// Keyed on confirmed output (a `data` event), NOT on the spawn request - so an
+// in-flight first spawn that re-mounts before any output is treated as a first
+// spawn (no false "no-session"), and an explicit restart of a not-yet-confirmed
+// tab still spawns. Module-scoped: survives TerminalView remounts, resets on a
+// full renderer reload so first-boot auto-start is normal.
+
+const spawned = new Set<string>();
+
+/** Mark a terminal as having a confirmed live session (called on PTY output). */
+export function markSpawned(id: string): void {
+  spawned.add(id);
+}
+
+/** True if this terminal already produced a session this renderer session, so a
+ *  re-mount should attach-only rather than spawn fresh. */
+export function wasSpawned(id: string): boolean {
+  return spawned.has(id);
+}
+
+/** Forget a terminal so its next mount spawns normally instead of attaching.
+ *  Called on an explicit (re)start whose target tab may be unmounted - the host
+ *  just killed the PTY, so an attach-only mount would wrongly report no-session
+ *  and leave the user's requested restart stuck as stopped. */
+export function forgetSpawn(id: string): void {
+  spawned.delete(id);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,11 @@ export interface SpawnRequest {
   cwd: string;
   cols: number;
   rows: number;
+  /** Attach to an existing PTY only - do NOT start a fresh process if the host
+   *  has no session for this id. Used when re-mounting a tab that already ran
+   *  this session: if its PTY died, surface a stopped/restartable state via a
+   *  `no-session` event instead of silently spawning a brand-new process. */
+  attachOnly?: boolean;
 }
 
 export type PtyEvent =
@@ -238,7 +243,10 @@ export type PtyEvent =
       ptyId: string;
       reason: SpawnFailureReason;
       detail: string;
-    };
+    }
+  // Host had no live session for an attach-only spawn: the process died while
+  // the host stayed up. The tab becomes stopped/restartable, not respawned.
+  | { type: "no-session"; ptyId: string };
 
 export interface WaitingNotificationRequest {
   projectSlug: string;

--- a/tests/pty-attach-only.test.mjs
+++ b/tests/pty-attach-only.test.mjs
@@ -1,0 +1,45 @@
+// Host side of the attach-only contract: when a re-mount asks to attach-only
+// and the host has no live PTY for that id, it must emit a `no-session` event
+// and NOT start a process. This covers the PRODUCER of no-session (the reducer
+// test covers the consumer); together they exercise both ends of the path that
+// a real PTY E2E can't reach in the sandbox. The attach-only branch returns
+// before any node-pty call, so this needs no real process.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnPty } from "../dist-electron/pty.js";
+
+function fakeSink() {
+  const events = [];
+  return {
+    events,
+    sendPtyEvent: (e) => events.push(e),
+    isDestroyed: () => false,
+  };
+}
+
+const baseReq = (over) => ({
+  ptyId: "attach-only-" + Math.random().toString(36).slice(2),
+  command: "echo hi",
+  cwd: "/tmp",
+  cols: 80,
+  rows: 24,
+  ...over,
+});
+
+test("attachOnly with no live session emits no-session and does not spawn", async () => {
+  const sink = fakeSink();
+  const req = baseReq({ attachOnly: true });
+  await spawnPty(req, sink);
+  assert.deepEqual(sink.events, [{ type: "no-session", ptyId: req.ptyId }]);
+});
+
+test("attachOnly returns before command/cwd validation (no spawn-failed)", async () => {
+  // A bad command/cwd would normally produce spawn-failed; attach-only must
+  // short-circuit first, so the only event is no-session.
+  const sink = fakeSink();
+  const req = baseReq({ attachOnly: true, command: "", cwd: "/no/such/dir/xyz" });
+  await spawnPty(req, sink);
+  assert.equal(sink.events.length, 1);
+  assert.equal(sink.events[0].type, "no-session");
+});

--- a/tests/pty-event-reducer.test.mjs
+++ b/tests/pty-event-reducer.test.mjs
@@ -306,3 +306,26 @@ test("clearedTerminalStatus: clears the bell left by a waiting overlay", () => {
   assert.equal(next.bell, false);
   assert.equal(next.status, "idle");
 });
+
+// --- no-session ----------------------------------------------------------
+
+test("no-session marks the terminal stopped + restartable, not running", () => {
+  const prev = { t1: termState("t1", { status: "running", bell: true }) };
+  const next = applyPtyEvent(prev, { type: "no-session", ptyId: "t1" });
+  assert.equal(next.t1.stopped, true);
+  assert.equal(next.t1.bell, false);
+  // exitCode stays null so it never reads as a clean "done" finish, and the
+  // derived lifecycle status is idle (restartable), not running or error.
+  assert.equal(next.t1.exitCode, null);
+  assert.equal(next.t1.status, "idle");
+});
+
+test("no-session for an unknown ptyId is a no-op (same map reference)", () => {
+  const prev = { t1: termState("t1") };
+  const next = applyPtyEvent(prev, { type: "no-session", ptyId: "ghost" });
+  assert.equal(next, prev);
+});
+
+test("no-session is not counted as activity", () => {
+  assert.equal(eventTouchesActivity({ type: "no-session", ptyId: "t1" }), false);
+});

--- a/tests/spawn-session.test.mjs
+++ b/tests/spawn-session.test.mjs
@@ -1,0 +1,30 @@
+// Confirmed-session registry behind attach-only re-mounts. Keying on confirmed
+// output (not the spawn request) is what avoids two bugs: a false "no-session"
+// when an in-flight first spawn re-mounts, and a stuck-stopped tab when an
+// explicit restart targets an unmounted terminal.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { markSpawned, wasSpawned, forgetSpawn } from "../dist-test/spawnSession.js";
+
+test("an unseen id was not spawned (first mount spawns normally)", () => {
+  assert.equal(wasSpawned("ss-new"), false);
+});
+
+test("markSpawned records a confirmed session (re-mount attaches)", () => {
+  assert.equal(wasSpawned("ss-a"), false);
+  markSpawned("ss-a");
+  assert.equal(wasSpawned("ss-a"), true);
+});
+
+test("forgetSpawn clears the marker so the next mount spawns fresh", () => {
+  markSpawned("ss-b");
+  assert.equal(wasSpawned("ss-b"), true);
+  forgetSpawn("ss-b");
+  assert.equal(wasSpawned("ss-b"), false);
+});
+
+test("forgetSpawn on an unknown id is a harmless no-op", () => {
+  forgetSpawn("ss-never");
+  assert.equal(wasSpawned("ss-never"), false);
+});

--- a/tsconfig.test-src.json
+++ b/tsconfig.test-src.json
@@ -25,6 +25,7 @@
     "src/terminal-keys.ts",
     "src/terminal-rendering.ts",
     "src/snippet-payload.ts",
+    "src/spawnSession.ts",
     "src/types.ts"
   ]
 }


### PR DESCRIPTION
## Show a stopped state when a re-mounted tab's PTY is gone

Complements #66 (agent session resume). Together: a tab whose PTY died either
resumes cleanly on an explicit restart (#66) or waits as **stopped** - never a
silent fresh (contextless) agent session.

### The bug

When a terminal tab re-mounts (tab re-activation, warm-pool churn) after its PTY
process died while the host stayed alive, the mount-time spawn silently started a
**brand-new process**. For a Claude/Codex tab that meant a fresh, empty session -
the same data-loss symptom diagnosed from on-disk session files.

### The fix

A tab that already produced a **confirmed** session re-mounts **attach-only**: if
the host has no live PTY it emits a `no-session` event and the tab becomes
stopped/restartable (Shift+Enter), instead of respawning.

- `SpawnRequest.attachOnly` + `PtyEvent` `no-session` (renderer + electron types).
- Host `spawnPty`: has the PTY → replay; else `attachOnly` → emit `no-session`,
  don't spawn; else spawn fresh.
- Reducer: `no-session` → `stopped` (idle, `exitCode` stays null).
- `src/spawnSession.ts`: a module Set keyed on **confirmed live output**
  (`markSpawned` on a genuine `data` event - skips the spawn-failure banner,
  post-exit stragglers, and closed tabs). `wasSpawned` gates the mount-spawn;
  `forgetSpawn` (after the kill) runs on explicit restart and on close.
- First-ever mount is never attach-only, so **boot auto-start is unaffected**.

### Review (2 rounds, Grok + Codex)

- Round 1 found + fixed: an in-flight first-spawn race (false `no-session`) and a
  stuck-stopped explicit restart of an unmounted tab.
- Round 2 found + fixed: `markSpawned` false-marking dead sessions
  (spawn-failure banner / post-exit / after-close), and a re-mark window between
  `forgetSpawn` and the kill.

### Tests

`tests/pty-attach-only.test.mjs` (host producer), the `no-session` block in
`tests/pty-event-reducer.test.mjs` (consumer), `tests/spawn-session.test.mjs`
(gate) - all mutation-verified. The from-root render path is CI/manual only
(real PTY exec is unavailable in the sandbox).

### Out of scope (pre-existing, not introduced here)

`spawnPty` checks `ptys.has` before its async preflight, so two concurrent spawn
requests for the same id can both spawn and orphan one. Predates this work (both
first-spawns are `attachOnly: false`). Surfaced by the Codex re-review; tracked as
a separate follow-up (host-side in-flight-spawn tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
