### PR TITLE
Escalate PTY kill to SIGKILL (fix orphan + double-spawn from a stuck child) - BUG-11

### DIFF
--- a/e2e/pty-kill-orphan.spec.ts
+++ b/e2e/pty-kill-orphan.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "./fixtures";
+import { fireShortcut } from "./helpers/shortcut";
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { ElectronApplication, Page } from "@playwright/test";
+
+// Switch to the experimental "Projects on left" layout (split disabled) via the
+// Settings segmented control - mirrors projects-left-no-split.spec.ts (no shared
+// helper exists).
+async function enableProjectsLeftLayout(window: Page, app: ElectronApplication) {
+  await fireShortcut(app, "open-settings");
+  const settings = window.locator(".aya-modal--settings");
+  await expect(settings).toBeVisible();
+  await settings
+    .locator('.aya-settings-segmented[aria-label="Window layout"] button', {
+      hasText: "Projects on left",
+    })
+    .click();
+  await window.keyboard.press("Escape");
+  await expect(settings).toBeHidden();
+  await expect(window.locator(".aya-topbar--alt")).toBeVisible();
+}
+
+// End-to-end reproduction of BUG-11 through the real app, in BOTH layouts: a tab
+// whose process traps/ignores SIGHUP (like `claude --chrome`) must actually die
+// when the tab is closed - the SIGKILL escalation guarantees it, so no orphan is
+// left running. Without the fix the process survives the graceful kill and keeps
+// appending to its heartbeat file (the orphan that then double-spawns).
+//
+// CI-only: needs a real PTY spawn (node-pty), which the local sandbox can't exec.
+test.skip(!process.env.CI, "needs real PTY execution (unavailable in local sandbox)");
+
+// Each tab writes to hb-<its AYA_TERMINAL_ID>.txt so a hidden sibling terminal
+// can't pollute the file we watch. Traps HUP so a plain kill won't stop it.
+const HEARTBEAT_CMD =
+  'sh -c \'trap "" HUP; while :; do echo tick >> "hb-$AYA_TERMINAL_ID.txt"; sleep 0.15; done\'';
+
+const hbSize = (dir: string, tabId: string): number => {
+  const p = join(dir, `hb-${tabId}.txt`);
+  try {
+    return statSync(p).size;
+  } catch {
+    return -1;
+  }
+};
+
+async function reproInLayout(
+  window: Page,
+  app: ElectronApplication,
+  seeded: { projectDir: string; tabIds: { left: string } },
+  projectsLeft: boolean,
+) {
+  if (projectsLeft) await enableProjectsLeftLayout(window, app);
+
+  const activeTab = seeded.tabIds.left; // shell 1 boots active
+  // The tab is mounted (a terminal pane rendered) so a heartbeat that never
+  // appears means the SPAWN failed, not the kill path - a clear RED, not a
+  // false pass. (Grok/Codex review: distinguish spawn failure from kill issue.)
+  await expect(window.locator('[data-testid="terminal-pane"]:visible').first()).toBeVisible();
+  // The tab's process is running and appending its heartbeat.
+  await expect
+    .poll(() => hbSize(seeded.projectDir, activeTab), { timeout: 10_000 })
+    .toBeGreaterThan(0);
+
+  // Close the active tab -> killPty -> SIGHUP (ignored) then SIGKILL escalation.
+  await fireShortcut(app, "close-tab");
+
+  // Past the 750ms escalation + margin, the process must be DEAD: the heartbeat
+  // file stops growing. (Orphan bug: it would keep appending.)
+  await window.waitForTimeout(2000);
+  const s1 = hbSize(seeded.projectDir, activeTab);
+  await window.waitForTimeout(700); // > the 150ms heartbeat interval
+  const s2 = hbSize(seeded.projectDir, activeTab);
+  expect(existsSync(join(seeded.projectDir, `hb-${activeTab}.txt`))).toBe(true);
+  expect(s2).toBe(s1); // no further writes -> the process was actually killed
+}
+
+test.describe("classic layout", () => {
+  test.use({ seedOptions: { split: false, presetList: [{ id: "shell", name: "Shell", icon: "$", color: "", command: HEARTBEAT_CMD }] } });
+  test("closing a SIGHUP-ignoring tab kills the process (no orphan)", async ({ window, app, seeded }) => {
+    await reproInLayout(window, app, seeded, false);
+  });
+});
+
+test.describe("experimental layout (projects-left)", () => {
+  test.use({ seedOptions: { split: false, presetList: [{ id: "shell", name: "Shell", icon: "$", color: "", command: HEARTBEAT_CMD }] } });
+  test("closing a SIGHUP-ignoring tab kills the process (no orphan)", async ({ window, app, seeded }) => {
+    await reproInLayout(window, app, seeded, true);
+  });
+});

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -60,6 +60,12 @@ const pendingKills = new Set<string>();
 // Auto-evict pending-kill markers so stale ids don't linger forever (defense
 // in depth — usually the spawn either runs within milliseconds or never).
 const PENDING_KILL_TTL_MS = 5_000;
+// Grace period before escalating a kill to SIGKILL. node-pty's default kill
+// sends SIGHUP, which a stuck agent (e.g. `claude --chrome`) can trap and
+// survive; since killPty removes the id from the map, a survivor becomes an
+// orphan that a later respawn of the same id turns into a SECOND live process.
+// The uncatchable follow-up guarantees the old child actually dies.
+const KILL_ESCALATE_MS = 750;
 // In-flight spawn guard: spawnPty awaits an async command-exists preflight
 // between the `ptys.has` check and registering the PTY. Two concurrent spawns
 // for the same id (e.g. a fast unmount+remount) could both pass that check and
@@ -546,6 +552,30 @@ export function resizePty(ptyId: string, cols: number, rows: number): void {
   }
 }
 
+/** Kill a PTY child, escalating to SIGKILL after a grace period. The graceful
+ *  signal lets a well-behaved process exit and clean up; the SIGKILL guarantees
+ *  a signal-ignoring one (e.g. `claude --chrome`) actually dies, so it can't
+ *  linger as an orphan after killPty removes it from the map (which would let a
+ *  respawn of the same id create a second live process). Exported for tests;
+ *  `schedule` is injectable so the escalation can be exercised synchronously. */
+export function terminatePtyChild(
+  p: Pick<PtyModule.IPty, "kill">,
+  schedule: (fn: () => void, ms: number) => void = setTimeout,
+): void {
+  try {
+    p.kill();
+  } catch {
+    // already gone
+  }
+  schedule(() => {
+    try {
+      p.kill("SIGKILL");
+    } catch {
+      // already exited — nothing to force-kill
+    }
+  }, KILL_ESCALATE_MS);
+}
+
 export function killPty(ptyId: string): void {
   outputBuffers.delete(ptyId);
   const p = ptys.get(ptyId);
@@ -557,21 +587,17 @@ export function killPty(ptyId: string): void {
     setTimeout(() => pendingKills.delete(ptyId), PENDING_KILL_TTL_MS);
     return;
   }
-  try {
-    p.kill();
-  } catch {
-    // already gone
-  }
+  // Remove from the map first (a re-mount/respawn should not attach to a dying
+  // PTY), then terminate with SIGKILL escalation so a signal-ignoring child
+  // can't survive and get orphaned.
   ptys.delete(ptyId);
+  terminatePtyChild(p);
 }
 
 export function killAll(): void {
   for (const [, p] of ptys) {
-    try {
-      p.kill();
-    } catch {
-      // ignore
-    }
+    // Same SIGKILL escalation as killPty so no child survives as an orphan.
+    terminatePtyChild(p);
   }
   ptys.clear();
   outputBuffers.clear();

--- a/tests/pty-kill-escalate.test.mjs
+++ b/tests/pty-kill-escalate.test.mjs
@@ -69,3 +69,37 @@ test("a SIGHUP-ignoring process survives the graceful kill but the escalation ki
   await sleep(1000); // past KILL_ESCALATE_MS -> SIGKILL delivered
   assert.equal(exited, true, "the SIGKILL escalation must terminate the stuck process");
 });
+
+// Edge: a well-behaved process exits on the graceful signal; the later SIGKILL
+// must be a harmless no-op (dead pid -> caught), not an error.
+test("a normal process exits on the graceful signal; escalation is a harmless no-op", async () => {
+  const child = spawn("sh", ["-c", "sleep 30"], { stdio: "ignore" }); // no trap -> dies on SIGHUP
+  let exited = false;
+  child.on("exit", () => {
+    exited = true;
+  });
+  await sleep(100);
+  // The handle does NOT swallow - so the escalation's SIGKILL on the by-then
+  // dead pid throws ESRCH straight into terminatePtyChild's own try/catch. If
+  // that catch regressed, the throw would escape the real setTimeout callback
+  // and crash the test process (uncaught) - so the tail wait actually verifies
+  // terminatePtyChild swallows the escalation error, not the handle.
+  const handle = {
+    kill: (sig) => process.kill(child.pid, sig ?? "SIGHUP"),
+  };
+  assert.doesNotThrow(() => terminatePtyChild(handle));
+  await sleep(300); // graceful SIGHUP kills a non-trapping process quickly
+  assert.equal(exited, true, "a non-trapping process dies on the graceful signal");
+  await sleep(700); // escalation fires on the already-dead pid -> must not crash
+});
+
+// Edge: terminating an already-exited process throws nothing (both signals hit a
+// dead pid -> ESRCH, swallowed).
+test("terminating an already-exited process is a no-op", async () => {
+  const child = spawn("sh", ["-c", "exit 0"], { stdio: "ignore" });
+  await new Promise((r) => child.on("exit", r));
+  const handle = {
+    kill: (sig) => process.kill(child.pid, sig ?? "SIGHUP"), // will throw ESRCH
+  };
+  assert.doesNotThrow(() => terminatePtyChild(handle, (fn) => fn()));
+});

--- a/tests/pty-kill-escalate.test.mjs
+++ b/tests/pty-kill-escalate.test.mjs
@@ -1,0 +1,71 @@
+// Kill escalation: killPty removes a PTY from the map and terminates the child.
+// A stuck child (e.g. `claude --chrome`) can trap the default kill signal and
+// survive, becoming an orphan that a later respawn of the same id turns into a
+// SECOND live process. terminatePtyChild must escalate to SIGKILL so the old
+// child actually dies. schedule is injectable so we run the escalation inline.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { terminatePtyChild } from "../dist-electron/pty.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test("terminatePtyChild sends the default kill, then escalates to SIGKILL", () => {
+  const signals = [];
+  const fake = { kill: (s) => signals.push(s ?? "default") };
+  let scheduled = null;
+  terminatePtyChild(fake, (fn, ms) => {
+    scheduled = { fn, ms };
+  });
+
+  // Immediate graceful kill (default signal), escalation deferred.
+  assert.deepEqual(signals, ["default"]);
+  assert.ok(scheduled, "an escalation must be scheduled");
+  assert.ok(scheduled.ms > 0, "escalation runs after a grace delay");
+
+  // Run the scheduled escalation -> uncatchable SIGKILL.
+  scheduled.fn();
+  assert.deepEqual(signals, ["default", "SIGKILL"]);
+});
+
+test("terminatePtyChild swallows errors when the child already exited", () => {
+  const fake = {
+    kill: () => {
+      throw new Error("process already gone");
+    },
+  };
+  // Neither the immediate kill nor the (inline) escalation may throw.
+  assert.doesNotThrow(() => terminatePtyChild(fake, (fn) => fn()));
+});
+
+// Reproduces the trigger against a REAL OS process: a child that traps/ignores
+// SIGHUP (as `claude --chrome` effectively did - PID survived a graceful kill
+// for minutes, orphaned, causing a double-spawn). The graceful signal must NOT
+// kill it, and the SIGKILL escalation MUST. Uses child_process (no node-pty).
+test("a SIGHUP-ignoring process survives the graceful kill but the escalation kills it", async () => {
+  const child = spawn("sh", ["-c", "trap '' HUP; sleep 30"], { stdio: "ignore" });
+  let exited = false;
+  child.on("exit", () => {
+    exited = true;
+  });
+  await sleep(150); // let the trap install
+
+  // Map the IPty-shaped kill(signal) onto the real process.
+  const handle = {
+    kill: (sig) => {
+      try {
+        process.kill(child.pid, sig ?? "SIGHUP");
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+  terminatePtyChild(handle); // real setTimeout escalation
+
+  await sleep(250); // past the graceful kill, before escalation
+  assert.equal(exited, false, "SIGHUP-ignoring process must survive the graceful kill");
+
+  await sleep(1000); // past KILL_ESCALATE_MS -> SIGKILL delivered
+  assert.equal(exited, true, "the SIGKILL escalation must terminate the stuck process");
+});


### PR DESCRIPTION
## Root cause (confirmed from live processes)

Diagnosed from the user's running app: a `claude --chrome` process was **alive 7+ minutes after its tab was killed**, orphaned, with a **second** live claude process for the **same tab id** (double-spawn).

`killPty` did `p.kill()` (node-pty's default signal is **SIGHUP**) then removed the id from the map **immediately, without confirming the process died**. A child that traps/ignores SIGHUP (`claude --chrome`) survives → orphaned (gone from the map but running) → a later respawn of the same id sees `ptys.has === false` and spawns a **second** process. The tab binds to the new process (host's last-write-wins map); the old runs invisibly (its output dropped by the `ptys.get(id) !== child` guard) and its MCP children leak → **black-screen tab**.

## Fix

`terminatePtyChild(p, schedule)`: graceful kill, then an **uncatchable SIGKILL after a 750ms grace window** so a stuck child actually dies and can't be orphaned. `killPty` removes the id from the map first (a respawn must not attach to a dying PTY) then terminates; `killAll` uses it too.

## Reproduction + tests (`tests/pty-kill-escalate.test.mjs`)

- Injected-fake: asserts default-kill **then** SIGKILL (mutation-verified: dropping SIGKILL → RED).
- Error-swallow on an already-exited child.
- **Real-process reproduction:** `sh -c "trap '' HUP; sleep 30"` **survives the graceful kill** and is **terminated by the escalation** — the exact SIGHUP-survival mechanism behind the orphan, without needing node-pty.

Full `killPty → spawnPty` integration needs node-pty (host tests can't load its ABI); the escalation seam + signal-survival mechanism are covered here, concurrent double-spawn is covered by `pty-double-spawn.test.mjs`.

## Review
Grok: **clean to merge**. Codex agent was blocked by the repo guard on the test's nested `sh -c` content (environmental). Optional follow-up (Grok, out of scope): cancel the escalation timer on `onExit` to close a negligible 750ms pid-reuse window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)