### PR TITLE
Phase-2 legacy sweep: reap pre-registry stray hosts + orphaned terminal children

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -83,6 +83,7 @@ import { readRepoProjectConfig } from "./project-local";
 import { repairProcessPath } from "./shell-path";
 import { PtyHostClient } from "./pty-host-client";
 import { reapStaleHostRecords } from "./pty-host-registry";
+import { sweepLegacyAyaProcesses } from "./pty-host-sweep";
 import {
   requirePositiveInt,
   requireString,
@@ -130,6 +131,10 @@ const RECOMMENDED_OLLAMA_MODEL = "gemma4:e4b";
 
 const ptyHost = new PtyHostClient(path.join(__dirname, "pty-host.js"));
 const UPDATE_AUTO_CHECK_DELAY_MS = 12_000;
+// Delay before the Phase-2 legacy sweep (stray pre-registry hosts + orphaned
+// terminal children of dead hosts). Off the startup path: nothing it targets
+// can interfere with the fresh session, so first paint never pays for it.
+const LEGACY_SWEEP_DELAY_MS = 5_000;
 let updateStatus: UpdateStatus = {
   phase: "idle",
   supported: false,
@@ -1181,6 +1186,12 @@ function showAyaAboutPanel(): void {
 // Set to true when a stale PTY host is detected on launch (#28). The Restart
 // Aya menu item reads this flag so it can kill the stale host before relaunching.
 let staleHostDetected = false;
+// Deferred Phase-2 legacy-sweep timer; cancelled on quit so a mid-teardown
+// sweep can't spawn a host or probe processes while the app is exiting.
+let legacySweepTimer: NodeJS.Timeout | null = null;
+// Set in before-quit: an already-fired sweep callback checks it and bails
+// (clearTimeout can't stop a callback that is already running).
+let appQuitting = false;
 
 /** Build a minimal RGBA PNG containing a filled circle.
  *  Uses only Node built-ins (zlib deflate + manual PNG framing). */
@@ -2095,11 +2106,13 @@ app.whenReady().then(async () => {
   // createWindow so a recorded stale host is dead before anything can connect
   // to it; the common-path cost is one `ps -p` fork for the kept host (the
   // system-wide snapshot only runs when a kill actually happens).
+  let keptCompatibleHosts: number[] = [];
   try {
     const summary = reapStaleHostRecords(
       ptyHost.expectedHostIdentity(app.getVersion()),
       path.join(__dirname, "pty-host.js"),
     );
+    keptCompatibleHosts = summary.keptCompatible;
     if (summary.reaped.length > 0) {
       console.log(
         `[aya] reaped ${summary.reaped.length} stale pty-host(s) + ${summary.killedDescendants.length} descendant(s):`,
@@ -2162,6 +2175,56 @@ app.whenReady().then(async () => {
   // not exist yet, so apply the amber "Restart Aya" affordance now if needed.
   if (staleHostDetected) setStaleMenuIcon();
 
+  // Phase-2 legacy sweep, deferred off the startup path: clean up what the
+  // registry structurally can't reach - pre-registry stray hosts (no record
+  // file, e.g. left behind by builds before the registry existed) and orphaned
+  // terminal children whose host already died. Deferred because none of these
+  // can interfere with the fresh session (a stray host holds no socket, a dead
+  // -leader orphan has no owner), so first paint shouldn't pay for the probes.
+  legacySweepTimer = setTimeout(() => {
+    legacySweepTimer = null;
+    void (async () => {
+      try {
+        // A quit that races the timer can't un-schedule an already-running
+        // callback - bail if teardown began (the flag is set in before-quit).
+        if (appQuitting) return;
+        // The current socket host must never be swept. Fail-closed twice over:
+        // no socket file -> don't consult the client at all (hostStatus would
+        // SPAWN a host as a side effect) and run without the stray-host pass;
+        // socket present but the host reports no pid (pre-registry host) ->
+        // also skip the stray-host pass, since we can't positively exclude it.
+        // S2 is unaffected either way - a live host's children are never in a
+        // dead-leader group.
+        let strayHosts = false;
+        const exclude = new Set<number>(keptCompatibleHosts);
+        if (await pathExists(PTY_HOST_SOCKET_PATH)) {
+          const status = await ptyHost.hostStatus();
+          if (typeof status.pid === "number") {
+            exclude.add(status.pid);
+            strayHosts = true;
+          } else {
+            console.log(
+              "[aya] legacy sweep: socket host has no pid handshake - skipping stray-host pass",
+            );
+          }
+        }
+        const summary = sweepLegacyAyaProcesses(exclude, undefined, { strayHosts });
+        if (summary.sweptHosts.length > 0 || summary.sweptOrphans.length > 0) {
+          console.log(
+            `[aya] legacy sweep: killed ${summary.sweptHosts.length} stray host group(s) ${JSON.stringify(summary.sweptHosts)} + ${summary.sweptOrphans.length} orphaned terminal process(es)`,
+          );
+        }
+        if (summary.truncated > 0) {
+          console.log(
+            `[aya] legacy sweep: ${summary.truncated} orphan candidate(s) beyond the probe cap - retried next launch`,
+          );
+        }
+      } catch {
+        // best effort - never destabilize a running session over cleanup
+      }
+    })();
+  }, LEGACY_SWEEP_DELAY_MS);
+
   // Honor an initial directory argument on first launch — the renderer
   // applies the same switch-or-create logic as for second-instance.
   const initialDir = findDirInArgv(process.argv);
@@ -2184,6 +2247,11 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  appQuitting = true;
+  if (legacySweepTimer) {
+    clearTimeout(legacySweepTimer);
+    legacySweepTimer = null;
+  }
   if (!IS_E2E_PTY_SHUTDOWN) return;
   void ptyHost.shutdown().catch(() => {
     // Test-only cleanup. Normal app runs intentionally keep PTYs alive.

--- a/electron/pty-host-client.ts
+++ b/electron/pty-host-client.ts
@@ -61,23 +61,23 @@ export class PtyHostClient {
     this.socket = null;
   }
 
-  /** Running host's identity + live PTY count. identity is null if the
-   *  handshake fails (an old host that predates the `version` request errors
-   *  out - itself a stale signal); ptyCount is 0 when unknown. */
+  /** Running host's identity + live PTY count + its pid (hosts from the
+   *  registry era report it; older hosts don't -> undefined). identity is null
+   *  if the handshake fails (an old host that predates the `version` request
+   *  errors out - itself a stale signal); ptyCount is 0 when unknown. */
   async hostStatus(): Promise<{
     identity: HostIdentity | null;
     ptyCount: number;
+    pid?: number;
   }> {
     try {
       const result = await this.request({ id: 0, type: "version" });
+      const obj =
+        result && typeof result === "object" ? (result as Record<string, unknown>) : {};
       return {
         identity: asHostIdentity(result),
-        ptyCount:
-          result &&
-          typeof result === "object" &&
-          typeof (result as { ptyCount?: unknown }).ptyCount === "number"
-            ? (result as { ptyCount: number }).ptyCount
-            : 0,
+        ptyCount: typeof obj.ptyCount === "number" ? obj.ptyCount : 0,
+        pid: typeof obj.pid === "number" ? obj.pid : undefined,
       };
     } catch {
       return { identity: null, ptyCount: 0 };

--- a/electron/pty-host-sweep.ts
+++ b/electron/pty-host-sweep.ts
@@ -1,0 +1,319 @@
+// Phase-2 legacy sweep: clean up Aya processes the registry (pty-host-registry)
+// structurally cannot reach - detached PTY hosts that PREDATE the registry (no
+// record file), and orphaned terminal children whose host already died (the
+// process group persists while members live, but a leader-based registry check
+// can never authorize killing it).
+//
+// Like the registry reap, every kill decision is FAIL-CLOSED and re-verified by
+// a fresh per-pid probe IMMEDIATELY before signaling:
+//  - S1 (stray hosts): a process only qualifies when its command line contains
+//    the highly specific "dist-electron/pty-host" script path, it runs as our
+//    uid, it is a detached group leader (pgid == pid), its env's AYA scope
+//    (AYA_HOME / AYA_DEV) matches OURS (so a prod app never kills a dev
+//    workflow's host or an isolated E2E fixture host), and it is not the
+//    current socket host / a registry-kept host / ourselves. Kill = one atomic
+//    kill(-pid) of its own verified group.
+//  - S2 (orphaned children): a process only qualifies when it belongs to a
+//    process group whose LEADER IS GONE, runs as our uid, and its env carries
+//    AYA_TERMINAL_ID= - the marker safeEnv stamps on every terminal child (and
+//    its descendants inherit). The env probe doubles as the just-before-kill
+//    re-verification (a reused pid shows a different env / group).
+// Any probe failure, scope mismatch, or ambiguity -> skip, never kill.
+
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AYA_HOME } from "./paths";
+
+/** One row of the system process snapshot. */
+export interface ProcRow {
+  uid: number;
+  pid: number;
+  ppid: number;
+  pgid: number;
+  command: string;
+}
+
+/** Fresh per-pid probe result: current group + command WITH environment (ps
+ *  eww), or null when the probe failed / the pid is gone. */
+export interface EnvProbe {
+  pgid: number;
+  /** `ps eww -o command=` output: argv followed by the process environment. */
+  commandWithEnv: string;
+}
+
+/** Markers safeEnv puts in EVERY terminal child's environment (both, always).
+ *  The leading space anchors each as a distinct entry in the `ps eww` dump;
+ *  requiring both makes an accidental argv collision (a grep/editor with one
+ *  of the strings in its arguments) implausible. */
+const AYA_CHILD_MARKER = " AYA_TERMINAL_ID=";
+const AYA_HOME_MARKER = " AYA_HOME=";
+/** Env marker every PTY host carries: the client spawns it with
+ *  ELECTRON_RUN_AS_NODE=1. An editor/grep/test-runner that merely mentions the
+ *  host script path in its ARGUMENTS does not run as-node. */
+const HOST_ENV_MARKER = " ELECTRON_RUN_AS_NODE=1";
+
+/** Does this command line LOOK like a PTY host's argv? The host is spawned as
+ *  exactly [execPath, hostScript], so the script path must be the SECOND
+ *  whitespace token - a substring match anywhere in the arguments (an editor
+ *  session, a grep, a test runner touching this very file) must never qualify.
+ *  Exec paths containing spaces fail closed (that host just isn't swept). */
+export function isHostArgv(command: string): boolean {
+  const m = command.match(/^\S+\s+(\S+)/);
+  return !!m && m[1].endsWith("dist-electron/pty-host.js");
+}
+// Per-pid env probes fork `ps` each - bound the orphan scan so a pathological
+// process table can't stall startup. Anything past the cap is logged, not
+// silently dropped (it gets another chance next launch).
+export const MAX_ORPHAN_PROBES = 64;
+
+/** The AYA "scope" (config home) a process runs under, parsed from its env
+ *  dump: explicit AYA_HOME= wins; else AYA_DEV=1 implies ~/.aya-dev; else the
+ *  default ~/.aya. Mirrors electron/paths.ts. Used so a sweep only ever kills
+ *  hosts belonging to ITS OWN scope. */
+export function scopeFromEnvDump(commandWithEnv: string, homedir: string): string {
+  const m = commandWithEnv.match(/ AYA_HOME=([^ ]+)/);
+  if (m) return path.resolve(m[1]);
+  if (commandWithEnv.includes(" AYA_DEV=1")) return path.join(homedir, ".aya-dev");
+  return path.join(homedir, ".aya");
+}
+
+/** Parse `ps -Axo uid=,pid=,ppid=,pgid=,command=` output. Malformed lines are
+ *  dropped (fail-closed: an unparseable row can never become a kill target). */
+export function parseSnapshot(psOutput: string): ProcRow[] {
+  const rows: ProcRow[] = [];
+  for (const line of psOutput.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+    if (!m) continue;
+    rows.push({
+      uid: Number(m[1]),
+      pid: Number(m[2]),
+      ppid: Number(m[3]),
+      pgid: Number(m[4]),
+      command: m[5].trim(),
+    });
+  }
+  return rows;
+}
+
+/** S1 candidates: processes that LOOK like stray PTY hosts. Snapshot-level
+ *  filter only - each candidate is re-verified by a fresh env probe (signature
+ *  still present, scope matches) before any signal. */
+export function selectStrayHostCandidates(
+  rows: ProcRow[],
+  opts: { uid: number; selfPid: number; excludePids: ReadonlySet<number> },
+): ProcRow[] {
+  return rows.filter(
+    (r) =>
+      // Snapshot command is pure argv (no `e` flag) - positional check is exact.
+      isHostArgv(r.command) &&
+      r.uid === opts.uid &&
+      r.pid !== opts.selfPid &&
+      r.pid > 1 &&
+      !opts.excludePids.has(r.pid) &&
+      // Only a detached leader can be group-killed as "its own" group; a
+      // non-leader host (shouldn't exist) is skipped rather than guessed at.
+      r.pgid === r.pid,
+  );
+}
+
+/** S2 candidates: members of process groups whose leader no longer exists.
+ *  Skips our own group, host-looking processes (S1 territory), foreign uids,
+ *  and system groups. Each candidate still needs the AYA_TERMINAL_ID env
+ *  marker (checked via the per-pid probe) before it can be killed. */
+export function selectOrphanCandidates(
+  rows: ProcRow[],
+  opts: { uid: number; selfPid: number; selfPgid: number },
+): ProcRow[] {
+  const livePids = new Set(rows.map((r) => r.pid));
+  return rows.filter(
+    (r) =>
+      r.uid === opts.uid &&
+      r.pid !== opts.selfPid &&
+      r.pid > 1 &&
+      r.pgid > 1 &&
+      r.pgid !== opts.selfPgid &&
+      !livePids.has(r.pgid) && // group leader is GONE -> orphaned group
+      !isHostArgv(r.command), // hosts are S1's job
+  );
+}
+
+export interface SweepDeps {
+  snapshot: () => ProcRow[];
+  envProbe: (pid: number) => EnvProbe | null;
+  /** Fresh, direct leader-liveness check: true = leader CONFIRMED gone (ps ran
+   *  and found no such pid), false = leader alive, null = probe failed
+   *  (unknown). S2 kills only on a confirmed-gone leader - the snapshot alone
+   *  could have silently dropped a LIVE host's row (parse hiccup, truncation)
+   *  and its children must never be mistaken for orphans. */
+  leaderGone: (pgid: number) => boolean | null;
+  kill: (pid: number, signal: NodeJS.Signals) => void;
+  uid: number;
+  selfPid: number;
+  selfPgid: number;
+  ayaHome: string;
+  homedir: string;
+}
+
+export interface SweepSummary {
+  sweptHosts: number[]; // stray host leaders whose groups were killed
+  sweptOrphans: number[]; // dead-leader-group members killed individually
+  skipped: number[]; // candidates left alone (probe failed / scope or marker mismatch)
+  truncated: number; // orphan candidates beyond the probe cap (retried next launch)
+}
+
+const defaultDeps = (): SweepDeps => ({
+  snapshot: readSnapshot,
+  envProbe: readEnvProbe,
+  leaderGone: readLeaderGone,
+  kill: (pid, signal) => process.kill(pid, signal),
+  uid: process.getuid?.() ?? -1,
+  selfPid: process.pid,
+  selfPgid: (() => {
+    try {
+      return readEnvProbe(process.pid)?.pgid ?? -1;
+    } catch {
+      return -1;
+    }
+  })(),
+  ayaHome: AYA_HOME,
+  homedir: os.homedir(),
+});
+
+/** Run the legacy sweep. Both passes re-verify every candidate with a fresh
+ *  per-pid probe right before signaling; anything ambiguous is skipped. The
+ *  stray-host pass can be disabled (passes.strayHosts=false) when the caller
+ *  cannot positively identify the CURRENT socket host to exclude it - killing
+ *  hosts without that exclusion would risk sweeping the live one. */
+export function sweepLegacyAyaProcesses(
+  excludePids: ReadonlySet<number>,
+  deps: SweepDeps = defaultDeps(),
+  passes: { strayHosts: boolean } = { strayHosts: true },
+): SweepSummary {
+  const summary: SweepSummary = { sweptHosts: [], sweptOrphans: [], skipped: [], truncated: 0 };
+  if (deps.uid < 0) return summary; // no uid (should not happen on mac/linux) -> do nothing
+  const rows = deps.snapshot();
+  if (rows.length === 0) return summary;
+
+  // --- S1: stray PTY hosts (no registry record needed) ---
+  const strayCandidates = passes.strayHosts
+    ? selectStrayHostCandidates(rows, {
+        uid: deps.uid,
+        selfPid: deps.selfPid,
+        excludePids,
+      })
+    : [];
+  for (const cand of strayCandidates) {
+    const probe = deps.envProbe(cand.pid);
+    if (
+      !probe ||
+      probe.pgid !== cand.pid || // no longer (or never was) its own leader
+      !isHostArgv(probe.commandWithEnv) || // pid reused / not a host's argv shape
+      !probe.commandWithEnv.includes(HOST_ENV_MARKER) || // every real host runs as-node
+      scopeFromEnvDump(probe.commandWithEnv, deps.homedir) !== deps.ayaHome // other workflow's host
+    ) {
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    try {
+      deps.kill(-cand.pid, "SIGKILL"); // atomic: the verified leader's own group
+      summary.sweptHosts.push(cand.pid);
+    } catch {
+      summary.skipped.push(cand.pid); // vanished or not permitted - leave it
+    }
+  }
+
+  // --- S2: orphaned terminal children in dead-leader groups ---
+  const orphans = selectOrphanCandidates(rows, {
+    uid: deps.uid,
+    selfPid: deps.selfPid,
+    selfPgid: deps.selfPgid,
+  });
+  const bounded = orphans.slice(0, MAX_ORPHAN_PROBES);
+  summary.truncated = orphans.length - bounded.length;
+  // A snapshot that silently dropped a LIVE host's row (parse hiccup) would
+  // make its children look orphaned - so leader absence must be re-confirmed
+  // by a direct probe before ANY member of that group is killed. Cache per
+  // group: one extra ps per dead group, not per member.
+  const leaderGoneCache = new Map<number, boolean | null>();
+  for (const cand of bounded) {
+    let gone = leaderGoneCache.get(cand.pgid);
+    if (gone === undefined) {
+      gone = deps.leaderGone(cand.pgid);
+      leaderGoneCache.set(cand.pgid, gone);
+    }
+    if (gone !== true) {
+      // Leader alive (snapshot lied) or probe failed -> these are NOT orphans.
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    const probe = deps.envProbe(cand.pid);
+    if (
+      !probe ||
+      probe.pgid !== cand.pgid || // moved groups since the snapshot (pid reuse)
+      !probe.commandWithEnv.includes(AYA_CHILD_MARKER) || // not an Aya terminal descendant
+      !probe.commandWithEnv.includes(AYA_HOME_MARKER) // safeEnv always sets BOTH markers
+    ) {
+      summary.skipped.push(cand.pid);
+      continue;
+    }
+    try {
+      deps.kill(cand.pid, "SIGKILL");
+      summary.sweptOrphans.push(cand.pid);
+    } catch {
+      summary.skipped.push(cand.pid);
+    }
+  }
+  return summary;
+}
+
+// --- Impure OS probes (injected in tests) ----------------------------------
+
+const PS_ENV = { ...process.env, LC_ALL: "C", LANG: "C", TZ: "UTC" };
+
+/** Full system snapshot: uid, pid, ppid, pgid, command per process. */
+export function readSnapshot(): ProcRow[] {
+  try {
+    const out = execFileSync("ps", ["-Axo", "uid=,pid=,ppid=,pgid=,command="], {
+      encoding: "utf8",
+      env: PS_ENV,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return parseSnapshot(out);
+  } catch {
+    return [];
+  }
+}
+
+/** Direct leader-liveness probe. true = ps ran and CONFIRMED the pid gone
+ *  (non-zero exit with a numeric status), false = pid alive, null = the probe
+ *  itself failed (spawn error) - state unknown, callers must skip. */
+export function readLeaderGone(pid: number): boolean | null {
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "pid="], {
+      encoding: "utf8",
+      env: PS_ENV,
+    }).trim();
+    return out ? false : true;
+  } catch (err) {
+    const status = (err as { status?: unknown }).status;
+    return typeof status === "number" ? true : null;
+  }
+}
+
+/** Per-pid probe: current pgid + command INCLUDING the environment (`ps eww`).
+ *  Null when the pid is gone or ps failed - callers must skip, never kill. */
+export function readEnvProbe(pid: number): EnvProbe | null {
+  try {
+    const out = execFileSync("ps", ["eww", "-p", String(pid), "-o", "pgid=,command="], {
+      encoding: "utf8",
+      env: PS_ENV,
+      maxBuffer: 4 * 1024 * 1024,
+    }).trim();
+    const m = out.match(/^\s*(\d+)\s+(.+)$/s);
+    if (!m) return null;
+    return { pgid: Number(m[1]), commandWithEnv: m[2] };
+  } catch {
+    return null;
+  }
+}

--- a/tests/pty-host-sweep.test.mjs
+++ b/tests/pty-host-sweep.test.mjs
@@ -1,0 +1,324 @@
+// The legacy sweep SIGKILLs processes it identifies as Aya leftovers, so every
+// gate is fail-closed and pinned here: a regression that widens a filter or
+// drops a probe re-verification risks killing an unrelated user process.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseSnapshot,
+  scopeFromEnvDump,
+  isHostArgv,
+  selectStrayHostCandidates,
+  selectOrphanCandidates,
+  sweepLegacyAyaProcesses,
+  MAX_ORPHAN_PROBES,
+} from "../dist-electron/pty-host-sweep.js";
+
+const HOME = "/Users/u";
+const AYA = "/Users/u/.aya";
+const HOST_CMD =
+  "/Applications/Aya.app/Contents/MacOS/Aya /Applications/Aya.app/Contents/Resources/app.asar/dist-electron/pty-host.js";
+// A verified host's env dump: argv + as-node marker (client always sets it).
+const HOST_ENV = `${HOST_CMD} ELECTRON_RUN_AS_NODE=1 PATH=/bin USER=u`;
+// A verified orphan's env dump: argv + BOTH safeEnv markers.
+const ORPHAN_ENV = `claude --chrome AYA_TERMINAL_ID=abc AYA_HOME=${AYA} PATH=/b`;
+
+const row = (o) => ({ uid: 501, ppid: 1, command: "/bin/zsh", ...o });
+
+const baseDeps = (over) => ({
+  snapshot: () => [],
+  envProbe: () => null,
+  leaderGone: () => true,
+  kill: () => assert.fail("unexpected kill"),
+  uid: 501,
+  selfPid: 1,
+  selfPgid: 1,
+  ayaHome: AYA,
+  homedir: HOME,
+  ...over,
+});
+
+// ---------- parseSnapshot ----------
+
+test("parseSnapshot parses valid rows and drops malformed lines", () => {
+  const out = parseSnapshot(
+    [
+      "  501 100 1 100 /bin/zsh -l",
+      "501 200 100 100 sleep 30",
+      "garbage line without numbers",
+      "  0 300 1 300 /sbin/launchd",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(out, [
+    { uid: 501, pid: 100, ppid: 1, pgid: 100, command: "/bin/zsh -l" },
+    { uid: 501, pid: 200, ppid: 100, pgid: 100, command: "sleep 30" },
+    { uid: 0, pid: 300, ppid: 1, pgid: 300, command: "/sbin/launchd" },
+  ]);
+});
+
+// ---------- scopeFromEnvDump ----------
+
+test("scopeFromEnvDump: explicit AYA_HOME wins, AYA_DEV maps to .aya-dev, default .aya", () => {
+  assert.equal(scopeFromEnvDump("cmd AYA_HOME=/tmp/x PATH=/bin", HOME), "/tmp/x");
+  assert.equal(scopeFromEnvDump("cmd AYA_DEV=1 PATH=/bin", HOME), `${HOME}/.aya-dev`);
+  assert.equal(scopeFromEnvDump("cmd PATH=/bin", HOME), `${HOME}/.aya`);
+});
+
+// ---------- isHostArgv: positional, not substring ----------
+
+test("isHostArgv: matches ONLY when the script is the second argv token", () => {
+  assert.equal(isHostArgv(HOST_CMD), true);
+  assert.equal(isHostArgv("/usr/bin/node /Users/u/proj/dist-electron/pty-host.js"), true);
+  // The dangerous lookalikes a substring match would have group-killed:
+  assert.equal(isHostArgv("vim electron/pty-host-sweep.ts dist-electron/pty-host.js"), false, "path in a LATER argument");
+  assert.equal(isHostArgv("grep -r dist-electron/pty-host.js ."), false, "grep with a flag second");
+  assert.equal(isHostArgv("rg dist-electron/pty-host ."), false, "prefix without .js");
+  assert.equal(isHostArgv("/bin/zsh"), false, "no second token");
+});
+
+// ---------- S1 candidate selection ----------
+
+test("selectStrayHostCandidates: positional signature + uid + leader + exclusions", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // stray host - candidate
+    row({ pid: 901, pgid: 901, command: HOST_CMD, uid: 502 }), // other uid - no
+    row({ pid: 902, pgid: 555, command: HOST_CMD }), // not a leader - no
+    row({ pid: 903, pgid: 903, command: HOST_CMD }), // excluded (current) - no
+    row({ pid: 904, pgid: 904, command: "grep -r dist-electron/pty-host.js ." }), // argv lookalike - no
+    row({ pid: 905, pgid: 905, command: HOST_CMD }), // self - no
+  ];
+  const got = selectStrayHostCandidates(rows, {
+    uid: 501,
+    selfPid: 905,
+    excludePids: new Set([903]),
+  });
+  assert.deepEqual(got.map((r) => r.pid), [900]);
+});
+
+// ---------- S2 candidate selection ----------
+
+test("selectOrphanCandidates: only dead-leader groups, never our group or hosts", () => {
+  const rows = [
+    row({ pid: 100, pgid: 100 }), // live leader
+    row({ pid: 101, pgid: 100 }), // child of LIVE leader - no (leader alive)
+    row({ pid: 200, pgid: 7777 }), // leader 7777 gone - candidate
+    row({ pid: 201, pgid: 7777, uid: 502 }), // foreign uid - no
+    row({ pid: 202, pgid: 8888 }), // our own group - no
+    row({ pid: 203, pgid: 7777, command: HOST_CMD }), // host-shaped - S1's job, no
+    row({ pid: 204, pgid: 7777 }), // second orphan - candidate
+  ];
+  const got = selectOrphanCandidates(rows, { uid: 501, selfPid: 1000, selfPgid: 8888 });
+  assert.deepEqual(got.map((r) => r.pid).sort((a, b) => a - b), [200, 204]);
+});
+
+// ---------- orchestration: S1 ----------
+
+test("sweep S1: a verified stray host gets ONE group kill; scope mismatch and probe failure are skipped", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // ours - swept
+    row({ pid: 910, pgid: 910, command: HOST_CMD }), // dev-scoped - skipped
+    row({ pid: 920, pgid: 920, command: HOST_CMD }), // probe fails - skipped
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: (pid) => {
+        if (pid === 900) return { pgid: 900, commandWithEnv: HOST_ENV };
+        if (pid === 910)
+          return { pgid: 910, commandWithEnv: `${HOST_CMD} ELECTRON_RUN_AS_NODE=1 AYA_DEV=1 PATH=/bin` };
+        return null; // 920
+      },
+      kill: (pid, sig) => {
+        assert.equal(sig, "SIGKILL");
+        killed.push(pid);
+      },
+    }),
+  );
+  assert.deepEqual(killed, [-900], "one atomic group kill of the verified leader only");
+  assert.deepEqual(summary.sweptHosts, [900]);
+  assert.deepEqual(summary.skipped.sort((a, b) => a - b), [910, 920]);
+});
+
+test("sweep S1: a probe WITHOUT ELECTRON_RUN_AS_NODE=1 is skipped (editor/grep can't fake a host)", () => {
+  const rows = [row({ pid: 900, pgid: 900, command: HOST_CMD })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      // Argv shape matches but the as-node env marker every REAL host carries
+      // is absent -> not a host.
+      envProbe: () => ({ pgid: 900, commandWithEnv: `${HOST_CMD} PATH=/bin USER=u` }),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [900]);
+});
+
+test("sweep S1: a pid reused since the snapshot (argv no longer host-shaped) is skipped", () => {
+  const rows = [row({ pid: 900, pgid: 900, command: HOST_CMD })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: () => ({ pgid: 900, commandWithEnv: "/usr/bin/vim notes.txt PATH=/bin" }),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [900]);
+});
+
+test("sweep S1 disabled (current host unidentifiable) never kills hosts; S2 still runs", () => {
+  const rows = [
+    row({ pid: 900, pgid: 900, command: HOST_CMD }), // would-be stray
+    row({ pid: 200, pgid: 7777 }), // dead-leader orphan
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      envProbe: (pid) =>
+        pid === 200 ? { pgid: 7777, commandWithEnv: ORPHAN_ENV } : { pgid: 900, commandWithEnv: HOST_ENV },
+      leaderGone: () => true,
+      kill: (pid) => killed.push(pid),
+    }),
+    { strayHosts: false },
+  );
+  assert.deepEqual(summary.sweptHosts, [], "stray pass disabled");
+  assert.deepEqual(summary.sweptOrphans, [200]);
+  assert.deepEqual(killed, [200]);
+});
+
+// ---------- orchestration: S2 ----------
+
+test("sweep S2: kills ONLY confirmed-dead-leader members carrying BOTH safeEnv markers", () => {
+  const rows = [
+    row({ pid: 200, pgid: 7777, command: "claude --chrome" }), // both markers - swept
+    row({ pid: 201, pgid: 7777, command: "some-daemon" }), // no markers - skipped
+    row({ pid: 202, pgid: 7777, command: "sleep 5" }), // moved group - skipped
+    row({ pid: 205, pgid: 7777, command: "grep AYA_TERMINAL_ID= ." }), // one marker only (argv) - skipped
+  ];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: (pgid) => {
+        assert.equal(pgid, 7777);
+        return true; // freshly confirmed gone
+      },
+      envProbe: (pid) => {
+        if (pid === 200) return { pgid: 7777, commandWithEnv: ORPHAN_ENV };
+        if (pid === 201) return { pgid: 7777, commandWithEnv: "some-daemon PATH=/b HOME=/u" };
+        if (pid === 205)
+          return { pgid: 7777, commandWithEnv: "grep AYA_TERMINAL_ID= . PATH=/b" }; // no AYA_HOME=
+        return { pgid: 9999, commandWithEnv: ORPHAN_ENV }; // 202 moved
+      },
+      kill: (pid, sig) => {
+        assert.equal(sig, "SIGKILL");
+        killed.push(pid);
+      },
+    }),
+  );
+  assert.deepEqual(killed, [200], "dual-marker-verified orphan only");
+  assert.deepEqual(summary.sweptOrphans, [200]);
+  assert.deepEqual(summary.skipped.sort((a, b) => a - b), [201, 202, 205]);
+});
+
+test("sweep S2: a leader that is actually ALIVE (snapshot lied) blocks the whole group", () => {
+  // The snapshot dropped the live host's row (parse hiccup) - its children look
+  // orphaned. The direct leader probe must catch this and kill NOTHING.
+  const rows = [row({ pid: 200, pgid: 7777, command: "claude --chrome" })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => false, // direct probe: leader is alive!
+      envProbe: () => assert.fail("must not even env-probe members of a live-leader group"),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, [], "live-leader children are NEVER killed");
+  assert.deepEqual(summary.skipped, [200]);
+});
+
+test("sweep S2: a failed leader probe (unknown state) blocks the group", () => {
+  const rows = [row({ pid: 200, pgid: 7777, command: "claude --chrome" })];
+  const killed = [];
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => null, // probe failed - unknown
+      envProbe: () => assert.fail("no env probe on unknown leader state"),
+      kill: (pid) => killed.push(pid),
+    }),
+  );
+  assert.deepEqual(killed, []);
+  assert.deepEqual(summary.skipped, [200]);
+});
+
+test("sweep S2: the leader probe is cached per group (one ps per dead group, not per member)", () => {
+  const rows = [
+    row({ pid: 200, pgid: 7777, command: "a" }),
+    row({ pid: 204, pgid: 7777, command: "b" }),
+  ];
+  let leaderProbes = 0;
+  sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => {
+        leaderProbes += 1;
+        return true;
+      },
+      envProbe: () => null, // all members skipped after that
+      kill: () => assert.fail("nothing verifiable"),
+    }),
+  );
+  assert.equal(leaderProbes, 1, "one leader probe per group");
+});
+
+test("sweep S2: the probe cap bounds work and reports truncation (no silent cap)", () => {
+  const rows = [];
+  for (let i = 0; i < MAX_ORPHAN_PROBES + 10; i++) {
+    rows.push(row({ pid: 10_000 + i, pgid: 7777 }));
+  }
+  let envProbes = 0;
+  const summary = sweepLegacyAyaProcesses(
+    new Set(),
+    baseDeps({
+      snapshot: () => rows,
+      leaderGone: () => true,
+      envProbe: () => {
+        envProbes += 1;
+        return null; // all skipped - we only measure the bound
+      },
+      kill: () => assert.fail("nothing verifiable to kill"),
+    }),
+  );
+  assert.equal(envProbes, MAX_ORPHAN_PROBES, "env-probe count is bounded");
+  assert.equal(summary.truncated, 10, "overflow is reported, not silently dropped");
+});
+
+test("sweep: empty snapshot or missing uid is a total no-op", () => {
+  assert.deepEqual(
+    sweepLegacyAyaProcesses(new Set(), baseDeps({ snapshot: () => [] })).sweptHosts,
+    [],
+  );
+  assert.deepEqual(
+    sweepLegacyAyaProcesses(
+      new Set(),
+      baseDeps({ uid: -1, snapshot: () => assert.fail("uid gate first") }),
+    ).sweptHosts,
+    [],
+  );
+});


### PR DESCRIPTION
## Why (Phase 2 of the stale-host cleanup)

The Phase-1 registry (#74) can only reap hosts that RECORDED themselves - i.e. hosts from that build onward. It structurally cannot touch what is actually polluting machines today (found live: **22 orphaned `claude` + 46 zsh under a 2.5-day-old host, plus a 3-week-old host from an older build**):

- **pre-registry stray hosts** - no record file, off-socket, never reachable;
- **orphaned terminal children of dead hosts** - the process group persists while members live, but a leader-based registry check can never authorize killing it.

This sweep closes both. Stacked on `fix/pty-host-reap` (#74).

## What

`electron/pty-host-sweep.ts` + deferred wiring in `main.ts` (5s after the window; never on the startup path; timer cleared on quit):

- **S1 - stray hosts:** snapshot (`ps -Axo uid,pid,ppid,pgid,command`) filtered to detached leaders (pgid==pid, our uid, not self/current/kept) whose argv is host-shaped; then a fresh per-pid `ps eww` probe must STILL show (a) the host script as the **second argv token** (`isHostArgv` - positional, not substring), (b) the `ELECTRON_RUN_AS_NODE=1` env marker every real host carries, and (c) an AYA scope (`AYA_HOME=`/`AYA_DEV`) equal to OURS (a prod app never kills a dev workflow's or E2E fixture's host). Kill = ONE atomic `kill(-pid)` of the verified leader's own group.
- **S2 - orphaned children:** members of groups whose leader is absent from the snapshot; before ANY member is signaled, leader absence is **re-confirmed by a direct `ps -p pgid` probe** (ran-and-absent = gone; probe failure blocks the whole group; cached once per group), then the member's own `ps eww` must show the SAME pgid and **both** safeEnv markers (`AYA_TERMINAL_ID=` and `AYA_HOME=`). Per-pid SIGKILL; capped at 64 probes/launch with truncation logged (no silent caps).
- **Fail-closed everywhere:** any probe failure, scope/marker mismatch, moved group, or unidentifiable current host (old socket host with no pid handshake -> the whole S1 pass is disabled) means SKIP, never kill.
- `hostStatus()` now returns the host's `pid` (used to exclude the current socket host); consulted only when the socket file exists, so the sweep never spawns a host as a side effect.

## Safety review

Two independent adversarial reviews (Codex + Grok). Codex's round-1 verdict on the initial version was **"yes, an unrelated process can be killed"** (P0: argv substring spoofing - e.g. a grep/editor with the host path in its arguments; P1: a live host silently dropped from the ps snapshot would make its children look orphaned; P1: marker-in-argv; P2: timer lifecycle). All fixed as above; Grok independently confirmed the same holes and the fixes.

All four hardened gates are **mutation-verified** (loosening any single one turns tests RED): positional argv (2), as-node env marker (1), direct leader-liveness probe (2), dual safeEnv markers (1). 15 sweep tests, 466/466 total.

## Known limits (documented in code)

- A descendant that called `setsid()` into its own live group is invisible to both passes.
- Exec paths containing spaces fail the positional parse -> such hosts are skipped (fail-closed), not swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
