### PR TITLE
E2E coverage audit - Batch 6 (Snippets editor + Diagnostics)

### DIFF
--- a/e2e/diagnostics.spec.ts
+++ b/e2e/diagnostics.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "./fixtures";
+import { fireShortcut } from "./helpers/shortcut";
+import type { ElectronApplication, Page } from "@playwright/test";
+
+// Settings > Diagnostics. The support report is copy-pasted into bug reports, so
+// it must be complete and the at-a-glance grid must not drift from the JSON it
+// summarizes. Refresh must actually re-fetch and produce parseable JSON.
+
+async function openDiagnostics(app: ElectronApplication, window: Page) {
+  // Let the renderer finish its initial load before firing a main-process
+  // shortcut, else app.evaluate can race a startup navigation.
+  await window.waitForLoadState("load");
+  await fireShortcut(app, "open-settings");
+  const settings = window.locator(".aya-modal--settings");
+  await expect(settings).toBeVisible();
+  await settings.getByTestId("settings-tab").filter({ hasText: "Diagnostics" }).click();
+  return settings;
+}
+
+test("Refresh produces a complete diagnostics report and the grid matches it", async ({
+  window,
+  app,
+}) => {
+  const settings = await openDiagnostics(app, window);
+  await settings.locator(".aya-modal-btn", { hasText: "Refresh" }).click();
+
+  const pre = settings.locator(".aya-settings-diagnostics-json");
+  await expect(pre).not.toBeEmpty();
+
+  const json = JSON.parse((await pre.innerText()).trim());
+
+  // Completeness: the fields a support report relies on must all be present.
+  expect(json.app?.version, "app.version").toBeTruthy();
+  expect(["development", "production"], "app.mode").toContain(json.app?.mode);
+  expect(typeof json.ptyHost?.ptyCount, "ptyHost.ptyCount").toBe("number");
+  expect(typeof json.ptyHost?.stale, "ptyHost.stale").toBe("boolean");
+  expect(Array.isArray(json.presets), "presets[]").toBe(true);
+  expect(json.projects, "projects").toBeTruthy();
+  expect(typeof json.projects.remote, "projects.remote").toBe("number");
+
+  // The summary grid must reflect the same values (no display drift). Scope to
+  // each labeled cell's <strong> and assert EXACT text - a plain grid-wide
+  // substring match would false-pass (a wrong single-digit count still matches
+  // a digit in the version string).
+  const grid = settings.locator(".aya-settings-diagnostics-grid");
+  const cell = (label: string) =>
+    grid
+      .locator("div")
+      .filter({ has: window.getByText(label, { exact: true }) })
+      .locator("strong");
+  await expect(cell("Mode")).toHaveText(json.app.mode);
+  await expect(cell("Version")).toHaveText(json.app.version);
+  await expect(cell("PTYs")).toHaveText(String(json.ptyHost.ptyCount));
+  await expect(cell("PTY host")).toHaveText(json.ptyHost.stale ? "stale" : "current");
+  await expect(cell("Presets")).toHaveText(String(json.presets.length));
+  await expect(cell("Remote projects")).toHaveText(String(json.projects.remote));
+});
+
+test("Copy JSON writes the exact report to the clipboard", async ({ window, app }) => {
+  const settings = await openDiagnostics(app, window);
+  await settings.locator(".aya-modal-btn", { hasText: "Refresh" }).click();
+  const pre = settings.locator(".aya-settings-diagnostics-json");
+  await expect(pre).not.toBeEmpty();
+  const shown = (await pre.innerText()).trim();
+
+  await settings.locator(".aya-modal-btn", { hasText: "Copy JSON" }).click();
+  await expect(
+    settings.locator(".aya-modal-btn", { hasText: "Copied" }),
+  ).toBeVisible();
+
+  // Read the real OS clipboard via Electron: a no-op writeClipboard that still
+  // flips the label to "Copied" must NOT pass.
+  const clip = (await app.evaluate(({ clipboard }) => clipboard.readText())).trim();
+  expect(clip).toBe(shown);
+  expect(() => JSON.parse(clip)).not.toThrow();
+});

--- a/e2e/snippets-editor.spec.ts
+++ b/e2e/snippets-editor.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "./fixtures";
+import { fireShortcut } from "./helpers/shortcut";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ElectronApplication, Page } from "@playwright/test";
+
+// Settings > Snippets editor (add / edit / remove / autoRun toggle). Assertions
+// are round-trips through the on-disk ~/.aya/snippets.json so a mutator that
+// silently drops a field or an id-dedup that mangles data is caught.
+
+async function openSnippets(app: ElectronApplication, window: Page) {
+  // Let the renderer finish its initial load before firing a main-process
+  // shortcut, else app.evaluate can race a startup navigation.
+  await window.waitForLoadState("load");
+  await fireShortcut(app, "open-settings");
+  const settings = window.locator(".aya-modal--settings");
+  await expect(settings).toBeVisible();
+  await settings.getByTestId("settings-tab").filter({ hasText: "Snippets" }).click();
+  // Tie readiness to loaded snippet data (the seeded default row), else editing
+  // can race the async list load and the dirty guard blocks the prop sync.
+  await expect(settings.locator(".aya-settings-snippet-row").first()).toBeVisible();
+  return settings;
+}
+
+function diskSnippets(ayaHome: string): Array<{ id: string; name: string; text: string; autoRun: boolean }> | null {
+  try {
+    return JSON.parse(readFileSync(join(ayaHome, "snippets.json"), "utf8")).snippets;
+  } catch {
+    return null;
+  }
+}
+
+test("adding a snippet persists its name, text, and the autoRun flag", async ({
+  window,
+  app,
+  seeded,
+}) => {
+  const settings = await openSnippets(app, window);
+  const rows = settings.locator(".aya-settings-snippet-row");
+  const before = await rows.count();
+
+  await settings.locator(".aya-settings-add").click();
+  await expect(rows).toHaveCount(before + 1);
+
+  const row = rows.last();
+  await row.locator(".aya-settings-snippet-name").fill("e2e run snippet");
+  await row.locator(".aya-settings-snippet-text").fill("echo hello");
+  // New rows default to type-only (hold); flip to run-on-send so we can assert
+  // the boolean round-trips (not silently coerced to the default).
+  await expect(row.locator(".aya-snippet-runtoggle--hold")).toBeVisible();
+  await row.locator(".aya-snippet-runtoggle").click();
+  await expect(row.locator(".aya-snippet-runtoggle--run")).toBeVisible();
+
+  await settings.locator(".aya-modal-btn--primary", { hasText: "Save" }).click();
+
+  await expect
+    .poll(() => {
+      const m = diskSnippets(seeded.ayaHome)?.find((s) => s.name === "e2e run snippet");
+      return m ? { id: m.id, text: m.text, autoRun: m.autoRun } : null;
+    })
+    .toEqual({ id: "e2e-run-snippet", text: "echo hello", autoRun: true });
+});
+
+test("two snippets sharing a derived id are persisted under distinct ids", async ({
+  window,
+  app,
+  seeded,
+}) => {
+  const settings = await openSnippets(app, window);
+  const rows = settings.locator(".aya-settings-snippet-row");
+  const before = await rows.count();
+
+  await settings.locator(".aya-settings-add").click();
+  await settings.locator(".aya-settings-add").click();
+  await expect(rows).toHaveCount(before + 2);
+
+  // Same label -> same presetSlug id -> the editor must dedup on save so one
+  // does not clobber the other (first keeps id, second gets a "-2" suffix).
+  for (const [i, text] of [[before, "first body"], [before + 1, "second body"]] as const) {
+    await rows.nth(i).locator(".aya-settings-snippet-name").fill("dup label");
+    await rows.nth(i).locator(".aya-settings-snippet-text").fill(text);
+  }
+
+  await settings.locator(".aya-modal-btn--primary", { hasText: "Save" }).click();
+
+  // Assert the id->text mapping (not just ids): a dedup that renamed correctly
+  // but merged/swapped bodies must still fail.
+  await expect
+    .poll(() => {
+      const dups = diskSnippets(seeded.ayaHome)
+        ?.filter((s) => s.name === "dup label")
+        .map((s) => ({ id: s.id, text: s.text }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+      return dups ?? null;
+    })
+    .toEqual([
+      { id: "dup-label", text: "first body" },
+      { id: "dup-label-2", text: "second body" },
+    ]);
+});
+
+test("removing a snippet (native confirm) drops it from disk", async ({
+  window,
+  app,
+  seeded,
+}) => {
+  const settings = await openSnippets(app, window);
+  const rows = settings.locator(".aya-settings-snippet-row");
+  const before = await rows.count();
+  expect(before).toBeGreaterThan(0);
+
+  const removedName = (
+    await rows.first().locator(".aya-settings-snippet-name").inputValue()
+  ).trim();
+  expect(removedName).toBeTruthy();
+
+  window.once("dialog", (d) => d.accept());
+  await rows.first().locator(".aya-settings-row-close").click();
+  await expect(rows).toHaveCount(before - 1);
+
+  await settings.locator(".aya-modal-btn--primary", { hasText: "Save" }).click();
+
+  await expect
+    .poll(() => {
+      const s = diskSnippets(seeded.ayaHome);
+      return s ? s.some((x) => x.name === removedName) : null;
+    })
+    .toBe(false);
+});


### PR DESCRIPTION
## E2E coverage audit - Batch 6 (Snippets editor + Diagnostics)

Adversarial E2E for two previously-untested Settings surfaces. No production bugs found - the app round-trips correctly; this is durable, mutation-verified coverage.

### Snippets editor (`e2e/snippets-editor.spec.ts`)
On-disk round-trips through `~/.aya/snippets.json`:
- **Add** persists `id` + `name`/`text` + the `autoRun` boolean (toggled from the default, so it's a real round-trip, not a defaulted value).
- **Dedup**: two snippets whose label derives the same id are saved under distinct ids (`dup-label` + `dup-label-2`) **and keep their distinct bodies** (id->text mapping asserted, so a rename that merged/swapped text still fails).
- **Remove** (native confirm) drops the snippet from disk.
- The open-helper waits for the seeded row so editing can't race the async list load.

### Diagnostics (`e2e/diagnostics.spec.ts`)
- **Refresh** yields a complete, parseable support report; each labeled grid cell's `<strong>` **exactly** matches the JSON it summarizes (per-cell scope - a grid-wide substring match would false-pass when a wrong single-digit count coincides with a digit in the version string).
- **Copy JSON** writes the exact report to the real OS clipboard, read back via Electron - a no-op `writeClipboard` that only flips the label to "Copied" fails.

### Verification
- Mutation-verified: no-op'ing the snippet save turns the 3 snippet tests RED; skipping the diagnostics fetch turns both diagnostics tests RED.
- Grok + Codex reviewed the tests; their two findings (grid substring false-pass, clipboard-facade copy test) are addressed by the per-cell and real-clipboard assertions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
