### PR TITLE
Guard against concurrent double-spawn of the same PTY id

### DIFF
--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -393,6 +393,15 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     }
     return;
   }
+  if (spawning.has(req.ptyId)) {
+    // A spawn for this id is already in flight (a concurrent re-mount got here
+    // first, before it could register its PTY). Bail BEFORE the attachOnly
+    // branch: the in-flight spawn owns the session and will stream to the
+    // renderer, so emitting no-session here would falsely strand the tab as
+    // stopped. (Checked before attachOnly so the host is robust regardless of
+    // the renderer's confirmed-output gating.)
+    return;
+  }
   if (req.attachOnly) {
     // Re-mount of a tab that already ran this session, but its PTY is gone (the
     // process died while the host stayed up). Don't silently start a fresh
@@ -460,10 +469,10 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
   }
 
   const binary = preflightBinary(req.command);
-  // A spawn for this id is already in flight (a concurrent re-mount got here
-  // first). Bail so we don't start a second process and orphan the first; the
-  // in-flight spawn owns the session and streams to the renderer.
-  if (spawning.has(req.ptyId)) return;
+  // Mark this id in-flight across the async preflight + spawn so a concurrent
+  // call bails at the guard above. (The bail itself lives before the attachOnly
+  // branch; here we only claim the marker, synchronously before the first await
+  // so no racing call can interleave before it is set.)
   spawning.add(req.ptyId);
   try {
     if (binary && !(await commandExists(binary))) {

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -60,6 +60,12 @@ const pendingKills = new Set<string>();
 // Auto-evict pending-kill markers so stale ids don't linger forever (defense
 // in depth — usually the spawn either runs within milliseconds or never).
 const PENDING_KILL_TTL_MS = 5_000;
+// In-flight spawn guard: spawnPty awaits an async command-exists preflight
+// between the `ptys.has` check and registering the PTY. Two concurrent spawns
+// for the same id (e.g. a fast unmount+remount) could both pass that check and
+// both spawn, orphaning the first. We mark an id as spawning across the await
+// so a racing call bails instead of starting a second process.
+const spawning = new Set<string>();
 
 export interface PtyEventSink {
   isDestroyed(): boolean;
@@ -454,56 +460,65 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
   }
 
   const binary = preflightBinary(req.command);
-  if (binary && !(await commandExists(binary))) {
-    reportSpawnFailure(
-      sink,
-      req.ptyId,
-      "command-not-found",
-      `command not found: ${binary}\nEdit the preset, install the CLI, or re-scan installed CLIs.`,
-    );
-    return;
-  }
-
-  const argv = shellArgv(req.command, cwd);
-  const file = argv[0];
-  const args = argv.slice(1);
-
-  let child: PtyModule.IPty;
+  // A spawn for this id is already in flight (a concurrent re-mount got here
+  // first). Bail so we don't start a second process and orphan the first; the
+  // in-flight spawn owns the session and streams to the renderer.
+  if (spawning.has(req.ptyId)) return;
+  spawning.add(req.ptyId);
   try {
-    child = loadNodePty().spawn(file, args, {
-      name: "xterm-256color",
-      cols: Math.max(req.cols, MIN_PTY_COLS),
-      rows: Math.max(req.rows, MIN_PTY_ROWS),
-      cwd,
-      env: safeEnv(req, cwd),
-    });
-  } catch (err) {
-    reportSpawnFailure(
-      sink,
-      req.ptyId,
-      "node-pty-spawn-error",
-      `failed to spawn: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return;
-  }
-
-  ptys.set(req.ptyId, child);
-
-  child.onData((chunk) => {
-    appendToOutputBuffer(req.ptyId, chunk);
-    if (sink.isDestroyed()) return;
-    sink.sendPtyEvent({ type: "data", ptyId: req.ptyId, chunk });
-  });
-
-  child.onExit(({ exitCode }) => {
-    if (ptys.get(req.ptyId) !== child) {
+    if (binary && !(await commandExists(binary))) {
+      reportSpawnFailure(
+        sink,
+        req.ptyId,
+        "command-not-found",
+        `command not found: ${binary}\nEdit the preset, install the CLI, or re-scan installed CLIs.`,
+      );
       return;
     }
-    ptys.delete(req.ptyId);
-    outputBuffers.delete(req.ptyId);
-    if (sink.isDestroyed()) return;
-    sink.sendPtyEvent({ type: "exit", ptyId: req.ptyId, exitCode });
-  });
+
+    const argv = shellArgv(req.command, cwd);
+    const file = argv[0];
+    const args = argv.slice(1);
+
+    let child: PtyModule.IPty;
+    try {
+      child = loadNodePty().spawn(file, args, {
+        name: "xterm-256color",
+        cols: Math.max(req.cols, MIN_PTY_COLS),
+        rows: Math.max(req.rows, MIN_PTY_ROWS),
+        cwd,
+        env: safeEnv(req, cwd),
+      });
+    } catch (err) {
+      reportSpawnFailure(
+        sink,
+        req.ptyId,
+        "node-pty-spawn-error",
+        `failed to spawn: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+
+    ptys.set(req.ptyId, child);
+
+    child.onData((chunk) => {
+      appendToOutputBuffer(req.ptyId, chunk);
+      if (sink.isDestroyed()) return;
+      sink.sendPtyEvent({ type: "data", ptyId: req.ptyId, chunk });
+    });
+
+    child.onExit(({ exitCode }) => {
+      if (ptys.get(req.ptyId) !== child) {
+        return;
+      }
+      ptys.delete(req.ptyId);
+      outputBuffers.delete(req.ptyId);
+      if (sink.isDestroyed()) return;
+      sink.sendPtyEvent({ type: "exit", ptyId: req.ptyId, exitCode });
+    });
+  } finally {
+    spawning.delete(req.ptyId);
+  }
 }
 
 export function writePty(ptyId: string, data: string): void {

--- a/tests/pty-double-spawn.test.mjs
+++ b/tests/pty-double-spawn.test.mjs
@@ -1,0 +1,58 @@
+// Concurrent-spawn guard. Two spawnPty calls for the same id (a fast
+// unmount+remount) used to both pass the `ptys.has` check and both spawn,
+// orphaning the first. The in-flight guard makes the racing call bail. We use a
+// command-not-found path so the test never reaches real node-pty: spawnPty runs
+// synchronously up to the async command-exists preflight, where the first call
+// marks the id in-flight before yielding; the second call (run by Promise.all
+// right after) sees the marker and short-circuits.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnPty } from "../dist-electron/pty.js";
+
+function fakeSink() {
+  const events = [];
+  return { events, sendPtyEvent: (e) => events.push(e), isDestroyed: () => false };
+}
+
+test("a concurrent spawn for the same id is suppressed (no second process)", async () => {
+  const sink1 = fakeSink();
+  const sink2 = fakeSink();
+  // Valid binary-name shape so preflightBinary returns it, but it does not
+  // exist -> command-not-found, never reaching node-pty.
+  const req = {
+    ptyId: "double-spawn-" + Math.random().toString(36).slice(2),
+    command: "aya-no-such-binary-zzz",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+  };
+
+  await Promise.all([spawnPty(req, sink1), spawnPty(req, sink2)]);
+
+  // First call owns the spawn attempt and reports the failure...
+  assert.ok(
+    sink1.events.some((e) => e.type === "spawn-failed" && e.reason === "command-not-found"),
+    "first call should reach the command-not-found preflight",
+  );
+  // ...the racing second call bails at the in-flight guard: no events at all.
+  assert.deepEqual(sink2.events, [], "concurrent duplicate spawn must be suppressed");
+});
+
+test("a sequential re-spawn after the first finished is NOT suppressed", async () => {
+  // Once the in-flight marker is cleared (finally), a later spawn for the same
+  // id runs again (it is a real retry, not a concurrent duplicate).
+  const id = "double-spawn-seq-" + Math.random().toString(36).slice(2);
+  const req = { ptyId: id, command: "aya-no-such-binary-zzz", cwd: "/tmp", cols: 80, rows: 24 };
+
+  const s1 = fakeSink();
+  await spawnPty(req, s1);
+  const s2 = fakeSink();
+  await spawnPty(req, s2);
+
+  assert.ok(s1.events.some((e) => e.type === "spawn-failed"));
+  assert.ok(
+    s2.events.some((e) => e.type === "spawn-failed"),
+    "a sequential retry should run (marker cleared by finally), not be suppressed",
+  );
+});


### PR DESCRIPTION
Pre-existing concurrency bug surfaced by the Codex re-review of #67: `spawnPty` checks `ptys.has` then awaits an async command-exists preflight before registering the PTY, so two concurrent spawns for the same id (fast unmount+remount) could both spawn and orphan one.

Fix: mark the id in-flight across the preflight+spawn (module Set, cleared in `finally`); a racing second call bails. Sequential retries still spawn.

Test `tests/pty-double-spawn.test.mjs` (concurrent vs sequential), mutation-verified (disabling the guard turns it RED). Runs down the command-not-found path so it never needs real node-pty.

**Stacked on #67** (edits the same `spawnPty`); base will retarget to main after #67 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)