### PR TITLE
Reap stale detached PTY-hosts by pid on launch (host registry) - Phase 1

### DIFF
--- a/e2e/pty-kill-orphan.spec.ts
+++ b/e2e/pty-kill-orphan.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./fixtures";
 import { fireShortcut } from "./helpers/shortcut";
-import { existsSync, statSync } from "node:fs";
+import { statSync } from "node:fs";
 import { join } from "node:path";
 import type { ElectronApplication, Page } from "@playwright/test";
 
@@ -61,17 +61,28 @@ async function reproInLayout(
   await expect
     .poll(() => hbSize(seeded.projectDir, activeTab), { timeout: 10_000 })
     .toBeGreaterThan(0);
+  const beforeClose = hbSize(seeded.projectDir, activeTab);
 
-  // Close the active tab -> killPty -> SIGHUP (ignored) then SIGKILL escalation.
+  // Close the active tab -> killPty -> graceful SIGHUP (ignored by the trap) then
+  // SIGKILL escalation.
   await fireShortcut(app, "close-tab");
 
-  // Past the 750ms escalation + margin, the process must be DEAD: the heartbeat
-  // file stops growing. (Orphan bug: it would keep appending.)
+  // First prove the process SURVIVES the graceful kill: inside the grace window
+  // (before the 750ms escalation) the trap-HUP loop keeps appending. This ASSERTS
+  // SIGHUP-resistance rather than assuming it from the fixture string - if the
+  // graceful signal alone killed the process (e.g. the trap silently broke, or
+  // node-pty's default signal changed), this fails RED instead of letting the
+  // test quietly decay into a facade.
+  await expect
+    .poll(() => hbSize(seeded.projectDir, activeTab), { timeout: 700 })
+    .toBeGreaterThan(beforeClose);
+
+  // Then prove the escalation actually kills it: past the 750ms window the file
+  // stops growing. (Orphan bug: a survivor would keep appending forever.)
   await window.waitForTimeout(2000);
   const s1 = hbSize(seeded.projectDir, activeTab);
   await window.waitForTimeout(700); // > the 150ms heartbeat interval
   const s2 = hbSize(seeded.projectDir, activeTab);
-  expect(existsSync(join(seeded.projectDir, `hb-${activeTab}.txt`))).toBe(true);
   expect(s2).toBe(s1); // no further writes -> the process was actually killed
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1605,45 +1605,60 @@ function createWindow(initial: WindowGeometry): BrowserWindow {
   return win;
 }
 
-/** On launch, detect a stale PTY host (#28). With zero live terminals it is
- *  safe to reap silently; otherwise a restart would kill the user's running
- *  processes, so we only notify the renderer (which offers a confirm + button).
- *  Best-effort: never blocks or crashes startup. */
-async function handleStaleHost(win: BrowserWindow | null): Promise<void> {
-  if (!win || win.isDestroyed()) return;
+/** On launch, auto-reap a stale PTY host (#28), even with live terminals: an
+ *  update ships new binaries, so the old host's terminals must restart anyway
+ *  (Shift+Enter), and leaving it alive is exactly what accumulated orphaned
+ *  hosts + processes. Best-effort: never blocks or crashes startup.
+ *
+ *  Honest limits: restart() only ASKS the socket-connected host to shut down -
+ *  the old host runs ITS OWN shutdown code. Hosts from builds before the #73
+ *  escalation SIGHUP their children and exit immediately, so a signal-ignoring
+ *  child (claude --chrome) can still be orphaned once, at this first-update
+ *  boundary; such hosts also predate the registry, so the by-pid reap can't
+ *  cover them either. Cleaning those already-orphaned trees is the Phase-2
+ *  sweep's job. Hosts from this build onward are covered on both paths. */
+async function handleStaleHost(): Promise<void> {
   try {
-    const { identity, ptyCount } = await ptyHost.hostStatus();
     const expected = ptyHost.expectedHostIdentity(app.getVersion());
+    let { identity } = await ptyHost.hostStatus();
+    if (identity === null) {
+      // identity null is ALSO returned for transient client-side failures (e.g.
+      // a >5s cold-spawn socket wait). Acting on it immediately would shut down
+      // the freshly-spawned, current-version host. Re-probe once after a short
+      // delay: a genuinely ancient host fails the version request consistently,
+      // while a slow spawn answers with a matching identity the second time.
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      ({ identity } = await ptyHost.hostStatus());
+    }
     if (!isHostStale(expected, identity)) return;
-    void ptyCount; // no longer gates the reap - see below
-    // Auto-reap a stale host, even with live terminals. Staleness means a
-    // version/scriptHash mismatch (the app was updated) or a failed handshake:
-    // either way the old host runs incompatible code, so its terminals must
-    // restart anyway (Shift+Enter). Leaving it alive is exactly what accumulated
-    // orphaned hosts + processes. restart() escalates child kills to SIGKILL
-    // (#73), so no signal-ignoring child is orphaned. The by-pid reconciliation
-    // at startup already reaps *recorded* stale hosts; this covers the one still
-    // holding the socket (incl. old hosts that predate the registry).
-    try {
-      await ptyHost.restart();
-      return;
-    } catch {
-      // Reap failed (host unreachable). Fall back to the manual affordance so
-      // the user can retry via "Restart Aya".
-    }
-    // Signal via the menu item icon instead of an intrusive banner (#52).
+    await ptyHost.restart();
+    // restart() swallows request errors by design (an old host may not honor
+    // "shutdown"), so returning is NOT proof the host died. Verify: re-probe the
+    // socket; a fresh current-version host (or none yet) means success, the SAME
+    // stale identity answering again means the reap failed.
+    const after = await ptyHost.hostStatus();
+    if (!isHostStale(expected, after.identity)) return;
+    // Reap didn't take - surface the manual affordance so the user can retry.
+    // The menu may not be installed yet (this runs before createWindow), so the
+    // caller applies the icon from the flag after installApplicationMenu.
     staleHostDetected = true;
-    const item = Menu.getApplicationMenu()?.getMenuItemById("restart-aya");
-    if (item) {
-      // 16x16 px amber dot at scaleFactor 2 = 8pt logical - renders as a
-      // small colored circle to the left of the label (standard macOS pattern).
-      item.icon = nativeImage.createFromBuffer(
-        makeCirclePng(16, 224, 112, 0), // amber #e07000
-        { scaleFactor: 2 },
-      );
-    }
+    setStaleMenuIcon();
   } catch {
     // best-effort; a host that can't be queried is handled on next use
+  }
+}
+
+/** Amber dot on the "Restart Aya" menu item - the manual reap affordance (#52).
+ *  No-op until the application menu is installed. */
+function setStaleMenuIcon(): void {
+  const item = Menu.getApplicationMenu()?.getMenuItemById("restart-aya");
+  if (item) {
+    // 16x16 px amber dot at scaleFactor 2 = 8pt logical - renders as a
+    // small colored circle to the left of the label (standard macOS pattern).
+    item.icon = nativeImage.createFromBuffer(
+      makeCirclePng(16, 224, 112, 0), // amber #e07000
+      { scaleFactor: 2 },
+    );
   }
 }
 
@@ -2070,11 +2085,16 @@ app.whenReady().then(async () => {
     }
   }
 
-  // Reap stale detached PTY hosts (and their whole process trees) left by older
-  // app versions BEFORE anything connects or spawns a fresh host. A same-build
-  // host is kept (survive-restart, #28); a version-mismatched one is force-killed
-  // by pid (fail-closed, verified via its recorded start time). This stops the
-  // orphan pile-up where each update left the previous host + its children alive.
+  // Reap stale detached PTY hosts (and their whole process groups) that THIS
+  // registry recorded - i.e. hosts from this build onward left behind by future
+  // updates. A same-build host is kept (survive-restart, #28); a version-
+  // mismatched one is force-killed by pid (fail-closed, verified via its
+  // recorded start time). Pre-registry hosts have no record and are NOT covered
+  // here (Phase-2 sweep); the one currently holding the socket is handled by
+  // handleStaleHost after the window loads. Placement: deliberately BEFORE
+  // createWindow so a recorded stale host is dead before anything can connect
+  // to it; the common-path cost is one `ps -p` fork for the kept host (the
+  // system-wide snapshot only runs when a kill actually happens).
   try {
     const summary = reapStaleHostRecords(
       ptyHost.expectedHostIdentity(app.getVersion()),
@@ -2086,8 +2106,23 @@ app.whenReady().then(async () => {
         summary.reaped,
       );
     }
+    if (summary.gc.length > 0 || summary.skipped.length > 0) {
+      console.log(
+        `[aya] pty-host registry: gc'd ${summary.gc.length} dead record(s), skipped ${summary.skipped.length} (indeterminate/probe-failed)`,
+      );
+    }
   } catch {
     // best effort — never block startup on reconciliation
+  }
+
+  // Reconcile the SOCKET-connected host too, still before the window exists:
+  // once the renderer loads it immediately spawns terminals, and a spawn that
+  // raced this check could land on the stale host and be killed by the reap
+  // (losing the user's first terminal). Fast path: no socket file, no host to
+  // reconcile — don't pay a probe (which would spawn a host early) on a cold
+  // start. The amber fallback icon is applied after installApplicationMenu.
+  if (await pathExists(PTY_HOST_SOCKET_PATH)) {
+    await handleStaleHost();
   }
 
   const savedState = await loadWindowState();
@@ -2123,11 +2158,9 @@ app.whenReady().then(async () => {
   });
   installApplicationMenu();
 
-  // After the renderer is listening, check whether the (detached, survives-
-  // restart) PTY host is from an older build and act on it (#28).
-  mainWindow.webContents.once("did-finish-load", () => {
-    void handleStaleHost(mainWindow);
-  });
+  // The stale-host reconcile ran before the window (see above); the menu did
+  // not exist yet, so apply the amber "Restart Aya" affordance now if needed.
+  if (staleHostDetected) setStaleMenuIcon();
 
   // Honor an initial directory argument on first launch — the renderer
   // applies the same switch-or-create logic as for second-instance.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -83,6 +83,7 @@ import { readRepoProjectConfig } from "./project-local";
 import { repairProcessPath } from "./shell-path";
 import { PtyHostClient } from "./pty-host-client";
 import { reapStaleHostRecords } from "./pty-host-registry";
+import { sweepLegacyAyaProcesses } from "./pty-host-sweep";
 import {
   requirePositiveInt,
   requireString,
@@ -130,6 +131,10 @@ const RECOMMENDED_OLLAMA_MODEL = "gemma4:e4b";
 
 const ptyHost = new PtyHostClient(path.join(__dirname, "pty-host.js"));
 const UPDATE_AUTO_CHECK_DELAY_MS = 12_000;
+// Delay before the Phase-2 legacy sweep (stray pre-registry hosts + orphaned
+// terminal children of dead hosts). Off the startup path: nothing it targets
+// can interfere with the fresh session, so first paint never pays for it.
+const LEGACY_SWEEP_DELAY_MS = 5_000;
 let updateStatus: UpdateStatus = {
   phase: "idle",
   supported: false,
@@ -1181,6 +1186,12 @@ function showAyaAboutPanel(): void {
 // Set to true when a stale PTY host is detected on launch (#28). The Restart
 // Aya menu item reads this flag so it can kill the stale host before relaunching.
 let staleHostDetected = false;
+// Deferred Phase-2 legacy-sweep timer; cancelled on quit so a mid-teardown
+// sweep can't spawn a host or probe processes while the app is exiting.
+let legacySweepTimer: NodeJS.Timeout | null = null;
+// Set in before-quit: an already-fired sweep callback checks it and bails
+// (clearTimeout can't stop a callback that is already running).
+let appQuitting = false;
 
 /** Build a minimal RGBA PNG containing a filled circle.
  *  Uses only Node built-ins (zlib deflate + manual PNG framing). */
@@ -2095,11 +2106,13 @@ app.whenReady().then(async () => {
   // createWindow so a recorded stale host is dead before anything can connect
   // to it; the common-path cost is one `ps -p` fork for the kept host (the
   // system-wide snapshot only runs when a kill actually happens).
+  let keptCompatibleHosts: number[] = [];
   try {
     const summary = reapStaleHostRecords(
       ptyHost.expectedHostIdentity(app.getVersion()),
       path.join(__dirname, "pty-host.js"),
     );
+    keptCompatibleHosts = summary.keptCompatible;
     if (summary.reaped.length > 0) {
       console.log(
         `[aya] reaped ${summary.reaped.length} stale pty-host(s) + ${summary.killedDescendants.length} descendant(s):`,
@@ -2162,6 +2175,56 @@ app.whenReady().then(async () => {
   // not exist yet, so apply the amber "Restart Aya" affordance now if needed.
   if (staleHostDetected) setStaleMenuIcon();
 
+  // Phase-2 legacy sweep, deferred off the startup path: clean up what the
+  // registry structurally can't reach - pre-registry stray hosts (no record
+  // file, e.g. left behind by builds before the registry existed) and orphaned
+  // terminal children whose host already died. Deferred because none of these
+  // can interfere with the fresh session (a stray host holds no socket, a dead
+  // -leader orphan has no owner), so first paint shouldn't pay for the probes.
+  legacySweepTimer = setTimeout(() => {
+    legacySweepTimer = null;
+    void (async () => {
+      try {
+        // A quit that races the timer can't un-schedule an already-running
+        // callback - bail if teardown began (the flag is set in before-quit).
+        if (appQuitting) return;
+        // The current socket host must never be swept. Fail-closed twice over:
+        // no socket file -> don't consult the client at all (hostStatus would
+        // SPAWN a host as a side effect) and run without the stray-host pass;
+        // socket present but the host reports no pid (pre-registry host) ->
+        // also skip the stray-host pass, since we can't positively exclude it.
+        // S2 is unaffected either way - a live host's children are never in a
+        // dead-leader group.
+        let strayHosts = false;
+        const exclude = new Set<number>(keptCompatibleHosts);
+        if (await pathExists(PTY_HOST_SOCKET_PATH)) {
+          const status = await ptyHost.hostStatus();
+          if (typeof status.pid === "number") {
+            exclude.add(status.pid);
+            strayHosts = true;
+          } else {
+            console.log(
+              "[aya] legacy sweep: socket host has no pid handshake - skipping stray-host pass",
+            );
+          }
+        }
+        const summary = sweepLegacyAyaProcesses(exclude, undefined, { strayHosts });
+        if (summary.sweptHosts.length > 0 || summary.sweptOrphans.length > 0) {
+          console.log(
+            `[aya] legacy sweep: killed ${summary.sweptHosts.length} stray host group(s) ${JSON.stringify(summary.sweptHosts)} + ${summary.sweptOrphans.length} orphaned terminal process(es)`,
+          );
+        }
+        if (summary.truncated > 0) {
+          console.log(
+            `[aya] legacy sweep: ${summary.truncated} orphan candidate(s) beyond the probe cap - retried next launch`,
+          );
+        }
+      } catch {
+        // best effort - never destabilize a running session over cleanup
+      }
+    })();
+  }, LEGACY_SWEEP_DELAY_MS);
+
   // Honor an initial directory argument on first launch — the renderer
   // applies the same switch-or-create logic as for second-instance.
   const initialDir = findDirInArgv(process.argv);
@@ -2184,6 +2247,11 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  appQuitting = true;
+  if (legacySweepTimer) {
+    clearTimeout(legacySweepTimer);
+    legacySweepTimer = null;
+  }
   if (!IS_E2E_PTY_SHUTDOWN) return;
   void ptyHost.shutdown().catch(() => {
     // Test-only cleanup. Normal app runs intentionally keep PTYs alive.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -82,6 +82,7 @@ import { normalizeLocalSummaryError } from "./local-summary-errors";
 import { readRepoProjectConfig } from "./project-local";
 import { repairProcessPath } from "./shell-path";
 import { PtyHostClient } from "./pty-host-client";
+import { reapStaleHostRecords } from "./pty-host-registry";
 import {
   requirePositiveInt,
   requireString,
@@ -1614,13 +1615,21 @@ async function handleStaleHost(win: BrowserWindow | null): Promise<void> {
     const { identity, ptyCount } = await ptyHost.hostStatus();
     const expected = ptyHost.expectedHostIdentity(app.getVersion());
     if (!isHostStale(expected, identity)) return;
-    // Only auto-reap silently when the handshake succeeded and confirmed zero
-    // terminals. When identity===null the host does not support the version
-    // request (old host after reinstall) so ptyCount is unknown - always show
-    // the banner.
-    if (identity !== null && ptyCount === 0) {
+    void ptyCount; // no longer gates the reap - see below
+    // Auto-reap a stale host, even with live terminals. Staleness means a
+    // version/scriptHash mismatch (the app was updated) or a failed handshake:
+    // either way the old host runs incompatible code, so its terminals must
+    // restart anyway (Shift+Enter). Leaving it alive is exactly what accumulated
+    // orphaned hosts + processes. restart() escalates child kills to SIGKILL
+    // (#73), so no signal-ignoring child is orphaned. The by-pid reconciliation
+    // at startup already reaps *recorded* stale hosts; this covers the one still
+    // holding the socket (incl. old hosts that predate the registry).
+    try {
       await ptyHost.restart();
       return;
+    } catch {
+      // Reap failed (host unreachable). Fall back to the manual affordance so
+      // the user can retry via "Restart Aya".
     }
     // Signal via the menu item icon instead of an intrusive banner (#52).
     staleHostDetected = true;
@@ -2059,6 +2068,26 @@ app.whenReady().then(async () => {
     } catch {
       // Non-fatal — just means we keep Electron's default dock icon.
     }
+  }
+
+  // Reap stale detached PTY hosts (and their whole process trees) left by older
+  // app versions BEFORE anything connects or spawns a fresh host. A same-build
+  // host is kept (survive-restart, #28); a version-mismatched one is force-killed
+  // by pid (fail-closed, verified via its recorded start time). This stops the
+  // orphan pile-up where each update left the previous host + its children alive.
+  try {
+    const summary = reapStaleHostRecords(
+      ptyHost.expectedHostIdentity(app.getVersion()),
+      path.join(__dirname, "pty-host.js"),
+    );
+    if (summary.reaped.length > 0) {
+      console.log(
+        `[aya] reaped ${summary.reaped.length} stale pty-host(s) + ${summary.killedDescendants.length} descendant(s):`,
+        summary.reaped,
+      );
+    }
+  } catch {
+    // best effort — never block startup on reconciliation
   }
 
   const savedState = await loadWindowState();

--- a/electron/pty-host-client.ts
+++ b/electron/pty-host-client.ts
@@ -61,23 +61,23 @@ export class PtyHostClient {
     this.socket = null;
   }
 
-  /** Running host's identity + live PTY count. identity is null if the
-   *  handshake fails (an old host that predates the `version` request errors
-   *  out - itself a stale signal); ptyCount is 0 when unknown. */
+  /** Running host's identity + live PTY count + its pid (hosts from the
+   *  registry era report it; older hosts don't -> undefined). identity is null
+   *  if the handshake fails (an old host that predates the `version` request
+   *  errors out - itself a stale signal); ptyCount is 0 when unknown. */
   async hostStatus(): Promise<{
     identity: HostIdentity | null;
     ptyCount: number;
+    pid?: number;
   }> {
     try {
       const result = await this.request({ id: 0, type: "version" });
+      const obj =
+        result && typeof result === "object" ? (result as Record<string, unknown>) : {};
       return {
         identity: asHostIdentity(result),
-        ptyCount:
-          result &&
-          typeof result === "object" &&
-          typeof (result as { ptyCount?: unknown }).ptyCount === "number"
-            ? (result as { ptyCount: number }).ptyCount
-            : 0,
+        ptyCount: typeof obj.ptyCount === "number" ? obj.ptyCount : 0,
+        pid: typeof obj.pid === "number" ? obj.pid : undefined,
       };
     } catch {
       return { identity: null, ptyCount: 0 };

--- a/electron/pty-host-registry.ts
+++ b/electron/pty-host-registry.ts
@@ -3,7 +3,10 @@
 //
 // The reap kills processes, so every decision here is FAIL-CLOSED: we only ever
 // signal a PID we are confident is the exact host a record describes. Any
-// uncertainty (PID reuse, missing metadata, cmdline mismatch) -> skip the kill.
+// uncertainty (PID reuse, missing metadata, cmdline mismatch, a failed probe,
+// an "unknown" identity hash) -> no kill. GC of a record additionally requires
+// a SUCCESSFUL probe showing the pid gone/reused - a failed probe keeps the
+// record so a live host never loses its only reapability pointer.
 //
 // Off-socket hosts can't be authenticated via the socket handshake, so the
 // cross-check is: the process is still alive, its OS start time matches the one
@@ -11,6 +14,7 @@
 // still looks like our host script. All three must hold.
 
 import { execFileSync } from "node:child_process";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { AYA_HOME } from "./paths";
@@ -18,12 +22,15 @@ import { AYA_HOME } from "./paths";
 export interface HostRecord {
   /** Host process pid (also its process-group leader: spawned detached). */
   pid: number;
-  /** Process-group id (== pid for a detached leader; recorded for tree kill). */
+  /** Process-group id. Must equal pid (detached leader) or the record is never
+   *  reaped; the host verifies this via the OS at write time. */
   pgid: number;
   version: string;
   scriptHash: string;
-  /** OS-reported start time (`ps -o lstart`) captured at spawn. Opaque string,
-   *  compared for exact equality to defend against PID reuse. */
+  /** OS-reported start time (`ps -o lstart`, pinned to UTC + C locale) captured
+   *  at spawn. Opaque string, compared for exact equality to defend against PID
+   *  reuse. Pinning TZ matters: lstart renders in the current zone, so a DST
+   *  shift between record and probe would otherwise unverify every record. */
   startTime: string;
   /** Random per-instance token (socket-handshake cross-check, future use). */
   nonce: string;
@@ -31,6 +38,9 @@ export interface HostRecord {
 
 export interface ProcInfo {
   alive: boolean;
+  /** True when the probe itself failed (ps could not run) - the pid's state is
+   *  UNKNOWN, which is different from "ps ran and the pid is gone". */
+  probeFailed: boolean;
   /** `ps -o lstart` for the pid, or null if it could not be read. */
   startTime: string | null;
   /** `ps -o command` for the pid, or null. */
@@ -39,22 +49,36 @@ export interface ProcInfo {
 
 export const HOST_REGISTRY_DIR = path.join(AYA_HOME, "pty-hosts");
 
+// A .tmp older than this is a crash leftover, safe to sweep. Young .tmp files
+// are spared: another host may be mid-write (writeFileSync -> renameSync).
+const TMP_SWEEP_AGE_MS = 60_000;
+
 const recordPath = (dir: string, pid: number): string =>
   path.join(dir, `${pid}.json`);
 
-/** Atomically write a host's record (tmp + rename). Best-effort. */
+/** Atomically write a host's record (tmp + rename). Refuses a record without a
+ *  start time - it could never be verified, so it would only ever be GC'd.
+ *  Best-effort beyond that. */
 export function writeHostRecord(rec: HostRecord, dir: string = HOST_REGISTRY_DIR): void {
+  if (!rec.startTime) return;
+  const tmp = `${recordPath(dir, rec.pid)}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
   try {
     fs.mkdirSync(dir, { recursive: true });
-    const tmp = `${recordPath(dir, rec.pid)}.${process.pid}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(rec), { mode: 0o600 });
     fs.renameSync(tmp, recordPath(dir, rec.pid));
   } catch {
     // best effort; a missing record just means this host won't be reaped by pid
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // leave it - readHostRecords sweeps aged .tmp files
+    }
   }
 }
 
-/** Read all valid host records in the registry (skips malformed files). */
+/** Read all valid host records in the registry. Self-healing: unlinks files
+ *  that fail parse/shape validation (writes are atomic, so a bad .json is a
+ *  crash artifact, never a mid-write) and sweeps aged .tmp leftovers. */
 export function readHostRecords(dir: string = HOST_REGISTRY_DIR): HostRecord[] {
   let names: string[];
   try {
@@ -64,12 +88,28 @@ export function readHostRecords(dir: string = HOST_REGISTRY_DIR): HostRecord[] {
   }
   const out: HostRecord[] = [];
   for (const name of names) {
+    const full = path.join(dir, name);
+    if (name.endsWith(".tmp")) {
+      try {
+        if (Date.now() - fs.statSync(full).mtimeMs > TMP_SWEEP_AGE_MS) {
+          fs.rmSync(full, { force: true });
+        }
+      } catch {
+        // best effort
+      }
+      continue;
+    }
     if (!name.endsWith(".json")) continue;
     try {
-      const rec = JSON.parse(fs.readFileSync(path.join(dir, name), "utf8")) as unknown;
+      const rec = JSON.parse(fs.readFileSync(full, "utf8")) as unknown;
       if (isHostRecord(rec)) out.push(rec);
+      else fs.rmSync(full, { force: true }); // wrong shape - non-actionable forever
     } catch {
-      // skip malformed / partial writes
+      try {
+        fs.rmSync(full, { force: true }); // unparseable - crash artifact
+      } catch {
+        // best effort
+      }
     }
   }
   return out;
@@ -89,7 +129,10 @@ function isHostRecord(v: unknown): v is HostRecord {
   const r = v as Record<string, unknown>;
   return (
     typeof r.pid === "number" &&
+    Number.isInteger(r.pid) &&
+    r.pid > 1 &&
     typeof r.pgid === "number" &&
+    Number.isInteger(r.pgid) &&
     typeof r.version === "string" &&
     typeof r.scriptHash === "string" &&
     typeof r.startTime === "string" &&
@@ -107,6 +150,7 @@ export function isSameRecordedProcess(
   info: ProcInfo,
   hostScript: string,
 ): boolean {
+  if (info.probeFailed) return false; // unknown state is never "same"
   if (!info.alive) return false;
   if (!info.startTime || info.startTime !== rec.startTime) return false;
   const scriptName = hostScript.slice(hostScript.lastIndexOf("/") + 1) || hostScript;
@@ -131,8 +175,29 @@ export function isReapableHost(
   return isSameRecordedProcess(rec, info, hostScript);
 }
 
+/** How a record compares to the identity THIS app would spawn.
+ *  - "compatible": same version AND same known scriptHash -> keep (#28).
+ *  - "stale": different version, or same version with two KNOWN, different
+ *    hashes (a rebuild) -> reap.
+ *  - "indeterminate": same version but either hash is the "unknown" sentinel
+ *    (a failed read at record or launch time). Comparing sentinels would be
+ *    catastrophic in both directions - "unknown"==="unknown" would trust a
+ *    foreign build, and real-vs-"unknown" would SIGKILL a healthy same-build
+ *    host - so we do NOTHING with such records this launch. */
+export function classifyRecord(
+  rec: Pick<HostRecord, "version" | "scriptHash">,
+  expected: { version: string; scriptHash: string },
+): "compatible" | "stale" | "indeterminate" {
+  if (rec.version !== expected.version) return "stale";
+  if (rec.scriptHash === "unknown" || expected.scriptHash === "unknown") {
+    return "indeterminate";
+  }
+  return rec.scriptHash === expected.scriptHash ? "compatible" : "stale";
+}
+
 /** All descendant pids of `rootPid`, recursively, from a (pid,ppid) list.
- *  Cycle-safe. Excludes the root itself. */
+ *  Cycle-safe. Excludes the root itself. Used only to LOG what a group kill
+ *  covered - never as a kill target (a snapshotted pid could be reused). */
 export function collectDescendants(
   rootPid: number,
   procs: Array<{ pid: number; ppid: number }>,
@@ -160,32 +225,44 @@ export function collectDescendants(
 
 // --- Impure OS probes (thin wrappers; injected in tests) ------------------
 
-/** `ps` fields for one pid. Returns alive:false when the pid is gone. */
+// C locale + UTC keep `lstart` a stable, zone-independent 24-char ctime string.
+// Without TZ pinning a DST transition between record and probe would shift the
+// rendered hour and silently unverify every record (empirically confirmed:
+// the same pid renders 08:52 under TZ=UTC and 10:52 under Europe/Warsaw).
+const PS_ENV = { ...process.env, LC_ALL: "C", LANG: "C", TZ: "UTC" };
+
+/** `ps` fields for one pid. alive:false when ps ran and the pid is gone;
+ *  probeFailed:true when ps itself could not run (fork pressure, sandbox) -
+ *  callers must treat that as UNKNOWN, not as dead. */
 export function readProcInfo(pid: number): ProcInfo {
   try {
     const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart=,command="], {
       encoding: "utf8",
-      // Force C locale so `lstart` is the stable 24-char English ctime we slice
-      // on below - a localized month/day name would shift the column and could
-      // corrupt the start-time comparison the reuse guard depends on.
-      env: { ...process.env, LC_ALL: "C", LANG: "C" },
+      env: PS_ENV,
     }).trim();
-    if (!out) return { alive: false, startTime: null, command: null };
+    if (!out) return { alive: false, probeFailed: false, startTime: null, command: null };
     // lstart is a fixed 24-char ctime string; the rest is the command.
     const lstart = out.slice(0, 24).trim();
     const command = out.slice(24).trim();
-    return { alive: true, startTime: lstart, command };
-  } catch {
-    return { alive: false, startTime: null, command: null };
+    return { alive: true, probeFailed: false, startTime: lstart, command };
+  } catch (err) {
+    // execFileSync throws BOTH when ps exits non-zero (pid does not exist -
+    // status is a number) and when ps itself failed to run (spawn error -
+    // status is null/undefined). Only the former proves the pid is gone.
+    const status = (err as { status?: unknown }).status;
+    if (typeof status === "number") {
+      return { alive: false, probeFailed: false, startTime: null, command: null };
+    }
+    return { alive: false, probeFailed: true, startTime: null, command: null };
   }
 }
 
-/** Snapshot of (pid, ppid) for every process (for descendant enumeration). */
+/** Snapshot of (pid, ppid) for every process (descendant LOGGING only). */
 export function listProcs(): Array<{ pid: number; ppid: number }> {
   try {
     const out = execFileSync("ps", ["-Ao", "pid=,ppid="], {
       encoding: "utf8",
-      env: { ...process.env, LC_ALL: "C", LANG: "C" },
+      env: PS_ENV,
     });
     const rows: Array<{ pid: number; ppid: number }> = [];
     for (const line of out.split("\n")) {
@@ -198,9 +275,26 @@ export function listProcs(): Array<{ pid: number; ppid: number }> {
   }
 }
 
-/** Own OS start time, recorded so a later reaper can verify identity. */
+/** Own OS start time, recorded so a later reaper can verify identity. Empty
+ *  string when the probe fails - writeHostRecord refuses such a record. */
 export function ownStartTime(): string {
   return readProcInfo(process.pid).startTime ?? "";
+}
+
+/** Own process-group id via the OS, or null when unreadable. The host records
+ *  itself only when it truly is a group leader (pgid === pid) - the property
+ *  the reaper's kill(-pgid) depends on - rather than assuming detached spawn. */
+export function ownPgid(): number | null {
+  try {
+    const out = execFileSync("ps", ["-p", String(process.pid), "-o", "pgid="], {
+      encoding: "utf8",
+      env: PS_ENV,
+    }).trim();
+    const pgid = Number(out);
+    return Number.isInteger(pgid) && pgid > 0 ? pgid : null;
+  } catch {
+    return null;
+  }
 }
 
 export interface ReapDeps {
@@ -211,10 +305,11 @@ export interface ReapDeps {
 }
 
 export interface ReapSummary {
-  reaped: number[]; // host pids whose tree we force-killed
-  killedDescendants: number[];
+  reaped: number[]; // host pids whose group we force-killed
+  killedDescendants: number[]; // pids observed in the killed groups (log only)
   keptCompatible: number[]; // records matching the expected identity (left alive)
-  gc: number[]; // dead/unverifiable records removed without signaling
+  gc: number[]; // records whose pid is verifiably gone/reused (removed, no signal)
+  skipped: number[]; // indeterminate identity or failed probe - left untouched
 }
 
 const defaultDeps = (): ReapDeps => ({
@@ -226,13 +321,18 @@ const defaultDeps = (): ReapDeps => ({
 
 /** Reconcile the registry on launch: KEEP a recorded host whose identity matches
  *  what we would spawn (#28 - survive same-version restart); force-kill the whole
- *  process TREE of any STALE (version/scriptHash-mismatched) host we can verify
- *  by pid (fail-closed via isReapableHost); GC records whose process is gone or
- *  can't be verified (removed WITHOUT signaling - never a blind kill).
+ *  process GROUP of any STALE (version/scriptHash-mismatched) host we can verify
+ *  by pid (fail-closed via isReapableHost); GC records whose process is verifiably
+ *  gone or reused (removed WITHOUT signaling - never a blind kill); SKIP records
+ *  we cannot judge this launch (failed probe, "unknown" hash sentinel) so a live
+ *  host never loses its record to a transient failure.
  *
  *  The kill targets the whole process GROUP (kill(-pgid)) of a just-verified,
  *  still-alive detached leader - atomic, and free of the enumerate-then-kill
  *  reuse race (a snapshotted child pid could be reused before we signal it).
+ *  POSIX delivers a group signal to every member INCLUDING the leader, so there
+ *  is deliberately no follow-up kill(pid) - that would be the one unverified
+ *  signal in the file and would reopen the reuse window the group kill closes.
  *  Known limits (accepted for now): a descendant that called setsid() escapes the
  *  group, and a leader that dies in the microseconds before the kill could let
  *  its pgid be reused. Deps are injectable so the decision + signalling are
@@ -243,20 +343,45 @@ export function reapStaleHostRecords(
   dir: string = HOST_REGISTRY_DIR,
   deps: ReapDeps = defaultDeps(),
 ): ReapSummary {
-  const summary: ReapSummary = { reaped: [], killedDescendants: [], keptCompatible: [], gc: [] };
+  const summary: ReapSummary = {
+    reaped: [],
+    killedDescendants: [],
+    keptCompatible: [],
+    gc: [],
+    skipped: [],
+  };
   const records = readHostRecords(dir);
   if (records.length === 0) return summary;
 
-  const isCompatible = (r: HostRecord) =>
-    r.version === expected.version && r.scriptHash === expected.scriptHash;
+  // Full-system snapshot only if a kill actually happens (log decoration is not
+  // worth a per-launch system-wide ps on the common keep path).
+  let procs: Array<{ pid: number; ppid: number }> | null = null;
 
-  const procs = deps.listProcs();
   for (const rec of records) {
-    if (isCompatible(rec)) {
+    const info = deps.readProcInfo(rec.pid);
+    if (info.probeFailed) {
+      // ps itself failed - the pid's state is unknown. Keep the record; a live
+      // stale host must not lose its only reapability pointer to a transient
+      // probe failure.
+      summary.skipped.push(rec.pid);
+      continue;
+    }
+    const kind = classifyRecord(rec, expected);
+    if (kind === "indeterminate") {
+      // Identity can't be compared ("unknown" hash) so NEVER kill - but GC is
+      // still safe when a successful probe shows the pid conclusively gone or
+      // reused; otherwise dead unknown-hash records would accumulate forever.
+      if (isSameRecordedProcess(rec, info, hostScript)) summary.skipped.push(rec.pid);
+      else {
+        removeHostRecord(rec.pid, dir);
+        summary.gc.push(rec.pid);
+      }
+      continue;
+    }
+    if (kind === "compatible") {
       // A same-build host: keep it (we'll connect to it) only if it's verifiably
       // the exact process we recorded; a dead OR reused pid gets GC'd (checking
       // start time, not just liveness, so a reused pid isn't mistaken for ours).
-      const info = deps.readProcInfo(rec.pid);
       if (isSameRecordedProcess(rec, info, hostScript)) summary.keptCompatible.push(rec.pid);
       else {
         removeHostRecord(rec.pid, dir);
@@ -265,29 +390,26 @@ export function reapStaleHostRecords(
       continue;
     }
     // Stale record. Only signal if we are CERTAIN this pid is that exact host.
-    const info = deps.readProcInfo(rec.pid);
     if (!isReapableHost(rec, info, hostScript, deps.selfPid)) {
       removeHostRecord(rec.pid, dir);
       summary.gc.push(rec.pid);
       continue;
     }
-    // Force-kill the whole process GROUP atomically. The host is a detached
-    // session leader (spawned with detached:true => setsid), so pgid == pid and
-    // every non-detached descendant is in its group. kill(-pgid) avoids the
-    // enumerate-then-kill TOCTOU (a listed child pid could be reused before we
-    // signal it); the group id is not reused while any member lives, and we just
-    // verified the leader alive - so the group is unambiguously ours.
-    const observed = collectDescendants(rec.pid, procs); // for the log only, never a kill target
+    procs ??= deps.listProcs();
+    const observed = collectDescendants(rec.pid, procs); // log only, never a kill target
     try {
       deps.kill(-rec.pgid, "SIGKILL");
-    } catch {
-      // group already gone
-    }
-    // Belt-and-suspenders: the leader itself (idempotent if the group kill got it).
-    try {
-      deps.kill(rec.pid, "SIGKILL");
-    } catch {
-      // already gone
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ESRCH") {
+        // EPERM or an unexpected error: the group may still be ALIVE and we
+        // failed to signal it. Removing the record now would strand a live
+        // stale host with no reapability pointer - keep it for a retry.
+        summary.skipped.push(rec.pid);
+        continue;
+      }
+      // ESRCH: the group vanished between probe and kill - safe to fall
+      // through and drop the record.
     }
     summary.killedDescendants.push(...observed);
     removeHostRecord(rec.pid, dir);

--- a/electron/pty-host-registry.ts
+++ b/electron/pty-host-registry.ts
@@ -1,0 +1,297 @@
+// Registry of detached PTY-host instances, used to reap STALE hosts (and their
+// process trees) that a normal app restart intentionally leaves alive (#28).
+//
+// The reap kills processes, so every decision here is FAIL-CLOSED: we only ever
+// signal a PID we are confident is the exact host a record describes. Any
+// uncertainty (PID reuse, missing metadata, cmdline mismatch) -> skip the kill.
+//
+// Off-socket hosts can't be authenticated via the socket handshake, so the
+// cross-check is: the process is still alive, its OS start time matches the one
+// recorded at spawn (the classic stale-PID-file defense), and its command line
+// still looks like our host script. All three must hold.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { AYA_HOME } from "./paths";
+
+export interface HostRecord {
+  /** Host process pid (also its process-group leader: spawned detached). */
+  pid: number;
+  /** Process-group id (== pid for a detached leader; recorded for tree kill). */
+  pgid: number;
+  version: string;
+  scriptHash: string;
+  /** OS-reported start time (`ps -o lstart`) captured at spawn. Opaque string,
+   *  compared for exact equality to defend against PID reuse. */
+  startTime: string;
+  /** Random per-instance token (socket-handshake cross-check, future use). */
+  nonce: string;
+}
+
+export interface ProcInfo {
+  alive: boolean;
+  /** `ps -o lstart` for the pid, or null if it could not be read. */
+  startTime: string | null;
+  /** `ps -o command` for the pid, or null. */
+  command: string | null;
+}
+
+export const HOST_REGISTRY_DIR = path.join(AYA_HOME, "pty-hosts");
+
+const recordPath = (dir: string, pid: number): string =>
+  path.join(dir, `${pid}.json`);
+
+/** Atomically write a host's record (tmp + rename). Best-effort. */
+export function writeHostRecord(rec: HostRecord, dir: string = HOST_REGISTRY_DIR): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${recordPath(dir, rec.pid)}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(rec), { mode: 0o600 });
+    fs.renameSync(tmp, recordPath(dir, rec.pid));
+  } catch {
+    // best effort; a missing record just means this host won't be reaped by pid
+  }
+}
+
+/** Read all valid host records in the registry (skips malformed files). */
+export function readHostRecords(dir: string = HOST_REGISTRY_DIR): HostRecord[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: HostRecord[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, name), "utf8")) as unknown;
+      if (isHostRecord(rec)) out.push(rec);
+    } catch {
+      // skip malformed / partial writes
+    }
+  }
+  return out;
+}
+
+/** Remove a host's record (on clean exit, or after a confirmed reap / GC). */
+export function removeHostRecord(pid: number, dir: string = HOST_REGISTRY_DIR): void {
+  try {
+    fs.rmSync(recordPath(dir, pid), { force: true });
+  } catch {
+    // best effort
+  }
+}
+
+function isHostRecord(v: unknown): v is HostRecord {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.pid === "number" &&
+    typeof r.pgid === "number" &&
+    typeof r.version === "string" &&
+    typeof r.scriptHash === "string" &&
+    typeof r.startTime === "string" &&
+    typeof r.nonce === "string"
+  );
+}
+
+/** Is the live pid the EXACT process we recorded? Alive, start time matches
+ *  exactly (PID-reuse defense), and the command still runs a pty-host script.
+ *  The start-time equality is the real authenticator; the command basename check
+ *  (not full path - a stale host lives in an older/different bundle) only rejects
+ *  a reused pid now running something unrelated. */
+export function isSameRecordedProcess(
+  rec: HostRecord,
+  info: ProcInfo,
+  hostScript: string,
+): boolean {
+  if (!info.alive) return false;
+  if (!info.startTime || info.startTime !== rec.startTime) return false;
+  const scriptName = hostScript.slice(hostScript.lastIndexOf("/") + 1) || hostScript;
+  if (!info.command || !info.command.includes(scriptName)) return false;
+  return true;
+}
+
+/** FAIL-CLOSED gate: may we SIGKILL (by process group) the host `rec` describes?
+ *  Adds the kill-only guards on top of the identity check: never our own pid,
+ *  never init/invalid, and the record MUST be a detached group leader (pgid ==
+ *  pid) so kill(-pgid) targets exactly that host's own group and not some other
+ *  group a corrupted/foreign record might name. */
+export function isReapableHost(
+  rec: HostRecord,
+  info: ProcInfo,
+  hostScript: string,
+  selfPid: number,
+): boolean {
+  if (rec.pid === selfPid) return false; // never reap ourselves
+  if (rec.pid <= 1) return false; // never signal init / invalid pids
+  if (rec.pgid !== rec.pid) return false; // must be a detached leader (pgid==pid)
+  return isSameRecordedProcess(rec, info, hostScript);
+}
+
+/** All descendant pids of `rootPid`, recursively, from a (pid,ppid) list.
+ *  Cycle-safe. Excludes the root itself. */
+export function collectDescendants(
+  rootPid: number,
+  procs: Array<{ pid: number; ppid: number }>,
+): number[] {
+  const childrenOf = new Map<number, number[]>();
+  for (const p of procs) {
+    const arr = childrenOf.get(p.ppid);
+    if (arr) arr.push(p.pid);
+    else childrenOf.set(p.ppid, [p.pid]);
+  }
+  const out: number[] = [];
+  const seen = new Set<number>([rootPid]);
+  const stack = [rootPid];
+  while (stack.length) {
+    const cur = stack.pop() as number;
+    for (const child of childrenOf.get(cur) ?? []) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      out.push(child);
+      stack.push(child);
+    }
+  }
+  return out;
+}
+
+// --- Impure OS probes (thin wrappers; injected in tests) ------------------
+
+/** `ps` fields for one pid. Returns alive:false when the pid is gone. */
+export function readProcInfo(pid: number): ProcInfo {
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart=,command="], {
+      encoding: "utf8",
+      // Force C locale so `lstart` is the stable 24-char English ctime we slice
+      // on below - a localized month/day name would shift the column and could
+      // corrupt the start-time comparison the reuse guard depends on.
+      env: { ...process.env, LC_ALL: "C", LANG: "C" },
+    }).trim();
+    if (!out) return { alive: false, startTime: null, command: null };
+    // lstart is a fixed 24-char ctime string; the rest is the command.
+    const lstart = out.slice(0, 24).trim();
+    const command = out.slice(24).trim();
+    return { alive: true, startTime: lstart, command };
+  } catch {
+    return { alive: false, startTime: null, command: null };
+  }
+}
+
+/** Snapshot of (pid, ppid) for every process (for descendant enumeration). */
+export function listProcs(): Array<{ pid: number; ppid: number }> {
+  try {
+    const out = execFileSync("ps", ["-Ao", "pid=,ppid="], {
+      encoding: "utf8",
+      env: { ...process.env, LC_ALL: "C", LANG: "C" },
+    });
+    const rows: Array<{ pid: number; ppid: number }> = [];
+    for (const line of out.split("\n")) {
+      const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+      if (m) rows.push({ pid: Number(m[1]), ppid: Number(m[2]) });
+    }
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/** Own OS start time, recorded so a later reaper can verify identity. */
+export function ownStartTime(): string {
+  return readProcInfo(process.pid).startTime ?? "";
+}
+
+export interface ReapDeps {
+  readProcInfo: (pid: number) => ProcInfo;
+  listProcs: () => Array<{ pid: number; ppid: number }>;
+  kill: (pid: number, signal: NodeJS.Signals) => void;
+  selfPid: number;
+}
+
+export interface ReapSummary {
+  reaped: number[]; // host pids whose tree we force-killed
+  killedDescendants: number[];
+  keptCompatible: number[]; // records matching the expected identity (left alive)
+  gc: number[]; // dead/unverifiable records removed without signaling
+}
+
+const defaultDeps = (): ReapDeps => ({
+  readProcInfo,
+  listProcs,
+  kill: (pid, signal) => process.kill(pid, signal),
+  selfPid: process.pid,
+});
+
+/** Reconcile the registry on launch: KEEP a recorded host whose identity matches
+ *  what we would spawn (#28 - survive same-version restart); force-kill the whole
+ *  process TREE of any STALE (version/scriptHash-mismatched) host we can verify
+ *  by pid (fail-closed via isReapableHost); GC records whose process is gone or
+ *  can't be verified (removed WITHOUT signaling - never a blind kill).
+ *
+ *  The kill targets the whole process GROUP (kill(-pgid)) of a just-verified,
+ *  still-alive detached leader - atomic, and free of the enumerate-then-kill
+ *  reuse race (a snapshotted child pid could be reused before we signal it).
+ *  Known limits (accepted for now): a descendant that called setsid() escapes the
+ *  group, and a leader that dies in the microseconds before the kill could let
+ *  its pgid be reused. Deps are injectable so the decision + signalling are
+ *  unit-testable without real processes. */
+export function reapStaleHostRecords(
+  expected: { version: string; scriptHash: string },
+  hostScript: string,
+  dir: string = HOST_REGISTRY_DIR,
+  deps: ReapDeps = defaultDeps(),
+): ReapSummary {
+  const summary: ReapSummary = { reaped: [], killedDescendants: [], keptCompatible: [], gc: [] };
+  const records = readHostRecords(dir);
+  if (records.length === 0) return summary;
+
+  const isCompatible = (r: HostRecord) =>
+    r.version === expected.version && r.scriptHash === expected.scriptHash;
+
+  const procs = deps.listProcs();
+  for (const rec of records) {
+    if (isCompatible(rec)) {
+      // A same-build host: keep it (we'll connect to it) only if it's verifiably
+      // the exact process we recorded; a dead OR reused pid gets GC'd (checking
+      // start time, not just liveness, so a reused pid isn't mistaken for ours).
+      const info = deps.readProcInfo(rec.pid);
+      if (isSameRecordedProcess(rec, info, hostScript)) summary.keptCompatible.push(rec.pid);
+      else {
+        removeHostRecord(rec.pid, dir);
+        summary.gc.push(rec.pid);
+      }
+      continue;
+    }
+    // Stale record. Only signal if we are CERTAIN this pid is that exact host.
+    const info = deps.readProcInfo(rec.pid);
+    if (!isReapableHost(rec, info, hostScript, deps.selfPid)) {
+      removeHostRecord(rec.pid, dir);
+      summary.gc.push(rec.pid);
+      continue;
+    }
+    // Force-kill the whole process GROUP atomically. The host is a detached
+    // session leader (spawned with detached:true => setsid), so pgid == pid and
+    // every non-detached descendant is in its group. kill(-pgid) avoids the
+    // enumerate-then-kill TOCTOU (a listed child pid could be reused before we
+    // signal it); the group id is not reused while any member lives, and we just
+    // verified the leader alive - so the group is unambiguously ours.
+    const observed = collectDescendants(rec.pid, procs); // for the log only, never a kill target
+    try {
+      deps.kill(-rec.pgid, "SIGKILL");
+    } catch {
+      // group already gone
+    }
+    // Belt-and-suspenders: the leader itself (idempotent if the group kill got it).
+    try {
+      deps.kill(rec.pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+    summary.killedDescendants.push(...observed);
+    removeHostRecord(rec.pid, dir);
+    summary.reaped.push(rec.pid);
+  }
+  return summary;
+}

--- a/electron/pty-host-sweep.ts
+++ b/electron/pty-host-sweep.ts
@@ -1,0 +1,319 @@
+// Phase-2 legacy sweep: clean up Aya processes the registry (pty-host-registry)
+// structurally cannot reach - detached PTY hosts that PREDATE the registry (no
+// record file), and orphaned terminal children whose host already died (the
+// process group persists while members live, but a leader-based registry check
+// can never authorize killing it).
+//
+// Like the registry reap, every kill decision is FAIL-CLOSED and re-verified by
+// a fresh per-pid probe IMMEDIATELY before signaling:
+//  - S1 (stray hosts): a process only qualifies when its command line contains
+//    the highly specific "dist-electron/pty-host" script path, it runs as our
+//    uid, it is a detached group leader (pgid == pid), its env's AYA scope
+//    (AYA_HOME / AYA_DEV) matches OURS (so a prod app never kills a dev
+//    workflow's host or an isolated E2E fixture host), and it is not the
+//    current socket host / a registry-kept host / ourselves. Kill = one atomic
+//    kill(-pid) of its own verified group.
+//  - S2 (orphaned children): a process only qualifies when it belongs to a
+//    process group whose LEADER IS GONE, runs as our uid, and its env carries
+//    AYA_TERMINAL_ID= - the marker safeEnv stamps on every terminal child (and
+//    its descendants inherit). The env probe doubles as the just-before-kill
+//    re-verification (a reused pid shows a different env / group).
+// Any probe failure, scope mismatch, or ambiguity -> skip, never kill.
+
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AYA_HOME } from "./paths";
+
+/** One row of the system process snapshot. */
+export interface ProcRow {
+  uid: number;
+  pid: number;
+  ppid: number;
+  pgid: number;
+  command: string;
+}
+
+/** Fresh per-pid probe result: current group + command WITH environment (ps
+ *  eww), or null when the probe failed / the pid is gone. */
+export interface EnvProbe {
+  pgid: number;
+  /** `ps eww -o command=` output: argv followed by the process environment. */
+  commandWithEnv: string;
+}
+
+/** Markers safeEnv puts in EVERY terminal child's environment (both, always).
+ *  The leading space anchors each as a distinct entry in the `ps eww` dump;
+ *  requiring both makes an accidental argv collision (a grep/editor with one
+ *  of the strings in its arguments) implausible. */
+const AYA_CHILD_MARKER = " AYA_TERMINAL_ID=";
+const AYA_HOME_MARKER = " AYA_HOME=";
+/** Env marker every PTY host carries: the client spawns it with
+ *  ELECTRON_RUN_AS_NODE=1. An editor/grep/test-runner that merely mentions the
+ *  host script path in its ARGUMENTS does not run as-node. */
+const HOST_ENV_MARKER = " ELECTRON_RUN_AS_NODE=1";
+
+/** Does this command line LOOK like a PTY host's argv? The host is spawned as
+ *  exactly [execPath, hostScript], so the script path must be the SECOND
+ *  whitespace token - a substring match anywhere in the arguments (an editor
+ *  session, a grep, a test runner touching this very file) must never qualify.
+ *  Exec paths containing spaces fail closed (that host just isn't swept). */
+export function isHostArgv(command: string): boolean {
+  const m = command.match(/^\S+\s+(\S+)/);
+  return !!m && m[1].endsWith("dist-electron/pty-host.js");
+}
+// Per-pid env probes fork `ps` each - bound the orphan scan so a pathological
+// process table can't stall startup. Anything past the cap is logged, not
+// silently dropped (it gets another chance next launch).
+export const MAX_ORPHAN_PROBES = 64;
+
+/** The AYA "scope" (config home) a process runs under, parsed from its env
+ *  dump: explicit AYA_HOME= wins; else AYA_DEV=1 implies ~/.aya-dev; else the
+ *  default ~/.aya. Mirrors electron/paths.ts. Used so a sweep only ever kills
+ *  hosts belonging to ITS OWN scope. */
+export function scopeFromEnvDump(commandWithEnv: string, homedir: string): string {
+  const m = commandWithEnv.match(/ AYA_HOME=([^ ]+)/);
+  if (m) return path.resolve(m[1]);
+  if (commandWithEnv.includes(" AYA_DEV=1")) return path.join(homedir, ".aya-dev");
+  return path.join(homedir, ".aya");
+}
+
+/** Parse `ps -Axo uid=,pid=,ppid=,pgid=,command=` output. Malformed lines are
+ *  dropped (fail-closed: an unparseable row can never become a kill target). */
+export function parseSnapshot(psOutput: string): ProcRow[] {
+  const rows: ProcRow[] = [];
+  for (const line of psOutput.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+    if (!m) continue;
+    rows.push({
+      uid: Number(m[1]),
+      pid: Number(m[2]),
+      ppid: Number(m[3]),
+      pgid: Number(m[4]),
+      command: m[5].trim(),
+    });
+  }
+  return rows;
+}
+
+/** S1 candidates: processes that LOOK like stray PTY hosts. Snapshot-level
+ *  filter only - each candidate is re-verified by a fresh env probe (signature
+ *  still present, scope matches) before any signal. */
+export function selectStrayHostCandidates(
+  rows: ProcRow[],
+  opts: { uid: number; selfPid: number; excludePids: ReadonlySet<number> },
+): ProcRow[] {
+  return rows.filter(
+    (r) =>
+      // Snapshot command is pure argv (no `e` flag) - positional check is exact.
+      isHostArgv(r.command) &&
+      r.uid === opts.uid &&
+      r.pid !== opts.selfPid &&
+      r.pid > 1 &&
+      !opts.excludePids.has(r.pid) &&
+      // Only a detached leader can be group-killed as "its own" group; a
+      // non-leader host (shouldn't exist) is skipped rather than guessed at.
+      r.pgid === r.pid,
+  );
+}
+
+/** S2 candidates: members of process groups whose leader no longer exists.
+ *  Skips our own group, host-looking processes (S1 territory), foreign uids,
+ *  and system groups. Each candidate still needs the AYA_TERMINAL_ID env
+ *  marker (checked via the per-pid probe) before it can be killed. */
+export function selectOrphanCandidates(
+  rows: ProcRow[],
+  opts: { uid: number; selfPid: number; selfPgid: number },
+): ProcRow[] {
+  const livePids = new Set(rows.map((r) => r.pid));
+  return rows.filter(
+    (r) =>
+      r.uid === opts.uid &&
+      r.pid !== opts.selfPid &&
+      r.pid > 1 &&
+      r.pgid > 1 &&
+      r.pgid !== opts.selfPgid &&
+      !livePids.has(r.pgid) && // group leader is GONE -> orphaned group
+      !isHostArgv(r.command), // hosts are S1's job
+  );
+}
+
+export interface SweepDeps {
+  snapshot: () => ProcRow[];
+  envProbe: (pid: number) => EnvProbe | null;
+  /** Fresh, direct leader-liveness check: true = leader CONFIRMED gone (ps ran
+   *  and found no such pid), false = leader alive, null = probe failed
+   *  (unknown). S2 kills only on a confirmed-gone leader - the snapshot alone
+   *  could have silently dropped a LIVE host's row (parse hiccup, truncation)
+   *  and its children must never be mistaken for orphans. */
+  leaderGone: (pgid: number) => boolean | null;
+  kill: (pid: number, signal: NodeJS.Signals) => void;
+  uid: number;
+  selfPid: number;
+  selfPgid: number;
+  ayaHome: string;
+  homedir: string;
+}
+
+export interface SweepSummary {
+  sweptHosts: number[]; // stray host leaders whose groups were killed
+  sweptOrphans: number[]; // dead-leader-group members killed individually
+  skipped: number[]; // candidates left alone (probe failed / scope or marker mismatch)
+  truncated: number; // orphan candidates beyond the probe cap (retried next launch)
+}
+
+const defaultDeps = (): SweepDeps => ({
+  snapshot: readSnapshot,
+  envProbe: readEnvProbe,
+  leaderGone: readLeaderGone,
+  kill: (pid, signal) => process.kill(pid, signal),
+  uid: process.getuid?.() ?? -1,
+  selfPid: process.pid,
+  selfPgid: (() => {
+    try {
+      return readEnvProbe(process.pid)?.pgid ?? -1;
+    } catch {
+      return -1;
+    }
+  })(),
+  ayaHome: AYA_HOME,
+  homedir: os.homedir(),
+});
+
+/** Run the legacy sweep. Both passes re-verify every candidate with a fresh
+ *  per-pid probe right before signaling; anything ambiguous is skipped. The
+ *  stray-host pass can be disabled (passes.strayHosts=false) when the caller
+ *  cannot positively identify the CURRENT socket host to exclude it - killing
+ *  hosts without that exclusion would risk sweeping the live one. */
+export function sweepLegacyAyaProcesses(
+  excludePids: ReadonlySet<number>,
+  deps: SweepDeps = defaultDeps(),
+  passes: { strayHosts: boolean } = { strayHosts: true },
+): SweepSummary {
+  const summary: SweepSummary = { sweptHosts: [], sweptOrphans: [], skipped: [], truncated: 0 };
+  if (deps.uid < 0) return summary; // no uid (should not happen on mac/linux) -> do nothing
+  const rows = deps.snapshot();
+  if (rows.length === 0) return summary;
+
+  // --- S1: stray PTY hosts (no registry record needed) ---
+  const strayCandidates = passes.strayHosts
+    ? selectStrayHostCandidates(rows, {
+        uid: deps.uid,
+        selfPid: deps.selfPid,
+        excludePids,
+      })
+    : [];
+  for (const cand of strayCandidates) {
+    const probe = deps.envProbe(cand.pid);
+    if (
+      !probe ||
+      probe.pgid !== cand.pid || // no longer (or never was) its own leader
+      !isHostArgv(probe.commandWithEnv) || // pid reused / not a host's argv shape
+      !probe.commandWithEnv.includes(HOST_ENV_MARKER) || // every real host runs as-node
+      scopeFromEnvDump(probe.commandWithEnv, deps.homedir) !== deps.ayaHome // other workflow's host
+    ) {
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    try {
+      deps.kill(-cand.pid, "SIGKILL"); // atomic: the verified leader's own group
+      summary.sweptHosts.push(cand.pid);
+    } catch {
+      summary.skipped.push(cand.pid); // vanished or not permitted - leave it
+    }
+  }
+
+  // --- S2: orphaned terminal children in dead-leader groups ---
+  const orphans = selectOrphanCandidates(rows, {
+    uid: deps.uid,
+    selfPid: deps.selfPid,
+    selfPgid: deps.selfPgid,
+  });
+  const bounded = orphans.slice(0, MAX_ORPHAN_PROBES);
+  summary.truncated = orphans.length - bounded.length;
+  // A snapshot that silently dropped a LIVE host's row (parse hiccup) would
+  // make its children look orphaned - so leader absence must be re-confirmed
+  // by a direct probe before ANY member of that group is killed. Cache per
+  // group: one extra ps per dead group, not per member.
+  const leaderGoneCache = new Map<number, boolean | null>();
+  for (const cand of bounded) {
+    let gone = leaderGoneCache.get(cand.pgid);
+    if (gone === undefined) {
+      gone = deps.leaderGone(cand.pgid);
+      leaderGoneCache.set(cand.pgid, gone);
+    }
+    if (gone !== true) {
+      // Leader alive (snapshot lied) or probe failed -> these are NOT orphans.
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    const probe = deps.envProbe(cand.pid);
+    if (
+      !probe ||
+      probe.pgid !== cand.pgid || // moved groups since the snapshot (pid reuse)
+      !probe.commandWithEnv.includes(AYA_CHILD_MARKER) || // not an Aya terminal descendant
+      !probe.commandWithEnv.includes(AYA_HOME_MARKER) // safeEnv always sets BOTH markers
+    ) {
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    try {
+      deps.kill(cand.pid, "SIGKILL");
+      summary.sweptOrphans.push(cand.pid);
+    } catch {
+      summary.skipped.push(cand.pid);
+    }
+  }
+  return summary;
+}
+
+// --- Impure OS probes (injected in tests) ----------------------------------
+
+const PS_ENV = { ...process.env, LC_ALL: "C", LANG: "C", TZ: "UTC" };
+
+/** Full system snapshot: uid, pid, ppid, pgid, command per process. */
+export function readSnapshot(): ProcRow[] {
+  try {
+    const out = execFileSync("ps", ["-Axo", "uid=,pid=,ppid=,pgid=,command="], {
+      encoding: "utf8",
+      env: PS_ENV,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return parseSnapshot(out);
+  } catch {
+    return [];
+  }
+}
+
+/** Direct leader-liveness probe. true = ps ran and CONFIRMED the pid gone
+ *  (non-zero exit with a numeric status), false = pid alive, null = the probe
+ *  itself failed (spawn error) - state unknown, callers must skip. */
+export function readLeaderGone(pid: number): boolean | null {
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "pid="], {
+      encoding: "utf8",
+      env: PS_ENV,
+    }).trim();
+    return out ? false : true;
+  } catch (err) {
+    const status = (err as { status?: unknown }).status;
+    return typeof status === "number" ? true : null;
+  }
+}
+
+/** Per-pid probe: current pgid + command INCLUDING the environment (`ps eww`).
+ *  Null when the pid is gone or ps failed - callers must skip, never kill. */
+export function readEnvProbe(pid: number): EnvProbe | null {
+  try {
+    const out = execFileSync("ps", ["eww", "-p", String(pid), "-o", "pgid=,command="], {
+      encoding: "utf8",
+      env: PS_ENV,
+      maxBuffer: 4 * 1024 * 1024,
+    }).trim();
+    const m = out.match(/^\s*(\d+)\s+(.+)$/s);
+    if (!m) return null;
+    return { pgid: Number(m[1]), commandWithEnv: m[2] };
+  } catch {
+    return null;
+  }
+}

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -14,7 +14,7 @@ import {
   activePtyCount,
   getBufferedOutput,
   killPty,
-  killAll,
+  shutdownPtyChildren,
   resizePty,
   searchPtyOutputs,
   spawnPty,
@@ -85,11 +85,15 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
     return null;
   }
   if (request.type === "shutdown") {
-    killAll();
     // Drop the socket synchronously so a client spawning a fresh host can't
     // reconnect to this exiting process in the window before exit.
     closeSocket();
-    setTimeout(() => process.exit(0), 0);
+    // Graceful-kill every child and exit as soon as they're all dead, escalating
+    // any survivor (e.g. a SIGHUP-ignoring `claude --chrome`) to SIGKILL at the
+    // deadline. Event-driven so a clean quit isn't delayed by a fixed timer, and
+    // - unlike a bare `process.exit(0)` - the host stays alive long enough to
+    // actually deliver the escalation, so no stuck child is left orphaned.
+    shutdownPtyChildren(() => process.exit(0));
     return null;
   }
   if (request.type === "search") {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -4,6 +4,7 @@ import * as net from "node:net";
 import * as path from "node:path";
 import { PTY_HOST_SOCKET_PATH, SOCKET_FILE_PERMISSIONS } from "./paths";
 import type { HostIdentity } from "./pty-host-staleness";
+import { writeHostRecord, removeHostRecord, ownStartTime } from "./pty-host-registry";
 import {
   type PtyHostEventMessage,
   type PtyHostRequest,
@@ -44,6 +45,12 @@ function closeSocket(): void {
   } catch {
     // best effort
   }
+  // NOTE: the registry record is deliberately NOT removed here. closeSocket runs
+  // on SIGTERM/SIGINT/exit, i.e. potentially while child PTYs are still alive; if
+  // we dropped the record now and the host then died, surviving children would be
+  // unreapable orphans (no record to find them by). The record is removed only
+  // after a clean shutdown confirms the children are dead (see the shutdown
+  // handler); otherwise the next launch GCs it once the pid is verified gone.
 }
 
 function sendLine(socket: net.Socket, value: PtyHostResponse | PtyHostEventMessage): void {
@@ -93,7 +100,13 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
     // deadline. Event-driven so a clean quit isn't delayed by a fixed timer, and
     // - unlike a bare `process.exit(0)` - the host stays alive long enough to
     // actually deliver the escalation, so no stuck child is left orphaned.
-    shutdownPtyChildren(() => process.exit(0));
+    shutdownPtyChildren(() => {
+      // Children are confirmed dead now - safe to drop our registry record (a
+      // signal/crash exit skips this and leaves the record for the next launch
+      // to GC once the pid is verified gone).
+      removeHostRecord(process.pid);
+      process.exit(0);
+    });
     return null;
   }
   if (request.type === "search") {
@@ -197,6 +210,18 @@ function start(): void {
     } catch {
       // best effort
     }
+    // Publish our registry record so a future app version can reap THIS host by
+    // pid if it turns out stale (spawned detached, we're our own group leader so
+    // pgid == pid). Written after listen so the record only exists once we're
+    // actually serving.
+    writeHostRecord({
+      pid: process.pid,
+      pgid: process.pid,
+      version: HOST_IDENTITY.version,
+      scriptHash: HOST_IDENTITY.scriptHash,
+      startTime: ownStartTime(),
+      nonce: crypto.randomBytes(8).toString("hex"),
+    });
   });
 
   process.once("SIGTERM", closeSocket);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -4,7 +4,12 @@ import * as net from "node:net";
 import * as path from "node:path";
 import { PTY_HOST_SOCKET_PATH, SOCKET_FILE_PERMISSIONS } from "./paths";
 import type { HostIdentity } from "./pty-host-staleness";
-import { writeHostRecord, removeHostRecord, ownStartTime } from "./pty-host-registry";
+import {
+  writeHostRecord,
+  removeHostRecord,
+  ownStartTime,
+  ownPgid,
+} from "./pty-host-registry";
 import {
   type PtyHostEventMessage,
   type PtyHostRequest,
@@ -34,6 +39,30 @@ let server: net.Server | null = null;
 /** Stop accepting connections and remove the socket file. Called on a clean
  *  shutdown BEFORE the process exits (so a client restarting the host can't
  *  reconnect to this dying process) and again on process-exit signals. */
+// Guards against overlapping shutdowns (a socket "shutdown" request racing a
+// SIGTERM): the SECOND shutdownPtyChildren call would find the ptys map already
+// drained by the first, take the empty-children fast path, and process.exit(0)
+// BEFORE the first call's 750ms SIGKILL escalation could fire - orphaning the
+// very stuck children the ladder exists to kill. First caller owns the exit.
+let hostShutdownStarted = false;
+
+/** Graceful host shutdown, idempotent: drop the socket synchronously (so a
+ *  client spawning a fresh host can't reconnect to this exiting process), kill
+ *  every child via the graceful->SIGKILL escalation ladder (event-driven, so a
+ *  clean quit isn't delayed by a fixed timer, and - unlike a bare
+ *  process.exit(0) - the host stays alive long enough to actually deliver the
+ *  escalation), then remove the registry record (children confirmed dead; a
+ *  crash exit skips this and leaves the record for next-launch GC) and exit. */
+function beginShutdown(): void {
+  if (hostShutdownStarted) return; // the in-flight shutdown owns the exit
+  hostShutdownStarted = true;
+  closeSocket();
+  shutdownPtyChildren(() => {
+    removeHostRecord(process.pid);
+    process.exit(0);
+  });
+}
+
 function closeSocket(): void {
   try {
     server?.close();
@@ -92,21 +121,7 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
     return null;
   }
   if (request.type === "shutdown") {
-    // Drop the socket synchronously so a client spawning a fresh host can't
-    // reconnect to this exiting process in the window before exit.
-    closeSocket();
-    // Graceful-kill every child and exit as soon as they're all dead, escalating
-    // any survivor (e.g. a SIGHUP-ignoring `claude --chrome`) to SIGKILL at the
-    // deadline. Event-driven so a clean quit isn't delayed by a fixed timer, and
-    // - unlike a bare `process.exit(0)` - the host stays alive long enough to
-    // actually deliver the escalation, so no stuck child is left orphaned.
-    shutdownPtyChildren(() => {
-      // Children are confirmed dead now - safe to drop our registry record (a
-      // signal/crash exit skips this and leaves the record for the next launch
-      // to GC once the pid is verified gone).
-      removeHostRecord(process.pid);
-      process.exit(0);
-    });
+    beginShutdown();
     return null;
   }
   if (request.type === "search") {
@@ -116,7 +131,9 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
     return getBufferedOutput(request.ptyId);
   }
   if (request.type === "version") {
-    return { ...HOST_IDENTITY, ptyCount: activePtyCount() };
+    // pid lets a client correlate the socket-connected host with a registry
+    // record (e.g. to spot a same-version host stranded off-socket).
+    return { ...HOST_IDENTITY, ptyCount: activePtyCount(), pid: process.pid };
   }
   throw new Error("unknown request");
 }
@@ -211,21 +228,33 @@ function start(): void {
       // best effort
     }
     // Publish our registry record so a future app version can reap THIS host by
-    // pid if it turns out stale (spawned detached, we're our own group leader so
-    // pgid == pid). Written after listen so the record only exists once we're
-    // actually serving.
-    writeHostRecord({
-      pid: process.pid,
-      pgid: process.pid,
-      version: HOST_IDENTITY.version,
-      scriptHash: HOST_IDENTITY.scriptHash,
-      startTime: ownStartTime(),
-      nonce: crypto.randomBytes(8).toString("hex"),
-    });
+    // pid if it turns out stale. Written after listen so the record only exists
+    // once we're actually serving. Leadership is VERIFIED via the OS, not
+    // assumed from detached spawn: the reaper's kill(-pgid) is only safe when
+    // this process really leads its own group, so if it doesn't (alternate
+    // launcher, future spawn change) we skip the record - degrading to
+    // pre-registry behavior instead of recording an unkillable/foreign group.
+    // writeHostRecord itself refuses an empty startTime (unverifiable record).
+    const pgid = ownPgid();
+    if (pgid === process.pid) {
+      writeHostRecord({
+        pid: process.pid,
+        pgid,
+        version: HOST_IDENTITY.version,
+        scriptHash: HOST_IDENTITY.scriptHash,
+        startTime: ownStartTime(),
+        nonce: crypto.randomBytes(8).toString("hex"),
+      });
+    }
   });
 
-  process.once("SIGTERM", closeSocket);
-  process.once("SIGINT", closeSocket);
+  // SIGTERM/SIGINT: registering a handler SUPPRESSES node's default termination,
+  // so closeSocket alone would leave a socketless zombie host running with live
+  // children (and, being same-version, the registry would keep it forever). Do a
+  // real graceful shutdown instead - beginShutdown is idempotent, so a signal
+  // racing an in-flight socket "shutdown" joins it instead of double-draining.
+  process.once("SIGTERM", beginShutdown);
+  process.once("SIGINT", beginShutdown);
   process.once("exit", closeSocket);
 }
 

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -65,13 +65,20 @@ const PENDING_KILL_TTL_MS = 5_000;
 // survive; since killPty removes the id from the map, a survivor becomes an
 // orphan that a later respawn of the same id turns into a SECOND live process.
 // The uncatchable follow-up guarantees the old child actually dies.
-const KILL_ESCALATE_MS = 750;
+export const KILL_ESCALATE_MS = 750;
 // In-flight spawn guard: spawnPty awaits an async command-exists preflight
 // between the `ptys.has` check and registering the PTY. Two concurrent spawns
 // for the same id (e.g. a fast unmount+remount) could both pass that check and
 // both spawn, orphaning the first. We mark an id as spawning across the await
 // so a racing call bails instead of starting a second process.
 const spawning = new Set<string>();
+// Set once the host begins shutting down. shutdownPtyChildren snapshots the live
+// PTYs and the host then lingers up to KILL_ESCALATE_MS to deliver SIGKILL; a
+// spawn that registered a PTY in that window would escape the snapshot and be
+// orphaned on exit. spawnPty bails when this is set (and again after its async
+// preflight) so no child is created after the snapshot. One-way: the host is
+// exiting, so it never resets.
+let shuttingDown = false;
 
 export interface PtyEventSink {
   isDestroyed(): boolean;
@@ -376,6 +383,11 @@ function safeEnv(req: SpawnRequest, cwd: string): { [key: string]: string } {
 }
 
 export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<void> {
+  if (shuttingDown) {
+    // The host is tearing down; a new PTY here would miss the shutdown snapshot
+    // and be orphaned on exit. Drop the spawn.
+    return;
+  }
   if (pendingKills.has(req.ptyId)) {
     // killPty arrived before this spawn (the renderer closed the tab between
     // mounting and the IPC round-trip). Drop the spawn so we don't orphan a
@@ -514,6 +526,20 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
       return;
     }
 
+    if (shuttingDown) {
+      // Shutdown began during our async preflight, after the snapshot was taken.
+      // Registering now would orphan this child, and a scheduled escalation might
+      // not fire before the host exits - so force-kill it synchronously (the
+      // SIGKILL syscall dooms it regardless of the host's remaining lifetime).
+      try {
+        child.kill();
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+      return;
+    }
+
     ptys.set(req.ptyId, child);
 
     child.onData((chunk) => {
@@ -594,14 +620,77 @@ export function killPty(ptyId: string): void {
   terminatePtyChild(p);
 }
 
-export function killAll(): void {
-  for (const [, p] of ptys) {
-    // Same SIGKILL escalation as killPty so no child survives as an orphan.
-    terminatePtyChild(p);
+/** Graceful shutdown of a set of PTY children, event-driven with a hard deadline
+ *  (the graceful->timeout->SIGKILL ladder of systemd/k8s/docker, but resolving
+ *  as soon as the children are actually dead so a clean quit isn't delayed by a
+ *  fixed timer). Sends the graceful signal to each, calls `onDone` once the last
+ *  child exits, and at the KILL_ESCALATE_MS deadline force-kills any survivor
+ *  (the SIGKILL syscall dooms it regardless of whether this host outlives it)
+ *  before resolving. Split from `shutdownPtyChildren` so the loop is unit-testable
+ *  with fake children; `schedule` is injectable. `onDone` fires exactly once. */
+export function shutdownChildren(
+  children: Array<Pick<PtyModule.IPty, "kill" | "onExit">>,
+  onDone: () => void,
+  schedule: (fn: () => void, ms: number) => void = setTimeout,
+): void {
+  let done = false;
+  const finish = () => {
+    if (done) return;
+    done = true;
+    onDone();
+  };
+
+  if (children.length === 0) {
+    // Defer so a caller returning a response can flush before the process exits.
+    schedule(finish, 0);
+    return;
   }
+
+  let remaining = children.length;
+  const settleOne = () => {
+    remaining -= 1;
+    if (remaining <= 0) finish();
+  };
+
+  for (const p of children) {
+    try {
+      p.onExit(() => settleOne());
+    } catch {
+      // Can't observe this child's exit — let the deadline cover it.
+    }
+    try {
+      p.kill(); // graceful first; a well-behaved child exits and triggers onExit
+    } catch {
+      settleOne(); // already gone — counts as settled
+    }
+  }
+
+  schedule(() => {
+    for (const p of children) {
+      try {
+        p.kill("SIGKILL");
+      } catch {
+        // already exited — nothing to force-kill
+      }
+    }
+    finish();
+  }, KILL_ESCALATE_MS);
+}
+
+/** Shut down every live PTY: drain the map, then graceful-kill-with-escalation
+ *  via shutdownChildren. Used by the host's shutdown path. */
+export function shutdownPtyChildren(
+  onDone: () => void,
+  schedule: (fn: () => void, ms: number) => void = setTimeout,
+): void {
+  // Block any further spawns (including one mid-preflight) from escaping the
+  // snapshot below and getting orphaned when the host exits.
+  shuttingDown = true;
+  const children = [...ptys.values()];
   ptys.clear();
   outputBuffers.clear();
   pendingKills.clear();
+  shutdownChildren(children, onDone, schedule);
 }
 
 export function activePtyCount(): number {

--- a/tests/pty-host-registry.test.mjs
+++ b/tests/pty-host-registry.test.mjs
@@ -5,9 +5,12 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 import {
   isReapableHost,
   collectDescendants,
@@ -15,6 +18,7 @@ import {
   readHostRecords,
   removeHostRecord,
   reapStaleHostRecords,
+  classifyRecord,
 } from "../dist-electron/pty-host-registry.js";
 
 const SCRIPT = "/Applications/Aya.app/Contents/Resources/app.asar/dist-electron/pty-host.js";
@@ -147,9 +151,10 @@ test("reap: a stale, verified host has its whole tree SIGKILLed + record removed
       kill: (pid, sig) => { assert.equal(sig, "SIGKILL"); killed.push(pid); },
     });
     assert.deepEqual(summary.reaped, [5000]);
-    // Kills by PROCESS GROUP (-pgid) plus the leader pid - NOT per-descendant
-    // enumeration (that would be a reuse-race kill target). pgid == 5000.
-    assert.deepEqual(killed.sort((a, b) => a - b), [-5000, 5000], "group kill + leader, no per-pid enumeration kill");
+    // ONE group kill (-pgid) and nothing else: no per-descendant enumeration
+    // kills (reuse-race targets) and no follow-up kill(pid) (POSIX group kill
+    // already hits the leader; a second signal would be the only unverified one).
+    assert.deepEqual(killed, [-5000], "exactly one group kill, no extra signals");
     assert.deepEqual(summary.killedDescendants.sort((a, b) => a - b), [5001, 5002], "descendants observed for the log only");
     assert.deepEqual(readHostRecords(dir), [], "stale record removed");
   });
@@ -226,10 +231,194 @@ test("reap: empty registry is a no-op", () => {
   withReg([], (dir) => {
     const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
       selfPid: 1,
-      readProcInfo: () => ({ alive: false, startTime: null, command: null }),
+      readProcInfo: () => ({ alive: false, probeFailed: false, startTime: null, command: null }),
       listProcs: () => [],
       kill: () => assert.fail("must not kill anything"),
     });
-    assert.deepEqual(summary, { reaped: [], killedDescendants: [], keptCompatible: [], gc: [] });
+    assert.deepEqual(summary, {
+      reaped: [],
+      killedDescendants: [],
+      keptCompatible: [],
+      gc: [],
+      skipped: [],
+    });
   });
+});
+
+// --- the "unknown" identity sentinel must never decide a kill or a keep ---
+
+test("classifyRecord: version mismatch is stale regardless of hashes", () => {
+  assert.equal(classifyRecord({ version: "0.7.0", scriptHash: "unknown" }, EXPECTED), "stale");
+  assert.equal(classifyRecord({ version: "0.7.0", scriptHash: "new" }, EXPECTED), "stale");
+});
+
+test("classifyRecord: same version needs BOTH hashes known to decide", () => {
+  assert.equal(classifyRecord({ version: "0.8.0", scriptHash: "new" }, EXPECTED), "compatible");
+  assert.equal(classifyRecord({ version: "0.8.0", scriptHash: "other" }, EXPECTED), "stale");
+  // 'unknown' on either side -> indeterminate: 'unknown'==='unknown' must not
+  // trust a foreign build, and real-vs-'unknown' must not SIGKILL a healthy one.
+  assert.equal(classifyRecord({ version: "0.8.0", scriptHash: "unknown" }, EXPECTED), "indeterminate");
+  assert.equal(
+    classifyRecord({ version: "0.8.0", scriptHash: "real" }, { version: "0.8.0", scriptHash: "unknown" }),
+    "indeterminate",
+  );
+});
+
+test("reap: a LIVE indeterminate record is skipped - never killed, record kept", () => {
+  const rec = { pid: 5100, pgid: 5100, version: "0.8.0", scriptHash: "unknown", startTime: "T", nonce: "n" };
+  withReg([rec], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: true, probeFailed: false, startTime: "T", command: `Aya ${SCRIPT}` }),
+      listProcs: () => [],
+      kill: () => assert.fail("must not kill on an indeterminate identity"),
+    });
+    assert.deepEqual(summary.skipped, [5100]);
+    assert.equal(readHostRecords(dir).length, 1, "record survives for a later launch");
+  });
+});
+
+test("reap: a DEAD indeterminate record is GC'd (no kill) so unknown-hash records can't pile up", () => {
+  const rec = { pid: 5150, pgid: 5150, version: "0.8.0", scriptHash: "unknown", startTime: "T", nonce: "n" };
+  withReg([rec], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: false, probeFailed: false, startTime: null, command: null }),
+      listProcs: () => [],
+      kill: () => assert.fail("must not kill on an indeterminate identity"),
+    });
+    assert.deepEqual(summary.gc, [5150]);
+    assert.deepEqual(readHostRecords(dir), [], "conclusively-dead record removed");
+  });
+});
+
+test("reap: a kill failing with EPERM KEEPS the record (live host must stay reapable)", () => {
+  const stale = { pid: 5300, pgid: 5300, version: "0.7.0", scriptHash: "old", startTime: "T", nonce: "n" };
+  withReg([stale], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: true, probeFailed: false, startTime: "T", command: `Aya ${SCRIPT}` }),
+      listProcs: () => [{ pid: 5300, ppid: 1 }],
+      kill: () => {
+        const err = new Error("not permitted");
+        err.code = "EPERM";
+        throw err;
+      },
+    });
+    assert.deepEqual(summary.reaped, [], "a failed signal is not a reap");
+    assert.deepEqual(summary.skipped, [5300]);
+    assert.equal(readHostRecords(dir).length, 1, "record kept for a retry next launch");
+  });
+});
+
+test("reap: a kill failing with ESRCH (group vanished mid-reap) still drops the record", () => {
+  const stale = { pid: 5400, pgid: 5400, version: "0.7.0", scriptHash: "old", startTime: "T", nonce: "n" };
+  withReg([stale], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: true, probeFailed: false, startTime: "T", command: `Aya ${SCRIPT}` }),
+      listProcs: () => [],
+      kill: () => {
+        const err = new Error("no such process");
+        err.code = "ESRCH";
+        throw err;
+      },
+    });
+    assert.deepEqual(summary.reaped, [5400], "gone-between-probe-and-kill counts as reaped");
+    assert.deepEqual(readHostRecords(dir), []);
+  });
+});
+
+test("reap: a failed probe (ps could not run) keeps the record - no kill, no GC", () => {
+  const stale = { pid: 5200, pgid: 5200, version: "0.7.0", scriptHash: "old", startTime: "T", nonce: "n" };
+  withReg([stale], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: false, probeFailed: true, startTime: null, command: null }),
+      listProcs: () => [],
+      kill: () => assert.fail("must not kill on an unknown process state"),
+    });
+    assert.deepEqual(summary.skipped, [5200]);
+    assert.deepEqual(summary.gc, [], "a live stale host must not lose its record to a transient ps failure");
+    assert.equal(readHostRecords(dir).length, 1);
+  });
+});
+
+// --- registry hygiene ---
+
+test("writeHostRecord refuses a record with an empty startTime", () => {
+  const dir = mkdtempSync(join(tmpdir(), "aya-reg-"));
+  try {
+    writeHostRecord({ ...REC, startTime: "" }, dir);
+    assert.deepEqual(readHostRecords(dir), [], "an unverifiable record must never be written");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readHostRecords self-heals: unparseable and wrong-shape .json files are removed", () => {
+  const dir = mkdtempSync(join(tmpdir(), "aya-reg-"));
+  try {
+    writeFileSync(join(dir, "123.json"), "{ not json");
+    writeFileSync(join(dir, "456.json"), JSON.stringify({ pid: 0.5, pgid: 1 })); // wrong shape
+    writeHostRecord(REC, dir); // one good record
+    const recs = readHostRecords(dir);
+    assert.deepEqual(recs.map((r) => r.pid), [REC.pid]);
+    const left = readdirSync(dir).filter((n) => n.endsWith(".json"));
+    assert.deepEqual(left, [`${REC.pid}.json`], "bad files are unlinked, not skipped forever");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- real host process: record lifecycle + graceful SIGTERM (integration) ---
+
+test("a real spawned host writes its record, and SIGTERM shuts it down cleanly (record removed)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "aya-host-it-"));
+  // detached:true mirrors the real client spawn (pty-host-client.ts startHost) -
+  // and is REQUIRED for the record: a non-leader host refuses to publish (its
+  // ownPgid() !== pid verification; confirmed by this very test failing without
+  // detached).
+  const host = spawn(process.execPath, ["dist-electron/pty-host.js"], {
+    env: { ...process.env, AYA_HOME: home },
+    stdio: "ignore",
+    detached: true,
+  });
+  let exited = false;
+  host.on("exit", () => {
+    exited = true;
+  });
+  try {
+    // Wait for the record (written after listen) - proves pid/pgid verification
+    // passed and startTime was non-empty on a real process.
+    const regDir = join(home, "pty-hosts");
+    const deadline = Date.now() + 5000;
+    let recs = [];
+    while (Date.now() < deadline) {
+      recs = readHostRecords(regDir);
+      if (recs.length > 0) break;
+      await sleep(50);
+    }
+    assert.equal(recs.length, 1, "host published its registry record");
+    assert.equal(recs[0].pid, host.pid);
+    assert.equal(recs[0].pgid, recs[0].pid, "host verified it leads its own group");
+    assert.ok(recs[0].startTime.length > 0, "record carries a verifiable start time");
+
+    // SIGTERM must now do a REAL graceful shutdown (not leave a socketless
+    // zombie): host exits and removes its record (children confirmed dead -
+    // there are none here).
+    host.kill("SIGTERM");
+    const exitDeadline = Date.now() + 5000;
+    while (Date.now() < exitDeadline && !exited) await sleep(50);
+    assert.equal(exited, true, "SIGTERM terminates the host (no suppressed-default zombie)");
+    await sleep(100); // let the record removal land
+    assert.deepEqual(readHostRecords(regDir), [], "clean shutdown removed the record");
+  } finally {
+    try {
+      host.kill("SIGKILL");
+    } catch {
+      // already dead
+    }
+    rmSync(home, { recursive: true, force: true });
+  }
 });

--- a/tests/pty-host-registry.test.mjs
+++ b/tests/pty-host-registry.test.mjs
@@ -1,0 +1,235 @@
+// The reaper SIGKILLs process trees, so isReapableHost is the safety gate: it
+// must be fail-closed - true ONLY when we are certain a live pid is the exact
+// host a record describes. These tests pin every rejection path (a regression
+// that flips one to `true` risks killing an unrelated user process).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isReapableHost,
+  collectDescendants,
+  writeHostRecord,
+  readHostRecords,
+  removeHostRecord,
+  reapStaleHostRecords,
+} from "../dist-electron/pty-host-registry.js";
+
+const SCRIPT = "/Applications/Aya.app/Contents/Resources/app.asar/dist-electron/pty-host.js";
+const REC = {
+  pid: 4242,
+  pgid: 4242,
+  version: "0.7.5",
+  scriptHash: "abc",
+  startTime: "Wed Jul  2 10:00:00 2026",
+  nonce: "n1",
+};
+const GOOD_INFO = {
+  alive: true,
+  startTime: REC.startTime,
+  command: `/Applications/Aya.app/Contents/MacOS/Aya ${SCRIPT}`,
+};
+const SELF = 999999; // a pid that is never our record's pid
+
+test("isReapableHost: all checks pass -> reapable", () => {
+  assert.equal(isReapableHost(REC, GOOD_INFO, SCRIPT, SELF), true);
+});
+
+test("isReapableHost: never reaps our own pid", () => {
+  assert.equal(isReapableHost(REC, GOOD_INFO, SCRIPT, REC.pid), false);
+});
+
+test("isReapableHost: never signals init/invalid pids", () => {
+  assert.equal(isReapableHost({ ...REC, pid: 1 }, GOOD_INFO, SCRIPT, SELF), false);
+  assert.equal(isReapableHost({ ...REC, pid: 0 }, GOOD_INFO, SCRIPT, SELF), false);
+});
+
+test("isReapableHost: dead process is not reaped", () => {
+  assert.equal(
+    isReapableHost(REC, { alive: false, startTime: null, command: null }, SCRIPT, SELF),
+    false,
+  );
+});
+
+test("isReapableHost: start-time mismatch (PID reuse) is not reaped", () => {
+  const reused = { ...GOOD_INFO, startTime: "Wed Jul  2 11:30:00 2026" };
+  assert.equal(isReapableHost(REC, reused, SCRIPT, SELF), false);
+});
+
+test("isReapableHost: missing start time is not reaped", () => {
+  assert.equal(isReapableHost(REC, { ...GOOD_INFO, startTime: null }, SCRIPT, SELF), false);
+});
+
+test("isReapableHost: command not matching the host script is not reaped", () => {
+  const other = { ...GOOD_INFO, command: "/usr/bin/some-unrelated-electron-app --foo" };
+  assert.equal(isReapableHost(REC, other, SCRIPT, SELF), false);
+  assert.equal(isReapableHost(REC, { ...GOOD_INFO, command: null }, SCRIPT, SELF), false);
+});
+
+test("isReapableHost: a record that is not a detached leader (pgid != pid) is not reaped", () => {
+  // Guards kill(-pgid) from ever targeting a group other than the verified
+  // leader's own (a corrupted/foreign record could name an unrelated pgid).
+  assert.equal(isReapableHost({ ...REC, pgid: 5 }, GOOD_INFO, SCRIPT, SELF), false);
+});
+
+test("collectDescendants: recursive tree, excludes root, cycle-safe", () => {
+  const procs = [
+    { pid: 100, ppid: 1 }, // root
+    { pid: 200, ppid: 100 }, // child
+    { pid: 300, ppid: 200 }, // grandchild
+    { pid: 400, ppid: 100 }, // child
+    { pid: 500, ppid: 999 }, // unrelated
+  ];
+  const d = collectDescendants(100, procs).sort((a, b) => a - b);
+  assert.deepEqual(d, [200, 300, 400]);
+  assert.equal(d.includes(100), false, "excludes the root");
+  assert.equal(d.includes(500), false, "excludes unrelated");
+});
+
+test("collectDescendants: a ppid cycle does not hang or duplicate", () => {
+  const procs = [
+    { pid: 10, ppid: 20 },
+    { pid: 20, ppid: 10 }, // cycle
+  ];
+  const d = collectDescendants(10, procs);
+  assert.deepEqual(d, [20]);
+});
+
+test("host record write/read/remove round-trips atomically", () => {
+  const dir = mkdtempSync(join(tmpdir(), "aya-reg-"));
+  try {
+    writeHostRecord(REC, dir);
+    writeHostRecord({ ...REC, pid: 4343 }, dir);
+    const recs = readHostRecords(dir).sort((a, b) => a.pid - b.pid);
+    assert.equal(recs.length, 2);
+    assert.deepEqual(recs[0], REC);
+    removeHostRecord(4242, dir);
+    const after = readHostRecords(dir);
+    assert.deepEqual(after.map((r) => r.pid), [4343]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readHostRecords: missing dir -> [], malformed files skipped", () => {
+  assert.deepEqual(readHostRecords(join(tmpdir(), "aya-reg-does-not-exist-xyz")), []);
+});
+
+// --- reapStaleHostRecords orchestration (injected deps, no real processes) ---
+
+const EXPECTED = { version: "0.8.0", scriptHash: "new" };
+
+function withReg(recs, fn) {
+  const dir = mkdtempSync(join(tmpdir(), "aya-reap-"));
+  try {
+    for (const r of recs) writeHostRecord(r, dir);
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("reap: a stale, verified host has its whole tree SIGKILLed + record removed", () => {
+  const stale = { pid: 5000, pgid: 5000, version: "0.7.0", scriptHash: "old", startTime: "T1", nonce: "x" };
+  withReg([stale], (dir) => {
+    const killed = [];
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: (pid) => (pid === 5000 ? { alive: true, startTime: "T1", command: `Aya ${SCRIPT}` } : { alive: false, startTime: null, command: null }),
+      listProcs: () => [
+        { pid: 5000, ppid: 1 },
+        { pid: 5001, ppid: 5000 }, // child
+        { pid: 5002, ppid: 5001 }, // grandchild
+        { pid: 6000, ppid: 1 }, // unrelated
+      ],
+      kill: (pid, sig) => { assert.equal(sig, "SIGKILL"); killed.push(pid); },
+    });
+    assert.deepEqual(summary.reaped, [5000]);
+    // Kills by PROCESS GROUP (-pgid) plus the leader pid - NOT per-descendant
+    // enumeration (that would be a reuse-race kill target). pgid == 5000.
+    assert.deepEqual(killed.sort((a, b) => a - b), [-5000, 5000], "group kill + leader, no per-pid enumeration kill");
+    assert.deepEqual(summary.killedDescendants.sort((a, b) => a - b), [5001, 5002], "descendants observed for the log only");
+    assert.deepEqual(readHostRecords(dir), [], "stale record removed");
+  });
+});
+
+test("reap: a compatible (same-build) live host is KEPT, never killed (#28 survive)", () => {
+  const same = { pid: 7000, pgid: 7000, version: "0.8.0", scriptHash: "new", startTime: "T2", nonce: "y" };
+  withReg([same], (dir) => {
+    const killed = [];
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: true, startTime: "T2", command: `Aya ${SCRIPT}` }),
+      listProcs: () => [{ pid: 7000, ppid: 1 }],
+      kill: (pid) => killed.push(pid),
+    });
+    assert.deepEqual(summary.keptCompatible, [7000]);
+    assert.deepEqual(killed, [], "same-build host is not signalled");
+    assert.equal(readHostRecords(dir).length, 1, "its record is kept");
+  });
+});
+
+test("reap: a stale record whose pid was REUSED (start-time mismatch) is GC'd, NOT killed", () => {
+  const stale = { pid: 8000, pgid: 8000, version: "0.7.0", scriptHash: "old", startTime: "T-orig", nonce: "z" };
+  withReg([stale], (dir) => {
+    const killed = [];
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      // pid 8000 is alive but with a DIFFERENT start time -> reused by something else
+      readProcInfo: () => ({ alive: true, startTime: "T-different", command: "/usr/bin/unrelated" }),
+      listProcs: () => [{ pid: 8000, ppid: 1 }],
+      kill: (pid) => killed.push(pid),
+    });
+    assert.deepEqual(killed, [], "must NOT signal a reused pid");
+    assert.deepEqual(summary.reaped, []);
+    assert.deepEqual(summary.gc, [8000]);
+    assert.deepEqual(readHostRecords(dir), [], "the stale record is dropped");
+  });
+});
+
+test("reap: a compatible record whose pid was REUSED is GC'd, not kept, not killed", () => {
+  const same = { pid: 7100, pgid: 7100, version: "0.8.0", scriptHash: "new", startTime: "T-was", nonce: "q" };
+  withReg([same], (dir) => {
+    const killed = [];
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      // alive but different start time -> pid reused by something unrelated
+      readProcInfo: () => ({ alive: true, startTime: "T-now", command: "/usr/bin/other" }),
+      listProcs: () => [{ pid: 7100, ppid: 1 }],
+      kill: (pid) => killed.push(pid),
+    });
+    assert.deepEqual(killed, [], "never signal a reused pid, even on the keep path");
+    assert.deepEqual(summary.keptCompatible, [], "a reused pid is not mistaken for our host");
+    assert.deepEqual(summary.gc, [7100]);
+  });
+});
+
+test("reap: a dead compatible record is GC'd", () => {
+  const dead = { pid: 9000, pgid: 9000, version: "0.8.0", scriptHash: "new", startTime: "T3", nonce: "w" };
+  withReg([dead], (dir) => {
+    const killed = [];
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: false, startTime: null, command: null }),
+      listProcs: () => [],
+      kill: (pid) => killed.push(pid),
+    });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(summary.gc, [9000]);
+    assert.deepEqual(readHostRecords(dir), []);
+  });
+});
+
+test("reap: empty registry is a no-op", () => {
+  withReg([], (dir) => {
+    const summary = reapStaleHostRecords(EXPECTED, SCRIPT, dir, {
+      selfPid: 1,
+      readProcInfo: () => ({ alive: false, startTime: null, command: null }),
+      listProcs: () => [],
+      kill: () => assert.fail("must not kill anything"),
+    });
+    assert.deepEqual(summary, { reaped: [], killedDescendants: [], keptCompatible: [], gc: [] });
+  });
+});

--- a/tests/pty-host-sweep.test.mjs
+++ b/tests/pty-host-sweep.test.mjs
@@ -1,0 +1,324 @@
+// The legacy sweep SIGKILLs processes it identifies as Aya leftovers, so every
+// gate is fail-closed and pinned here: a regression that widens a filter or
+// drops a probe re-verification risks killing an unrelated user process.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseSnapshot,
+  scopeFromEnvDump,
+  isHostArgv,
+  selectStrayHostCandidates,
+  selectOrphanCandidates,
+  sweepLegacyAyaProcesses,
+  MAX_ORPHAN_PROBES,
+} from "../dist-electron/pty-host-sweep.js";
+
+const HOME = "/Users/u";
+const AYA = "/Users/u/.aya";
+const HOST_CMD =
+  "/Applications/Aya.app/Contents/MacOS/Aya /Applications/Aya.app/Contents/Resources/app.asar/dist-electron/pty-host.js";
+// A verified host's env dump: argv + as-node marker (client always sets it).
+const HOST_ENV = `${HOST_CMD} ELECTRON_RUN_AS_NODE=1 PATH=/bin USER=u`;
+// A verified orphan's env dump: argv + BOTH safeEnv markers.
+const ORPHAN_ENV = `claude --chrome AYA_TERMINAL_ID=abc AYA_HOME=${AYA} PATH=/b`;
+
+const row = (o) => ({ uid: 501, ppid: 1, command: "/bin/zsh", ...o });
+
+const baseDeps = (over) => ({
+  snapshot: () => [],
+  envProbe: () => null,
+  leaderGone: () => true,
+  kill: () => assert.fail("unexpected kill"),
+  uid: 501,
+  selfPid: 1,
+  selfPgid: 1,
+  ayaHome: AYA,
+  homedir: HOME,
+  ...over,
+});
+
+// ---------- parseSnapshot ----------
+
+test("parseSnapshot parses valid rows and drops malformed lines", () => {
+  const out = parseSnapshot(
+    [
+      "  501 100 1 100 /bin/zsh -l",
+      "501 200 100 100 sleep 30",
+      "garbage line without numbers",
+      "  0 300 1 300 /sbin/launchd",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(out, [
+    { uid: 501, pid: 100, ppid: 1, pgid: 100, command: "/bin/zsh -l" },
+    { uid: 501, pid: 200, ppid: 100, pgid: 100, command: "sleep 30" },
+    { uid: 0, pid: 300, ppid: 1, pgid: 300, command: "/sbin/launchd" },
+  ]);
+});
+
+// ---------- scopeFromEnvDump ----------
+
+test("scopeFromEnvDump: explicit AYA_HOME wins, AYA_DEV maps to .aya-dev, default .aya", () => {
+  assert.equal(scopeFromEnvDump("cmd AYA_HOME=/tmp/x PATH=/bin", HOME), "/tmp/x");
+  assert.equal(scopeFromEnvDump("cmd AYA_DEV=1 PATH=/bin", HOME), `${HOME}/.aya-dev`);
+  assert.equal(scopeFromEnvDump("cmd PATH=/bin", HOME), `${HOME}/.aya`);
+});
+
+// ---------- isHostArgv: positional, not substring ----------
+
+test("isHostArgv: matches ONLY when the script is the second argv token", () => {
+  assert.equal(isHostArgv(HOST_CMD), true);
+  assert.equal(isHostArgv("/usr/bin/node /Users/u/proj/dist-electron/pty-host.js"), true);
+  // The dangerous lookalikes a substring match would have group-killed:
+  assert.equal(isHostArgv("vim electron/pty-host-sweep.ts dist-electron/pty-host.js"), false, "path in a LATER argument");
+  assert.equal(isHostArgv("grep -r dist-electron/pty-host.js ."), false, "grep with a flag second");
+  assert.equal(isHostArgv("rg dist-electron/pty-host ."), false, "prefix without .js");
+  assert.equal(isHostArgv("/bin/zsh"), false, "no second token");
+});
+
+// ---------- S1 candidate selection ----------
+
+test("selectStrayHostCandidates: positional signature + uid + leader + exclusions", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // stray host - candidate
+    row({ pid: 901, pgid: 901, command: HOST_CMD, uid: 502 }), // other uid - no
+    row({ pid: 902, pgid: 555, command: HOST_CMD }), // not a leader - no
+    row({ pid: 903, pgid: 903, command: HOST_CMD }), // excluded (current) - no
+    row({ pid: 904, pgid: 904, command: "grep -r dist-electron/pty-host.js ." }), // argv lookalike - no
+    row({ pid: 905, pgid: 905, command: HOST_CMD }), // self - no
+  ];
+  const got = selectStrayHostCandidates(rows, {
+    uid: 501,
+    selfPid: 905,
+    excludePids: new Set([903]),
+  });
+  assert.deepEqual(got.map((r) => r.pid), [900]);
+});
+
+// ---------- S2 candidate selection ----------
+
+test("selectOrphanCandidates: only dead-leader groups, never our group or hosts", () => {
+  const rows = [
+    row({ pid: 100, pgid: 100 }), // live leader
+    row({ pid: 101, pgid: 100 }), // child of LIVE leader - no (leader alive)
+    row({ pid: 200, pgid: 7777 }), // leader 7777 gone - candidate
+    row({ pid: 201, pgid: 7777, uid: 502 }), // foreign uid - no
+    row({ pid: 202, pgid: 8888 }), // our own group - no
+    row({ pid: 203, pgid: 7777, command: HOST_CMD }), // host-shaped - S1's job, no
+    row({ pid: 204, pgid: 7777 }), // second orphan - candidate
+  ];
+  const got = selectOrphanCandidates(rows, { uid: 501, selfPid: 1000, selfPgid: 8888 });
+  assert.deepEqual(got.map((r) => r.pid).sort((a, b) => a - b), [200, 204]);
+});
+
+// ---------- orchestration: S1 ----------
+
+test("sweep S1: a verified stray host gets ONE group kill; scope mismatch and probe failure are skipped", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // ours - swept
+    row({ pid: 910, pgid: 910, command: HOST_CMD }), // dev-scoped - skipped
+    row({ pid: 920, pgid: 920, command: HOST_CMD }), // probe fails - skipped
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: (pid) => {
+        if (pid === 900) return { pgid: 900, commandWithEnv: HOST_ENV };
+        if (pid === 910)
+          return { pgid: 910, commandWithEnv: `${HOST_CMD} ELECTRON_RUN_AS_NODE=1 AYA_DEV=1 PATH=/bin` };
+        return null; // 920
+      },
+      kill: (pid, sig) => {
+        assert.equal(sig, "SIGKILL");
+        killed.push(pid);
+      },
+    }),
+  );
+  assert.deepEqual(killed, [-900], "one atomic group kill of the verified leader only");
+  assert.deepEqual(summary.sweptHosts, [900]);
+  assert.deepEqual(summary.skipped.sort((a, b) => a - b), [910, 920]);
+});
+
+test("sweep S1: a probe WITHOUT ELECTRON_RUN_AS_NODE=1 is skipped (editor/grep can't fake a host)", () => {
+  const rows = [row({ pid: 900, pgid: 900, command: HOST_CMD })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      // Argv shape matches but the as-node env marker every REAL host carries
+      // is absent -> not a host.
+      envProbe: () => ({ pgid: 900, commandWithEnv: `${HOST_CMD} PATH=/bin USER=u` }),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [900]);
+});
+
+test("sweep S1: a pid reused since the snapshot (argv no longer host-shaped) is skipped", () => {
+  const rows = [row({ pid: 900, pgid: 900, command: HOST_CMD })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: () => ({ pgid: 900, commandWithEnv: "/usr/bin/vim notes.txt PATH=/bin" }),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [900]);
+});
+
+test("sweep S1 disabled (current host unidentifiable) never kills hosts; S2 still runs", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // would-be stray
+    row({ pid: 200, pgid: 7777 }), // dead-leader orphan
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: (pid) =>
+        pid === 200 ? { pgid: 7777, commandWithEnv: ORPHAN_ENV } : { pgid: 900, commandWithEnv: HOST_ENV },
+      leaderGone: () => true,
+      kill: (pid) => killed.push(pid),
+    }),
+    { strayHosts: false },
+  );
+  assert.deepEqual(summary.sweptHosts, [], "stray pass disabled");
+  assert.deepEqual(summary.sweptOrphans, [200]);
+  assert.deepEqual(killed, [200]);
+});
+
+// ---------- orchestration: S2 ----------
+
+test("sweep S2: kills ONLY confirmed-dead-leader members carrying BOTH safeEnv markers", () => {
+  const rows = [
+    row({ pid: 200, pgid: 7777, command: "claude --chrome" }), // both markers - swept
+    row({ pid: 201, pgid: 7777, command: "some-daemon" }), // no markers - skipped
+    row({ pid: 202, pgid: 7777, command: "sleep 5" }), // moved group - skipped
+    row({ pid: 205, pgid: 7777, command: "grep AYA_TERMINAL_ID= ." }), // one marker only (argv) - skipped
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: (pgid) => {
+        assert.equal(pgid, 7777);
+        return true; // freshly confirmed gone
+      },
+      envProbe: (pid) => {
+        if (pid === 200) return { pgid: 7777, commandWithEnv: ORPHAN_ENV };
+        if (pid === 201) return { pgid: 7777, commandWithEnv: "some-daemon PATH=/b HOME=/u" };
+        if (pid === 205)
+          return { pgid: 7777, commandWithEnv: "grep AYA_TERMINAL_ID= . PATH=/b" }; // no AYA_HOME=
+        return { pgid: 9999, commandWithEnv: ORPHAN_ENV }; // 202 moved
+      },
+      kill: (pid, sig) => {
+        assert.equal(sig, "SIGKILL");
+        killed.push(pid);
+      },
+    }),
+  );
+  assert.deepEqual(killed, [200], "dual-marker-verified orphan only");
+  assert.deepEqual(summary.sweptOrphans, [200]);
+  assert.deepEqual(summary.skipped.sort((a, b) => a - b), [201, 202, 205]);
+});
+
+test("sweep S2: a leader that is actually ALIVE (snapshot lied) blocks the whole group", () => {
+  // The snapshot dropped the live host's row (parse hiccup) - its children look
+  // orphaned. The direct leader probe must catch this and kill NOTHING.
+  const rows = [row({ pid: 200, pgid: 7777, command: "claude --chrome" })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => false, // direct probe: leader is alive!
+      envProbe: () => assert.fail("must not even env-probe members of a live-leader group"),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, [], "live-leader children are NEVER killed");
+  assert.deepEqual(summary.skipped, [200]);
+});
+
+test("sweep S2: a failed leader probe (unknown state) blocks the group", () => {
+  const rows = [row({ pid: 200, pgid: 7777, command: "claude --chrome" })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => null, // probe failed - unknown
+      envProbe: () => assert.fail("no env probe on unknown leader state"),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [200]);
+});
+
+test("sweep S2: the leader probe is cached per group (one ps per dead group, not per member)", () => {
+  const rows = [
+    row({ pid: 200, pgid: 7777, command: "a" }),
+    row({ pid: 204, pgid: 7777, command: "b" }),
+  ];
+  let leaderProbes = 0;
+  sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => {
+        leaderProbes += 1;
+        return true;
+      },
+      envProbe: () => null, // all members skipped after that
+      kill: () => assert.fail("nothing verifiable"),
+    }),
+  );
+  assert.equal(leaderProbes, 1, "one leader probe per group");
+});
+
+test("sweep S2: the probe cap bounds work and reports truncation (no silent cap)", () => {
+  const rows = [];
+  for (let i = 0; i < MAX_ORPHAN_PROBES + 10; i++) {
+    rows.push(row({ pid: 10_000 + i, pgid: 7777 }));
+  }
+  let envProbes = 0;
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => true,
+      envProbe: () => {
+        envProbes += 1;
+        return null; // all skipped - we only measure the bound
+      },
+      kill: () => assert.fail("nothing verifiable to kill"),
+    }),
+  );
+  assert.equal(envProbes, MAX_ORPHAN_PROBES, "env-probe count is bounded");
+  assert.equal(summary.truncated, 10, "overflow is reported, not silently dropped");
+});
+
+test("sweep: empty snapshot or missing uid is a total no-op", () => {
+  assert.deepEqual(
+    sweepLegacyAyaProcesses(new Set(), baseDeps({ snapshot: () => [] })).sweptHosts,
+    [],
+  );
+  assert.deepEqual(
+    sweepLegacyAyaProcesses(
+      new Set(),
+      baseDeps({ uid: -1, snapshot: () => assert.fail("uid gate first") }),
+    ).sweptHosts,
+    [],
+  );
+});

--- a/tests/pty-kill-escalate.test.mjs
+++ b/tests/pty-kill-escalate.test.mjs
@@ -7,7 +7,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { terminatePtyChild } from "../dist-electron/pty.js";
+import {
+  terminatePtyChild,
+  shutdownChildren,
+  shutdownPtyChildren,
+  spawnPty,
+  activePtyCount,
+  KILL_ESCALATE_MS,
+} from "../dist-electron/pty.js";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -22,21 +29,28 @@ test("terminatePtyChild sends the default kill, then escalates to SIGKILL", () =
   // Immediate graceful kill (default signal), escalation deferred.
   assert.deepEqual(signals, ["default"]);
   assert.ok(scheduled, "an escalation must be scheduled");
-  assert.ok(scheduled.ms > 0, "escalation runs after a grace delay");
+  // Pin the exact grace window, not just "some delay": a near-zero grace would
+  // race the graceful exit and defeat "let a well-behaved child clean up first".
+  assert.equal(scheduled.ms, KILL_ESCALATE_MS, "escalation runs after the grace window");
 
   // Run the scheduled escalation -> uncatchable SIGKILL.
   scheduled.fn();
   assert.deepEqual(signals, ["default", "SIGKILL"]);
 });
 
-test("terminatePtyChild swallows errors when the child already exited", () => {
+test("terminatePtyChild swallows errors but still attempts both kills", () => {
+  let calls = 0;
   const fake = {
     kill: () => {
+      calls += 1;
       throw new Error("process already gone");
     },
   };
-  // Neither the immediate kill nor the (inline) escalation may throw.
+  // Neither the immediate kill nor the (inline) escalation may throw...
   assert.doesNotThrow(() => terminatePtyChild(fake, (fn) => fn()));
+  // ...and both kills must actually be ATTEMPTED - a do-nothing SUT that never
+  // calls kill would also not throw, so the count is what makes this diagnostic.
+  assert.equal(calls, 2, "both the graceful kill and the escalation are attempted");
 });
 
 // Reproduces the trigger against a REAL OS process: a child that traps/ignores
@@ -51,9 +65,14 @@ test("a SIGHUP-ignoring process survives the graceful kill but the escalation ki
   });
   await sleep(150); // let the trap install
 
-  // Map the IPty-shaped kill(signal) onto the real process.
+  // Map the IPty-shaped kill(signal) onto the real process, recording signals so
+  // we prove the graceful kill was actually SENT (not merely that the process
+  // happened to survive - a SUT that skipped the graceful kill would also leave
+  // a trap-HUP process alive at the 250ms checkpoint).
+  const signals = [];
   const handle = {
     kill: (sig) => {
+      signals.push(sig ?? "SIGHUP");
       try {
         process.kill(child.pid, sig ?? "SIGHUP");
       } catch {
@@ -64,9 +83,11 @@ test("a SIGHUP-ignoring process survives the graceful kill but the escalation ki
   terminatePtyChild(handle); // real setTimeout escalation
 
   await sleep(250); // past the graceful kill, before escalation
+  assert.deepEqual(signals, ["SIGHUP"], "the graceful signal was actually sent");
   assert.equal(exited, false, "SIGHUP-ignoring process must survive the graceful kill");
 
   await sleep(1000); // past KILL_ESCALATE_MS -> SIGKILL delivered
+  assert.deepEqual(signals, ["SIGHUP", "SIGKILL"], "escalation followed with SIGKILL");
   assert.equal(exited, true, "the SIGKILL escalation must terminate the stuck process");
 });
 
@@ -95,11 +116,116 @@ test("a normal process exits on the graceful signal; escalation is a harmless no
 
 // Edge: terminating an already-exited process throws nothing (both signals hit a
 // dead pid -> ESRCH, swallowed).
-test("terminating an already-exited process is a no-op", async () => {
+test("terminating an already-exited process attempts both kills without throwing", async () => {
   const child = spawn("sh", ["-c", "exit 0"], { stdio: "ignore" });
   await new Promise((r) => child.on("exit", r));
+  let calls = 0;
   const handle = {
-    kill: (sig) => process.kill(child.pid, sig ?? "SIGHUP"), // will throw ESRCH
+    kill: (sig) => {
+      calls += 1;
+      process.kill(child.pid, sig ?? "SIGHUP"); // real dead pid -> throws ESRCH
+    },
   };
   assert.doesNotThrow(() => terminatePtyChild(handle, (fn) => fn()));
+  // Both real ESRCH throws were swallowed AND both kills were attempted (a SUT
+  // that skipped the kill would pass doesNotThrow alone).
+  assert.equal(calls, 2, "graceful + escalation both attempted against the dead pid");
+});
+
+// Fake IPty child for shutdownChildren: records signals; a "well-behaved" child
+// fires its onExit listener the moment it receives the graceful kill, a "stuck"
+// one ignores the graceful signal and only its SIGKILL is observed (its onExit
+// is never fired, mirroring a trap-HUP process the deadline must force-kill).
+function fakeChild(behavior) {
+  const signals = [];
+  let onExit = null;
+  return {
+    signals,
+    get exitListenerRegistered() {
+      return onExit !== null;
+    },
+    kill(sig) {
+      signals.push(sig ?? "graceful");
+      if (behavior === "wellbehaved" && sig === undefined) onExit?.();
+    },
+    onExit(fn) {
+      onExit = fn;
+      return { dispose() {} };
+    },
+  };
+}
+
+// Event-driven shutdown: when every child exits on the graceful signal, resolve
+// WITHOUT waiting for (or needing) the SIGKILL deadline - a clean quit is not
+// delayed by a fixed timer.
+test("shutdownChildren resolves as soon as well-behaved children exit (no wait for deadline)", () => {
+  const a = fakeChild("wellbehaved");
+  const b = fakeChild("wellbehaved");
+  let scheduledDeadline = null;
+  let done = 0;
+  shutdownChildren([a, b], () => (done += 1), (fn, ms) => {
+    scheduledDeadline = { fn, ms };
+  });
+
+  // Both exited on the graceful kill -> onDone already fired; no SIGKILL sent.
+  assert.equal(done, 1, "shutdown resolves once the last child exits");
+  assert.deepEqual(a.signals, ["graceful"]);
+  assert.deepEqual(b.signals, ["graceful"]);
+  // The deadline is scheduled at the grace window but is moot now; running it
+  // late must not re-resolve or send a redundant fatal signal to live pids.
+  assert.equal(scheduledDeadline.ms, KILL_ESCALATE_MS);
+  scheduledDeadline.fn();
+  assert.equal(done, 1, "onDone fires exactly once");
+});
+
+// A stuck child ignoring the graceful signal must NOT resolve shutdown early;
+// only the deadline SIGKILL closes it out.
+test("shutdownChildren escalates a stuck child to SIGKILL at the deadline", () => {
+  const stuck = fakeChild("stuck");
+  let deadline = null;
+  let done = 0;
+  shutdownChildren([stuck], () => (done += 1), (fn) => {
+    deadline = fn;
+  });
+
+  assert.deepEqual(stuck.signals, ["graceful"]);
+  assert.equal(done, 0, "not resolved while the stuck child is still alive");
+
+  deadline(); // fire the KILL_ESCALATE_MS deadline
+  assert.deepEqual(stuck.signals, ["graceful", "SIGKILL"], "survivor is force-killed");
+  assert.equal(done, 1, "the deadline SIGKILL resolves shutdown");
+});
+
+// No children -> resolve on the next tick (deferred so a caller can flush its
+// response before the process exits), never synchronously.
+test("shutdownChildren with no children resolves on the next tick", () => {
+  let scheduled = null;
+  let done = 0;
+  shutdownChildren([], () => (done += 1), (fn, ms) => {
+    scheduled = { fn, ms };
+  });
+  assert.equal(done, 0, "not resolved synchronously");
+  assert.equal(scheduled.ms, 0, "deferred to the next tick");
+  scheduled.fn();
+  assert.equal(done, 1);
+});
+
+// MUST BE LAST: shutdownPtyChildren sets a one-way shuttingDown flag on the
+// module, so any test spawning after this would be affected. Once shutdown has
+// begun, spawnPty must refuse to create a new child - otherwise a spawn arriving
+// in the host's post-snapshot linger window would escape the shutdown sweep and
+// be orphaned on exit (the widened-race gap this guard closes).
+test("spawnPty refuses to start a child once shutdown has begun (z-last)", async () => {
+  shutdownPtyChildren(() => {}, () => {}); // sets shuttingDown; empty map, no-op schedule
+  const events = [];
+  const sink = { isDestroyed: () => false, sendPtyEvent: (e) => events.push(e) };
+  await spawnPty(
+    { ptyId: "post-shutdown", command: "sh", cwd: process.cwd(), cols: 80, rows: 24 },
+    sink,
+  );
+  // Guarded: no PTY registered and no spawn/failure event emitted. (Without the
+  // guard, spawnPty would proceed - either registering a real PTY -> count 1, or
+  // emitting a spawn-failure event -> events.length 1 - so both assertions bite.)
+  assert.equal(activePtyCount(), 0, "no PTY registered after shutdown began");
+  assert.equal(events.length, 0, "no spawn/failure event emitted after shutdown began");
 });


### PR DESCRIPTION
## Why

Found by live-debugging a real incident (white screen / broken tab in the experimental layout). The installed app's **detached PTY-host had run 2.5 days across app updates**, accumulating **22 orphaned `claude` + 46 zsh** processes, plus a **second 3-week-old orphaned host** from an older build.

The host is intentionally kept alive across app restarts (#28) to preserve sessions, and `before-quit` is a no-op in production. The only reap path (`ptyHost.restart`) talks to the **current socket** and relied on the host's own (SIGHUP) `killAll` - so off-socket hosts were never reached and signal-ignoring children were orphaned. **Nothing killed a stale host by pid.** Each update left the previous host + its tree alive.

Stacked on #73 (kill-escalation / event-driven shutdown) - the reap reuses that work.

## What (Phase 1)

- **`electron/pty-host-registry.ts`** (new): each host publishes `~/.aya/pty-hosts/<pid>.json` `{pid,pgid,version,scriptHash,startTime,nonce}` at startup. On launch the app reconciles the registry **before** spawning/connecting: a **same-build host is kept** (survive-restart, #28); a **version-mismatched one is force-reaped**; dead/unverifiable records are **GC'd without signaling**.
- **Fail-closed, group-based kill:** SIGKILLs `kill(-pgid)` of a just-verified, still-alive detached leader (pgid==pid), avoiding the enumerate-then-kill pid-reuse race. `isReapableHost` requires: alive + **exact start-time match** (reuse defense) + command still running a pty-host script + not-self + pid>1 + pgid==pid. Any uncertainty -> skip the kill.
- **`handleStaleHost`** now auto-reaps a stale host even with live terminals (an update ships new binaries, so its terminals must restart anyway); amber "Restart Aya" icon only as a fallback.
- `ps` calls force `LC_ALL=C` so the fixed-width `lstart` parse is locale-stable.
- The host keeps its record through signal/crash exit (surviving children stay reapable next launch) and removes it only after a clean shutdown confirms children are dead.

## Safety

This SIGKILLs process trees, so it was reviewed by **Codex + Grok**. Their CRITICAL/HIGH findings are all fixed:
- snapshot-then-kill TOCTOU -> **process-group kill**
- locale-fragile `lstart` -> **LC_ALL=C**
- record removed too early (SIGTERM) -> **moved to post-child-death**
- corrupted-record wrong-group kill -> **pgid==pid guard**
- reused-pid mis-kept -> **start-time check on the keep path**

All 8 fail-closed paths are unit-tested + **mutation-verified** (18 tests in `tests/pty-host-registry.test.mjs`). **441/441 host tests green.**

## Accepted Phase-1 limits (documented in code)

- A descendant that calls `setsid()` escapes the group.
- Pre-registry strays (no record, like the 3-week-old host) need the **Phase-2 legacy sweep** (follow-up PR).
- A leader that dies in the microseconds before the kill leaves a tiny pgid-reuse window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
