### PR TITLE
Extract magic numbers into named, test-pinned constants (full audit)

### DIFF
--- a/e2e/config-hot-reload.spec.ts
+++ b/e2e/config-hot-reload.spec.ts
@@ -1,3 +1,4 @@
+import { WATCH_DEBOUNCE_MS } from "../dist-electron/config-watcher.js";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { test, expect } from "./fixtures";
@@ -119,7 +120,7 @@ test("an invalid hand-edit is handled gracefully and keeps the last good state",
   // debounce so the bad write is processed, then check the UI kept the last good
   // value and stayed responsive (it didn't blank out or crash).
   writeFileSync(join(seeded.ayaHome, "snippets.json"), "{ this is not json");
-  await window.waitForTimeout(400);
+  await window.waitForTimeout(WATCH_DEBOUNCE_MS * 2);
   await expect(
     drawer.locator(".aya-snippet-name", { hasText: GOOD }),
   ).toBeVisible();

--- a/e2e/pty-kill-orphan.spec.ts
+++ b/e2e/pty-kill-orphan.spec.ts
@@ -1,3 +1,4 @@
+import { KILL_ESCALATE_MS } from "../dist-electron/pty.js";
 import { test, expect } from "./fixtures";
 import { fireShortcut } from "./helpers/shortcut";
 import { statSync } from "node:fs";
@@ -32,8 +33,16 @@ test.skip(!process.env.CI, "needs real PTY execution (unavailable in local sandb
 
 // Each tab writes to hb-<its AYA_TERMINAL_ID>.txt so a hidden sibling terminal
 // can't pollute the file we watch. Traps HUP so a plain kill won't stop it.
+// Heartbeat cadence of the trap-HUP fixture; the quiet-probe wait below spans
+// several intervals so an alive process cannot look idle.
+const HEARTBEAT_INTERVAL_MS = 150;
+// Timings anchored to the production grace window (values preserved: 700/2000).
+const GRACE_WINDOW_PROBE_TIMEOUT_MS = KILL_ESCALATE_MS - 50;
+const POST_ESCALATION_SETTLE_MS = KILL_ESCALATE_MS + 1250;
+const HEARTBEAT_QUIET_PROBE_MS = 700; // >= several heartbeat intervals
+
 const HEARTBEAT_CMD =
-  'sh -c \'trap "" HUP; while :; do echo tick >> "hb-$AYA_TERMINAL_ID.txt"; sleep 0.15; done\'';
+  `sh -c 'trap "" HUP; while :; do echo tick >> "hb-$AYA_TERMINAL_ID.txt"; sleep ${HEARTBEAT_INTERVAL_MS / 1000}; done'`;
 
 const hbSize = (dir: string, tabId: string): number => {
   const p = join(dir, `hb-${tabId}.txt`);
@@ -74,14 +83,14 @@ async function reproInLayout(
   // node-pty's default signal changed), this fails RED instead of letting the
   // test quietly decay into a facade.
   await expect
-    .poll(() => hbSize(seeded.projectDir, activeTab), { timeout: 700 })
+    .poll(() => hbSize(seeded.projectDir, activeTab), { timeout: GRACE_WINDOW_PROBE_TIMEOUT_MS })
     .toBeGreaterThan(beforeClose);
 
   // Then prove the escalation actually kills it: past the 750ms window the file
   // stops growing. (Orphan bug: a survivor would keep appending forever.)
-  await window.waitForTimeout(2000);
+  await window.waitForTimeout(POST_ESCALATION_SETTLE_MS);
   const s1 = hbSize(seeded.projectDir, activeTab);
-  await window.waitForTimeout(700); // > the 150ms heartbeat interval
+  await window.waitForTimeout(HEARTBEAT_QUIET_PROBE_MS); // > the heartbeat interval
   const s2 = hbSize(seeded.projectDir, activeTab);
   expect(s2).toBe(s1); // no further writes -> the process was actually killed
 }

--- a/electron/cli-shim.ts
+++ b/electron/cli-shim.ts
@@ -6,6 +6,7 @@
 // at the repair path; parseShimTargets lets cliStatus() detect a dead shim
 // and surface "Reinstall" in Settings.
 
+import { COMMAND_NOT_FOUND_EXIT_CODE } from "./constants";
 import * as path from "node:path";
 
 // Marker baked into every shim we generate; parseShimTargets refuses to parse
@@ -42,7 +43,7 @@ export function renderCliShim(
   lines.push(
     'if [ ! -x "$AYA_CLI" ]; then',
     '  echo "aya: cannot find Aya.app (moved or renamed?). Open Aya -> Settings -> aya command-line tool -> Reinstall." >&2',
-    "  exit 127",
+    `  exit ${COMMAND_NOT_FOUND_EXIT_CODE}`,
     "fi",
     'exec "$AYA_CLI" "$@"',
     "",

--- a/electron/config-watcher.ts
+++ b/electron/config-watcher.ts
@@ -24,7 +24,7 @@ import { AYA_HOME, PROJECTS_DIR } from "./paths";
 import type { ConfigSlice } from "./types";
 
 // A single save can fire a burst of file events, wait a moment so it becomes one reload.
-const WATCH_DEBOUNCE_MS = 200;
+export const WATCH_DEBOUNCE_MS = 200;
 // fs.watch directory events are not equally reliable across macOS/libuv
 // versions, especially in temp-like locations. Keep a scoped polling fallback
 // so manual config edits still reload even if the native directory watcher is

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,0 +1,15 @@
+// Cross-module domain constants shared by otherwise-unrelated main-process
+// modules. Values that live here are used from 2+ files that must stay in
+// sync; single-module constants belong at the top of their own file.
+
+/** POSIX "command not found / not executable" exit status. Synthesized by the
+ *  PTY host when a spawn fails, and emitted by the generated CLI shim when the
+ *  real binary is missing - both sides must report the same code or the
+ *  renderer's exit-classification drifts. */
+export const COMMAND_NOT_FOUND_EXIT_CODE = 127;
+
+/** How long a quick liveness/availability probe of an external command or
+ *  local service may take (`command -v`-style checks before spawning a preset,
+ *  harness scans, the Ollama /api/tags reachability probe). Long enough for a
+ *  cold disk hit, short enough not to stall spawning noticeably. */
+export const COMMAND_PROBE_TIMEOUT_MS = 2_500;

--- a/electron/harnesses.ts
+++ b/electron/harnesses.ts
@@ -7,6 +7,7 @@
 // binaries installed via version managers.
 
 import { execFile } from "node:child_process";
+import { COMMAND_PROBE_TIMEOUT_MS } from "./constants";
 import { userShell } from "./shell";
 
 export interface HarnessDef {
@@ -22,7 +23,6 @@ export interface HarnessDef {
 }
 
 // Timeout for the login-shell PATH probe used to detect a harness binary.
-const COMMAND_PROBE_TIMEOUT_MS = 2500;
 
 /** Known agent harnesses + interactive AI CLIs we'll probe for. Add new
  *  ones here as the ecosystem grows. */

--- a/electron/local-summary-errors.ts
+++ b/electron/local-summary-errors.ts
@@ -1,3 +1,7 @@
+/** Cap for summary-ish strings surfaced to the renderer (model summaries and
+ *  their error fallbacks share it - main.ts imports this for the former). */
+export const SUMMARY_TEXT_MAX_CHARS = 160;
+
 export function normalizeLocalSummaryError(error?: string): string | undefined {
   if (!error) return undefined;
   const cleaned = error.replace(/\s+/g, " ").trim();
@@ -9,5 +13,5 @@ export function normalizeLocalSummaryError(error?: string): string | undefined {
     return "apple-model-unavailable";
   }
   if (cleaned.includes("spawn ENOTDIR")) return "helper-not-executable";
-  return cleaned.slice(0, 160);
+  return cleaned.slice(0, SUMMARY_TEXT_MAX_CHARS);
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -78,11 +78,12 @@ import {
   uninstallUsageHook,
 } from "./usage-hook";
 import { listMonitoredSessions } from "./session-monitor";
-import { normalizeLocalSummaryError } from "./local-summary-errors";
+import { normalizeLocalSummaryError, SUMMARY_TEXT_MAX_CHARS } from "./local-summary-errors";
 import { readRepoProjectConfig } from "./project-local";
 import { repairProcessPath } from "./shell-path";
 import { PtyHostClient } from "./pty-host-client";
 import { reapStaleHostRecords } from "./pty-host-registry";
+import { COMMAND_PROBE_TIMEOUT_MS } from "./constants";
 import { sweepLegacyAyaProcesses } from "./pty-host-sweep";
 import {
   requirePositiveInt,
@@ -131,6 +132,28 @@ const RECOMMENDED_OLLAMA_MODEL = "gemma4:e4b";
 
 const ptyHost = new PtyHostClient(path.join(__dirname, "pty-host.js"));
 const UPDATE_AUTO_CHECK_DELAY_MS = 12_000;
+// Local Ollama daemon endpoint (fixed default port) - chat + tags probes.
+const OLLAMA_BASE_URL = "http://localhost:11434";
+// Summarizer sampling knobs, shared by BOTH backends (OpenAI-compatible and
+// Ollama) - the two request builders must stay in sync.
+const SUMMARY_TEMPERATURE = 0.2;
+const SUMMARY_MAX_TOKENS = 64;
+// Title fallback caps (first-line words / chars) for the local summary.
+const SUMMARY_TITLE_MAX_WORDS = 8;
+const SUMMARY_TITLE_MAX_CHARS = 80;
+// Bound captured `ollama pull` stderr so a chatty child can't balloon memory.
+const OLLAMA_PULL_STDERR_MAX_BYTES = 8192;
+// Max accepted Ollama model-name length (IPC input-validation cap).
+const OLLAMA_MODEL_NAME_MAX_LEN = 120;
+const OLLAMA_MODEL_NAME_RE = new RegExp(`^[A-Za-z0-9._:/-]{1,${OLLAMA_MODEL_NAME_MAX_LEN}}$`);
+// Cap of $PATH entries returned to the renderer diagnostics view.
+const MAX_PATH_ENTRIES_RETURNED = 40;
+// Delay before re-probing a host that answered the version handshake with
+// null - long enough for a slow cold spawn to finish listening.
+const STALE_HOST_REPROBE_DELAY_MS = 1_000;
+// macOS needs a moment after fullscreen transitions before the window hack
+// can be re-applied.
+const MACOS_FULLSCREEN_HACK_DELAY_MS = 250;
 // Delay before the Phase-2 legacy sweep (stray pre-registry hosts + orphaned
 // terminal children of dead hosts). Off the startup path: nothing it targets
 // can interfere with the fresh session, so first paint never pays for it.
@@ -289,7 +312,7 @@ async function summarizeWithApple(
         const parsed = JSON.parse(stdout) as Partial<LocalSummaryResult>;
         const summary =
           typeof parsed.summary === "string"
-            ? parsed.summary.replace(/\s+/g, " ").trim().slice(0, 160)
+            ? parsed.summary.replace(/\s+/g, " ").trim().slice(0, SUMMARY_TEXT_MAX_CHARS)
             : "";
         finish({
           available: parsed.available === true,
@@ -313,8 +336,8 @@ function cleanSummary(value: string): string {
     .replace(/\s+/g, " ")
     .replace(/^["'`]+|["'`.]+$/g, "")
     .trim();
-  const words = oneLine.split(/\s+/).filter(Boolean).slice(0, 8).join(" ");
-  return words.slice(0, 80);
+  const words = oneLine.split(/\s+/).filter(Boolean).slice(0, SUMMARY_TITLE_MAX_WORDS).join(" ");
+  return words.slice(0, SUMMARY_TITLE_MAX_CHARS);
 }
 
 function summaryPrompt(req: LocalSummaryRequest): string {
@@ -379,8 +402,8 @@ async function summarizeWithOpenAiCompatible(args: {
       },
       body: JSON.stringify({
         model,
-        temperature: 0.2,
-        max_tokens: 64,
+        temperature: SUMMARY_TEMPERATURE,
+        max_tokens: SUMMARY_MAX_TOKENS,
         think: false,
         messages: [
           {
@@ -427,7 +450,7 @@ async function summarizeWithOllama(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), LOCAL_SUMMARY_TIMEOUT_MS);
   try {
-    const response = await fetch("http://localhost:11434/api/chat", {
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
       method: "POST",
       signal: controller.signal,
       headers: { "Content-Type": "application/json" },
@@ -444,8 +467,8 @@ async function summarizeWithOllama(
           { role: "user", content: summaryPrompt(req) },
         ],
         options: {
-          temperature: 0.2,
-          num_predict: 64,
+          temperature: SUMMARY_TEMPERATURE,
+          num_predict: SUMMARY_MAX_TOKENS,
         },
       }),
     });
@@ -503,8 +526,8 @@ async function ollamaStatus(
     };
   }
   try {
-    const response = await fetch("http://localhost:11434/api/tags", {
-      signal: AbortSignal.timeout(2500),
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/tags`, {
+      signal: AbortSignal.timeout(COMMAND_PROBE_TIMEOUT_MS),
     });
     if (!response.ok) {
       return {
@@ -552,7 +575,7 @@ async function ollamaStatus(
 
 function validateOllamaModelName(value: unknown): string {
   const model = requireString(value, "intelligence:pull-ollama-model.model").trim();
-  if (!/^[A-Za-z0-9._:/-]{1,120}$/.test(model)) {
+  if (!OLLAMA_MODEL_NAME_RE.test(model)) {
     throw new Error("Ollama model name contains unsupported characters.");
   }
   return model;
@@ -568,7 +591,7 @@ async function pullOllamaModel(model: string): Promise<OllamaStatus> {
     let stderr = "";
     child.stderr.setEncoding("utf-8");
     child.stderr.on("data", (chunk: string) => {
-      if (stderr.length < 8192) stderr += chunk;
+      if (stderr.length < OLLAMA_PULL_STDERR_MAX_BYTES) stderr += chunk;
     });
     child.on("error", reject);
     child.on("close", (code) => {
@@ -737,7 +760,7 @@ async function diagnosticsReport(): Promise<DiagnosticsReport> {
     },
     shell: {
       shell: process.env.SHELL ?? null,
-      pathEntries: pathEntries().slice(0, 40),
+      pathEntries: pathEntries().slice(0, MAX_PATH_ENTRIES_RETURNED),
     },
     cli,
     ptyHost: {
@@ -1496,7 +1519,7 @@ function createWindow(initial: WindowGeometry): BrowserWindow {
   win.on("enter-full-screen", () => {
     sendFullScreen(true);
     applyMacOsWindowHack(win);
-    setTimeout(() => applyMacOsWindowHack(win), 250);
+    setTimeout(() => applyMacOsWindowHack(win), MACOS_FULLSCREEN_HACK_DELAY_MS);
   });
   win.on("leave-full-screen", () => {
     sendFullScreen(false);
@@ -1638,7 +1661,7 @@ async function handleStaleHost(): Promise<void> {
       // the freshly-spawned, current-version host. Re-probe once after a short
       // delay: a genuinely ancient host fails the version request consistently,
       // while a slow spawn answers with a matching identity the second time.
-      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      await new Promise((resolve) => setTimeout(resolve, STALE_HOST_REPROBE_DELAY_MS));
       ({ identity } = await ptyHost.hostStatus());
     }
     if (!isHostStale(expected, identity)) return;

--- a/electron/paths.ts
+++ b/electron/paths.ts
@@ -38,7 +38,8 @@ export const CONTROL_SOCKET_PATH = path.join(AYA_HOME, "aya.sock");
 export const REMOTE_SOCKET_PATH = path.join(AYA_HOME, "aya-remote.sock");
 export const PTY_HOST_SOCKET_PATH = path.join(AYA_HOME, "pty-host.sock");
 
-// rw------- for unix sockets: they accept unauthenticated local commands /
-// remote bridge traffic, so they must never be readable/writable by other users.
-// One definition for all socket servers.
-export const SOCKET_FILE_PERMISSIONS = 0o600;
+// rw------- (owner-only). Sockets accept unauthenticated local commands /
+// remote bridge traffic, and host-registry records name kill targets - none
+// of it may be readable/writable by other users. One definition for both.
+export const OWNER_ONLY_FILE_MODE = 0o600;
+export const SOCKET_FILE_PERMISSIONS = OWNER_ONLY_FILE_MODE;

--- a/electron/pty-host-registry.ts
+++ b/electron/pty-host-registry.ts
@@ -17,7 +17,7 @@ import { execFileSync } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { AYA_HOME } from "./paths";
+import { AYA_HOME, OWNER_ONLY_FILE_MODE } from "./paths";
 
 export interface HostRecord {
   /** Host process pid (also its process-group leader: spawned detached). */
@@ -49,6 +49,11 @@ export interface ProcInfo {
 
 export const HOST_REGISTRY_DIR = path.join(AYA_HOME, "pty-hosts");
 
+// Fixed width of the `ps -o lstart=` ctime field (C locale + UTC pinned in
+// PS_ENV below): "Wed Jul  2 10:00:00 2026" = 24 chars. The two slices in
+// readProcInfo MUST use the same offset - one constant keeps them agreeing.
+export const PS_LSTART_WIDTH = 24;
+
 // A .tmp older than this is a crash leftover, safe to sweep. Young .tmp files
 // are spared: another host may be mid-write (writeFileSync -> renameSync).
 const TMP_SWEEP_AGE_MS = 60_000;
@@ -64,7 +69,7 @@ export function writeHostRecord(rec: HostRecord, dir: string = HOST_REGISTRY_DIR
   const tmp = `${recordPath(dir, rec.pid)}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
   try {
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(tmp, JSON.stringify(rec), { mode: 0o600 });
+    fs.writeFileSync(tmp, JSON.stringify(rec), { mode: OWNER_ONLY_FILE_MODE });
     fs.renameSync(tmp, recordPath(dir, rec.pid));
   } catch {
     // best effort; a missing record just means this host won't be reaped by pid
@@ -242,8 +247,8 @@ export function readProcInfo(pid: number): ProcInfo {
     }).trim();
     if (!out) return { alive: false, probeFailed: false, startTime: null, command: null };
     // lstart is a fixed 24-char ctime string; the rest is the command.
-    const lstart = out.slice(0, 24).trim();
-    const command = out.slice(24).trim();
+    const lstart = out.slice(0, PS_LSTART_WIDTH).trim();
+    const command = out.slice(PS_LSTART_WIDTH).trim();
     return { alive: true, probeFailed: false, startTime: lstart, command };
   } catch (err) {
     // execFileSync throws BOTH when ps exits non-zero (pid does not exist -

--- a/electron/pty-host-sweep.ts
+++ b/electron/pty-host-sweep.ts
@@ -66,6 +66,10 @@ export function isHostArgv(command: string): boolean {
 // process table can't stall startup. Anything past the cap is logged, not
 // silently dropped (it gets another chance next launch).
 export const MAX_ORPHAN_PROBES = 64;
+// Output caps for the ps probes: the full process table can be large (many
+// processes x long commands); a single env-laden process is much smaller.
+export const PS_SNAPSHOT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+export const PS_ENV_PROBE_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
 
 /** The AYA "scope" (config home) a process runs under, parsed from its env
  *  dump: explicit AYA_HOME= wins; else AYA_DEV=1 implies ~/.aya-dev; else the
@@ -277,7 +281,7 @@ export function readSnapshot(): ProcRow[] {
     const out = execFileSync("ps", ["-Axo", "uid=,pid=,ppid=,pgid=,command="], {
       encoding: "utf8",
       env: PS_ENV,
-      maxBuffer: 16 * 1024 * 1024,
+      maxBuffer: PS_SNAPSHOT_MAX_BUFFER_BYTES,
     });
     return parseSnapshot(out);
   } catch {
@@ -308,7 +312,7 @@ export function readEnvProbe(pid: number): EnvProbe | null {
     const out = execFileSync("ps", ["eww", "-p", String(pid), "-o", "pgid=,command="], {
       encoding: "utf8",
       env: PS_ENV,
-      maxBuffer: 4 * 1024 * 1024,
+      maxBuffer: PS_ENV_PROBE_MAX_BUFFER_BYTES,
     }).trim();
     const m = out.match(/^\s*(\d+)\s+(.+)$/s);
     if (!m) return null;

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -12,10 +12,11 @@ import { execFile } from "node:child_process";
 import type * as PtyModule from "node-pty";
 import type { PtyEvent, SpawnFailureReason, SpawnRequest } from "./types";
 import { AYA_HOME, CONTROL_SOCKET_PATH } from "./paths";
+import { COMMAND_NOT_FOUND_EXIT_CODE, COMMAND_PROBE_TIMEOUT_MS } from "./constants";
 import { userShell } from "./shell";
 
 // Timeout for the shell `command -v` existence check during spawn preflight.
-const COMMAND_CHECK_TIMEOUT_MS = 2500;
+
 // Minimum PTY dimensions clamped before spawn/resize (node-pty needs >0).
 const MIN_PTY_COLS = 4; // minimum PTY columns
 const MIN_PTY_ROWS = 2; // minimum PTY rows
@@ -337,7 +338,7 @@ function reportSpawnFailure(
   const banner = `\r\n\x1b[1;31maya: \x1b[0m\x1b[31m${message}\x1b[0m\r\n\r\n`;
   sink.sendPtyEvent({ type: "spawn-failed", ptyId, reason, detail: message });
   sink.sendPtyEvent({ type: "data", ptyId, chunk: banner });
-  sink.sendPtyEvent({ type: "exit", ptyId, exitCode: 127 });
+  sink.sendPtyEvent({ type: "exit", ptyId, exitCode: COMMAND_NOT_FOUND_EXIT_CODE });
 }
 
 function preflightBinary(command: string): string | null {
@@ -358,7 +359,7 @@ function commandExists(binary: string): Promise<boolean> {
     execFile(
       userShell(),
       ["-l", "-i", "-c", `command -v -- ${binary} >/dev/null 2>&1`],
-      { timeout: COMMAND_CHECK_TIMEOUT_MS, windowsHide: true },
+      { timeout: COMMAND_PROBE_TIMEOUT_MS, windowsHide: true },
       (err) => resolve(err === null),
     );
   });

--- a/electron/remote-client.ts
+++ b/electron/remote-client.ts
@@ -12,6 +12,8 @@ import type {
 import type { RemoteMessage } from "./remote-protocol";
 
 const REQUEST_TIMEOUT_MS = 15_000;
+// Cap on the base64 bridge child's stdout - bounds the remote snapshot size.
+const REMOTE_BRIDGE_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const REMOTE_NODE_BRIDGE = `
 const net = require("node:net");
 const id = process.argv[1];
@@ -207,7 +209,7 @@ function runRemoteRequest(
       {
         encoding: "utf8",
         timeout: REQUEST_TIMEOUT_MS,
-        maxBuffer: 10 * 1024 * 1024,
+        maxBuffer: REMOTE_BRIDGE_MAX_BUFFER_BYTES,
       },
       (err, stdout, stderr) => {
         let matchedError: Error | null = null;

--- a/scripts/capture-site-assets.cjs
+++ b/scripts/capture-site-assets.cjs
@@ -1,3 +1,6 @@
+// One viewport definition - the clip clamps below must never exceed it.
+const VIEWPORT = { width: 1440, height: 920 };
+
 const { _electron: electron } = require("@playwright/test");
 const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
@@ -144,8 +147,8 @@ async function screenshotUnion(page, locators, out, padding = 18) {
   if (boxes.length === 0) throw new Error(`No boxes for ${out}`);
   const left = Math.max(0, Math.min(...boxes.map((b) => b.x)) - padding);
   const top = Math.max(0, Math.min(...boxes.map((b) => b.y)) - padding);
-  const right = Math.min(1440, Math.max(...boxes.map((b) => b.x + b.width)) + padding);
-  const bottom = Math.min(920, Math.max(...boxes.map((b) => b.y + b.height)) + padding);
+  const right = Math.min(VIEWPORT.width, Math.max(...boxes.map((b) => b.x + b.width)) + padding);
+  const bottom = Math.min(VIEWPORT.height, Math.max(...boxes.map((b) => b.y + b.height)) + padding);
   await page.screenshot({
     path: out,
     clip: { x: left, y: top, width: right - left, height: bottom - top },
@@ -174,7 +177,7 @@ async function main() {
 
   try {
     const page = await app.firstWindow();
-    await page.setViewportSize({ width: 1440, height: 920 });
+    await page.setViewportSize(VIEWPORT);
     await page.waitForLoadState("domcontentloaded");
     await waitForApp(page);
     await setDarkTheme(page);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,8 @@ const AYA_INTELLIGENCE_STORAGE_KEY = "aya:intelligence";
 const WARM_PROJECT_TERMINAL_CACHE_SIZE = 4;
 const LOCAL_SUMMARY_REFRESH_MS = 30 * 60 * 1000;
 const LOCAL_SUMMARY_DEBOUNCE_MS = 10_000;
+// Debounce for the single project-state disk writer (the #18 race fix).
+const PROJECT_STATE_SAVE_DEBOUNCE_MS = 150;
 const LOCAL_SUMMARY_MIN_UPDATE_MS = 2 * 60 * 1000;
 const LOCAL_SUMMARY_MIN_NEW_LINES = 8;
 const LOCAL_SUMMARY_MAX_LINES = 30;
@@ -1249,7 +1251,7 @@ export function App() {
         activeTab: compactRecord(activeTabByProject),
         singleView: compactRecord(singleViewByProject),
       });
-    }, 150);
+    }, PROJECT_STATE_SAVE_DEBOUNCE_MS);
     return () => window.clearTimeout(handle);
   }, [
     didBootstrap,

--- a/src/agentPreset.ts
+++ b/src/agentPreset.ts
@@ -44,8 +44,14 @@ export function effectiveAutoResume(preset: Preset): boolean {
 /** The argument that continues the MOST RECENT session for the cwd. A bare
  *  `--resume` (claude) / `resume` (codex) opens an interactive picker instead
  *  of auto-continuing, so use the "continue latest" forms. */
+/** The per-agent "continue latest session" CLI arguments. Wrong string =
+ *  silently lost agent sessions, so they are named and pinned by tests (which
+ *  also assert commandHasResumeFlag recognizes each one). */
+export const CODEX_RESUME_ARG = "resume --last";
+export const CLAUDE_RESUME_ARG = "--continue";
+
 export function resumeArg(preset: Preset): string {
-  return effectiveAgent(preset) === "codex" ? "resume --last" : "--continue";
+  return effectiveAgent(preset) === "codex" ? CODEX_RESUME_ARG : CLAUDE_RESUME_ARG;
 }
 
 /** True when the command already carries a resume/continue flag, so appending

--- a/src/components/ProjectsLeftLayout.tsx
+++ b/src/components/ProjectsLeftLayout.tsx
@@ -1,3 +1,8 @@
+import {
+  RECENT_MENU_WIDTH_PX,
+  MENU_VIEWPORT_EDGE_PX,
+  MENU_ANCHOR_GAP_PX,
+} from "../ui-constants";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { CLAUDE_BRAND_COLOR, CODEX_BRAND_COLOR } from "../colors";
 import {
@@ -176,22 +181,20 @@ export function ProjectsLeftLayout({
     // won't render) and use a functional updater so two fast toggles can't both
     // read a stale `showLauncher` and leave the menu stuck open.
     const r = anchor.getBoundingClientRect();
-    const top = Math.round(r.bottom + 6);
+    const top = Math.round(r.bottom + MENU_ANCHOR_GAP_PX);
     // The fixed menu is right-anchored by default (opens leftward, aligned to the
     // button's right edge). When the "+" sits near the left edge (few / no tabs)
     // that runs off-screen to the left, so anchor by the left edge instead (opens
-    // rightward). MENU_WIDTH must track `.aya-recent-menu { width }` in
+    // rightward). RECENT_MENU_WIDTH_PX must track `.aya-recent-menu { width }` in
     // overrides.css.
-    const MENU_WIDTH = 280;
-    const EDGE = 6;
     setMenuPos(
-      r.right < MENU_WIDTH
+      r.right < RECENT_MENU_WIDTH_PX
         ? {
             top,
             // Clamp so a very narrow window doesn't clip the right edge either.
             left: Math.max(
-              EDGE,
-              Math.min(Math.round(r.left), window.innerWidth - MENU_WIDTH - EDGE),
+              MENU_VIEWPORT_EDGE_PX,
+              Math.min(Math.round(r.left), window.innerWidth - RECENT_MENU_WIDTH_PX - MENU_VIEWPORT_EDGE_PX),
             ),
           }
         : { top, right: Math.round(window.innerWidth - r.right) },

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -51,22 +51,55 @@ export interface SearchResult {
   moreOccurrences?: number;
 }
 
+/** The whole relevance-scoring rubric in one place. Tiers follow a rough
+ *  exact = 2x prefix, prefix ~ 2-4x contains ladder; result kinds are ranked
+ *  against each other by their tier magnitudes (projects above terminals,
+ *  launcher entries above events, content hits lowest). Edit ordering here,
+ *  not in the scoring functions below. */
+const SCORE = {
+  project: { exact: 1000, prefix: 500, contains: 200 },
+  terminal: { exact: 500, prefix: 250, contains: 100 },
+  launcher: {
+    run: { exact: 800, prefix: 400, contains: 120 },
+    name: { exact: 700, prefix: 350, contains: 100 },
+    command: { exact: 500, prefix: 250, contains: 80 },
+  },
+  event: {
+    title: { exact: 650, prefix: 325, contains: 120 },
+    detail: { exact: 450, prefix: 225, contains: 90 },
+    project: { exact: 350, prefix: 175, contains: 70 },
+    terminal: { exact: 300, prefix: 150, contains: 60 },
+    level: { exact: 500, prefix: 250, contains: 100 },
+  },
+  /** Boost for "Run <preset>" launcher rows (actionable over informational). */
+  launcherRunBonus: 25,
+  /** Closed projects rank below open ones with the same match quality. */
+  closedProjectPenalty: -25,
+  /** Base score of a scrollback content hit... */
+  contentHitBase: 10,
+  /** ...plus one point per extra occurrence, capped (NOT related to the
+   *  SEARCH_MAX_RESULTS=50 result cap despite the equal value). */
+  contentHitMaxOccurrenceBonus: 50,
+  /** Small boost so a matching event outranks a bare content hit. */
+  eventBonus: 15,
+} as const;
+
 /** Per-token score against a project name. Returns 0 if the token doesn't
  *  match anywhere — caller treats that as "this token disqualifies the
  *  whole item" in AND-matching. */
 function scoreTokenAgainstProject(name: string, tok: string): number {
   const n = name.toLowerCase();
-  if (n === tok) return 1000;
-  if (n.startsWith(tok)) return 500;
-  if (n.includes(tok)) return 200;
+  if (n === tok) return SCORE.project.exact;
+  if (n.startsWith(tok)) return SCORE.project.prefix;
+  if (n.includes(tok)) return SCORE.project.contains;
   return 0;
 }
 /** Per-token score against a terminal name. */
 function scoreTokenAgainstTerminal(name: string, tok: string): number {
   const n = name.toLowerCase();
-  if (n === tok) return 500;
-  if (n.startsWith(tok)) return 250;
-  if (n.includes(tok)) return 100;
+  if (n === tok) return SCORE.terminal.exact;
+  if (n.startsWith(tok)) return SCORE.terminal.prefix;
+  if (n.includes(tok)) return SCORE.terminal.contains;
   return 0;
 }
 
@@ -103,9 +136,9 @@ function terminalAllTokens(
 function launcherAllTokens(preset: Preset, tokens: string[]): number {
   let total = 0;
   const haystacks = [
-    { value: "run", exact: 800, prefix: 400, contains: 120 },
-    { value: preset.name, exact: 700, prefix: 350, contains: 100 },
-    { value: preset.command, exact: 500, prefix: 250, contains: 80 },
+    { value: "run", ...SCORE.launcher.run },
+    { value: preset.name, ...SCORE.launcher.name },
+    { value: preset.command, ...SCORE.launcher.command },
   ];
   for (const tok of tokens) {
     let best = 0;
@@ -129,11 +162,11 @@ function eventAllTokens(
 ): number {
   let total = 0;
   const haystacks = [
-    { value: event.title, exact: 650, prefix: 325, contains: 120 },
-    { value: event.detail ?? "", exact: 450, prefix: 225, contains: 90 },
-    { value: projectName, exact: 350, prefix: 175, contains: 70 },
-    { value: terminalName, exact: 300, prefix: 150, contains: 60 },
-    { value: event.level, exact: 500, prefix: 250, contains: 100 },
+    { value: event.title, ...SCORE.event.title },
+    { value: event.detail ?? "", ...SCORE.event.detail },
+    { value: projectName, ...SCORE.event.project },
+    { value: terminalName, ...SCORE.event.terminal },
+    { value: event.level, ...SCORE.event.level },
   ];
   for (const tok of tokens) {
     let best = 0;
@@ -236,7 +269,7 @@ function buildResults(
           secondary: `New terminal in ${activeProject.name}`,
           icon: preset.icon,
           iconColor: preset.color || undefined,
-          score: s + 25,
+          score: s + SCORE.launcherRunBonus,
         });
       }
     }
@@ -254,7 +287,7 @@ function buildResults(
         label: p.name,
         secondary: isOpen ? p.directory : `Closed · ${p.directory}`,
         icon: "📁",
-        score: s + (isOpen ? 0 : -25),
+        score: s + (isOpen ? 0 : SCORE.closedProjectPenalty),
       });
     }
   }
@@ -297,7 +330,7 @@ function buildResults(
       secondary: project ? `in ${project.name}` : "",
       icon: preset.icon,
       iconColor: preset.color || undefined,
-      score: 10 + Math.min(hit.more, 50),
+      score: SCORE.contentHitBase + Math.min(hit.more, SCORE.contentHitMaxOccurrenceBonus),
       snippet: hit.snippet,
       matchStart: hit.matchStart,
       matchLength: hit.matchLength,
@@ -322,7 +355,7 @@ function buildResults(
         event.detail,
       ].filter(Boolean).join(" · "),
       icon: event.level === "error" ? "!" : event.level === "waiting" ? "?" : "i",
-      score: s + 15,
+      score: s + SCORE.eventBonus,
     });
   }
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -49,6 +49,12 @@ const RENDER_REPAIR_DELAY_MS = 80;
 const FOCUS_RETRY_DELAY_MS = 60;
 // How long to keep showing "Restoring sessions…" before assuming the replay
 // arrived (or there was nothing to replay).
+// ASCII range/offset for the Ctrl+<letter> -> control-byte mapping below:
+// 'a'(97)..'z'(122) minus 96 yields 0x01..0x1A.
+const ASCII_LOWER_A = 97;
+const ASCII_LOWER_Z = 122;
+const CTRL_BYTE_OFFSET = 96;
+
 const RESTORE_FALLBACK_MS = 2_500;
 const INPUT_LOG_MAX_CHARS = 240;
 const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`]+/i;
@@ -638,10 +644,10 @@ function TerminalViewComponent({
         ev.key.length === 1
       ) {
         const code = ev.key.toLowerCase().charCodeAt(0);
-        if (code >= 97 && code <= 122) {
+        if (code >= ASCII_LOWER_A && code <= ASCII_LOWER_Z) {
           // a–z → control byte 0x01–0x1A
           ev.preventDefault();
-          const ctrlByte = String.fromCharCode(code - 96);
+          const ctrlByte = String.fromCharCode(code - CTRL_BYTE_OFFSET);
           void window.aya.ptyWrite(terminal.id, ctrlByte);
           return false;
         }

--- a/src/components/UsageChip.tsx
+++ b/src/components/UsageChip.tsx
@@ -1,3 +1,4 @@
+import { RECENT_MENU_WIDTH_PX } from "../ui-constants";
 import { useEffect, useRef, useState } from "react";
 import type { UsageAccount, UsageData, UsageWindow } from "../types";
 
@@ -204,7 +205,7 @@ export function UsageChip({
         </span>
       </button>
       {open && (
-        <div className="aya-recent-menu" role="menu" style={{ width: 280, padding: 12 }}>
+        <div className="aya-recent-menu" role="menu" style={{ width: RECENT_MENU_WIDTH_PX, padding: 12 }}>
           <div className="aya-recent-menu-title">{label} — account-wide</div>
           <div style={{ color: CHIP_MUTED_COLOR, fontSize: 12, marginBottom: 10 }}>
             {accountText}, all sessions, not this project

--- a/src/preset-ids.ts
+++ b/src/preset-ids.ts
@@ -1,0 +1,8 @@
+// Well-known preset ids referenced by BEHAVIOR, not just display. These must
+// match the ids in electron/presets.ts (built-ins) or the id a user gives a
+// preset (gemini) - renaming either side silently disables the behavior keyed
+// on it, so the ids live here as named constants and a test cross-checks the
+// built-in ones against DEFAULT_PRESETS.
+export const PRESET_ID_CODEX = "codex";
+/** Not a built-in: matches a user-added Gemini preset by conventional id. */
+export const PRESET_ID_GEMINI = "gemini";

--- a/src/terminal-rendering.ts
+++ b/src/terminal-rendering.ts
@@ -1,11 +1,11 @@
-const SCROLLBACK_PRESERVING_PRESET_IDS = new Set([
-  "codex",
-]);
+import { PRESET_ID_CODEX, PRESET_ID_GEMINI } from "./preset-ids";
+
+const SCROLLBACK_PRESERVING_PRESET_IDS = new Set([PRESET_ID_CODEX]);
 
 // Gemini redraws its prompt/status region aggressively enough that xterm's
 // WebGL canvas can flicker on prompt-line updates. Keep opencode on WebGL:
 // its block-heavy UI shows 1px glyph seams in the DOM renderer.
-const WEBGL_DISABLED_PRESET_IDS = new Set(["gemini"]);
+const WEBGL_DISABLED_PRESET_IDS = new Set([PRESET_ID_GEMINI]);
 
 export function shouldUseTerminalWebgl(
   enableWebgl: boolean,

--- a/src/ui-constants.ts
+++ b/src/ui-constants.ts
@@ -1,0 +1,16 @@
+// Shared UI dimensions that participate in LOGIC (clamping/positioning math),
+// not just styling - so the TSX math and the inline styles agree by
+// construction. The CSS side cannot import these: .aya-recent-menu's
+// `width: 280px` in overrides.css must be kept in sync by hand (the constants
+// here are the source of truth; the clamp silently mis-positions if CSS
+// drifts).
+
+/** Fixed width of the .aya-recent-menu dropdown - used both as the rendered
+ *  width and in the off-screen clamp math. */
+export const RECENT_MENU_WIDTH_PX = 280;
+/** Minimum gap between a dropdown menu and the viewport edge. */
+export const MENU_VIEWPORT_EDGE_PX = 6;
+/** Vertical gap between a menu and its anchor button. Same value as the edge
+ *  gap today, but a distinct knob - anchoring and viewport clamping are
+ *  independent decisions. */
+export const MENU_ANCHOR_GAP_PX = 6;

--- a/tests/agent-preset.test.mjs
+++ b/tests/agent-preset.test.mjs
@@ -110,3 +110,35 @@ test("commandWithAutoResume returns the original command verbatim when skipped",
   // Empty command is returned as-is (not trimmed) so callers see no surprise.
   assert.equal(commandWithAutoResume(preset({ command: "   " }), true), "   ");
 });
+
+// --- pinned resume-arg vocabulary (cross-checked against its own detector) ---
+import {
+  CODEX_RESUME_ARG,
+  CLAUDE_RESUME_ARG,
+} from "../dist-test/agentPreset.js";
+import { PRESET_ID_CODEX, PRESET_ID_GEMINI } from "../dist-test/preset-ids.js";
+import { DEFAULT_PRESETS } from "../dist-electron/presets.js";
+
+test("resume args are the pinned CLI vocabulary", () => {
+  assert.equal(CODEX_RESUME_ARG, "resume --last");
+  assert.equal(CLAUDE_RESUME_ARG, "--continue");
+});
+
+test("commandHasResumeFlag recognizes exactly the args resumeArg appends", () => {
+  // If the arg and its detector ever drift apart, a restored tab would either
+  // double-append the flag or never resume - the bug the module guards against.
+  const claude = { id: "claude", name: "c", icon: "", color: "", command: "claude" };
+  const codex = { id: "codex", name: "x", icon: "", color: "", command: "codex" };
+  assert.equal(commandHasResumeFlag(claude, `claude ${CLAUDE_RESUME_ARG}`), true);
+  assert.equal(commandHasResumeFlag(codex, `codex ${CODEX_RESUME_ARG}`), true);
+  assert.equal(commandHasResumeFlag(claude, "claude"), false);
+  assert.equal(commandHasResumeFlag(codex, "codex"), false);
+});
+
+test("behavior-keyed preset ids match the electron built-ins (cross-boundary tripwire)", () => {
+  const ids = DEFAULT_PRESETS.map((p) => p.id);
+  assert.ok(ids.includes(PRESET_ID_CODEX), "codex built-in id drifted from PRESET_ID_CODEX");
+  // gemini is intentionally NOT a built-in - it matches a user-named preset.
+  assert.equal(ids.includes(PRESET_ID_GEMINI), false);
+  assert.equal(PRESET_ID_GEMINI, "gemini");
+});

--- a/tests/cli-shim.test.mjs
+++ b/tests/cli-shim.test.mjs
@@ -4,6 +4,7 @@
 // the repair path (Settings -> Reinstall) instead of sh's cryptic
 // "No such file or directory".
 
+import { COMMAND_NOT_FOUND_EXIT_CODE } from "../dist-electron/constants.js";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -49,7 +50,7 @@ test("when nothing resolves, the shim names the repair path and exits 127", () =
   const s = renderCliShim(PRIMARY, FALLBACK);
   assert.ok(s.includes("Settings"));
   assert.ok(s.toLowerCase().includes("reinstall"));
-  assert.ok(s.includes("exit 127"));
+  assert.ok(s.includes(`exit ${COMMAND_NOT_FOUND_EXIT_CODE}`));
 });
 
 test("parseShimTargets round-trips the generated shim", () => {

--- a/tests/ipc-validation.test.mjs
+++ b/tests/ipc-validation.test.mjs
@@ -1,6 +1,7 @@
 // Runtime validation for renderer -> main IPC payloads. TypeScript covers the
 // happy path, but malformed IPC messages still arrive as unknown at runtime.
 
+import { MAX_SPLIT_ROWS, MAX_SPLIT_COLS } from "../dist-electron/validation.js";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -94,7 +95,7 @@ test("validateProjectConfig rejects invalid split layout payloads", () => {
       validateProjectConfig({
         ...base,
         splitLayout: {
-          rows: 6,
+          rows: MAX_SPLIT_ROWS + 1,
           cols: 1,
           rowFr: [1],
           colFr: [1],
@@ -147,16 +148,16 @@ test("validateProjectConfig accepts a max 5x5 split but rejects one beyond max",
   const atMax = validateProjectConfig({
     ...base,
     splitLayout: {
-      rows: 5,
-      cols: 5,
+      rows: MAX_SPLIT_ROWS,
+      cols: MAX_SPLIT_COLS,
       rowFr: [1, 1, 1, 1, 1],
       colFr: [1, 1, 1, 1, 1],
       cells: ["t1"],
       activeCell: 0,
     },
   });
-  assert.equal(atMax.splitLayout?.rows, 5);
-  assert.equal(atMax.splitLayout?.cols, 5);
+  assert.equal(atMax.splitLayout?.rows, MAX_SPLIT_ROWS);
+  assert.equal(atMax.splitLayout?.cols, MAX_SPLIT_COLS);
 
   // One row beyond the maximum is rejected.
   assert.throws(
@@ -164,8 +165,8 @@ test("validateProjectConfig accepts a max 5x5 split but rejects one beyond max",
       validateProjectConfig({
         ...base,
         splitLayout: {
-          rows: 6,
-          cols: 5,
+          rows: MAX_SPLIT_ROWS + 1,
+          cols: MAX_SPLIT_COLS,
           rowFr: [1],
           colFr: [1],
           cells: ["t1"],
@@ -181,8 +182,8 @@ test("validateProjectConfig accepts a max 5x5 split but rejects one beyond max",
       validateProjectConfig({
         ...base,
         splitLayout: {
-          rows: 5,
-          cols: 6,
+          rows: MAX_SPLIT_ROWS,
+          cols: MAX_SPLIT_COLS + 1,
           rowFr: [1],
           colFr: [1],
           cells: ["t1"],
@@ -335,4 +336,9 @@ test("validateThemesFile checks nested theme color shape", () => {
       }),
     /themes:save\.themes\[0\]\.colors\.brightWhite/,
   );
+});
+
+test("split-grid maximum is pinned (boundary tests above derive from it)", () => {
+  assert.equal(MAX_SPLIT_ROWS, 5);
+  assert.equal(MAX_SPLIT_COLS, 5);
 });

--- a/tests/pty-host-registry.test.mjs
+++ b/tests/pty-host-registry.test.mjs
@@ -6,7 +6,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -105,6 +105,9 @@ test("host record write/read/remove round-trips atomically", () => {
   const dir = mkdtempSync(join(tmpdir(), "aya-reg-"));
   try {
     writeHostRecord(REC, dir);
+    // Records name kill targets - they must be owner-only like the sockets.
+    const mode = statSync(join(dir, `${REC.pid}.json`)).mode & 0o777;
+    assert.equal(mode, 0o600, "host record written owner-only");
     writeHostRecord({ ...REC, pid: 4343 }, dir);
     const recs = readHostRecords(dir).sort((a, b) => a.pid - b.pid);
     assert.equal(recs.length, 2);

--- a/tests/pty-kill-escalate.test.mjs
+++ b/tests/pty-kill-escalate.test.mjs
@@ -18,6 +18,15 @@ import {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Real-timer margins anchored to the production grace window so a retuned
+// KILL_ESCALATE_MS moves them automatically. Values preserved from the
+// hand-tuned originals (250 / 1000 / 700); slack is deliberate CI headroom.
+const TRAP_INSTALL_MS = 150;
+const SPAWN_SETTLE_MS = 100;
+const GRACEFUL_EXIT_SETTLE_MS = 300;
+const PRE_ESCALATION_PROBE_MS = KILL_ESCALATE_MS - 500; // after graceful kill, before SIGKILL
+const POST_ESCALATION_TOTAL_MS = KILL_ESCALATE_MS + 250; // safely past the deadline
+
 test("terminatePtyChild sends the default kill, then escalates to SIGKILL", () => {
   const signals = [];
   const fake = { kill: (s) => signals.push(s ?? "default") };
@@ -63,7 +72,7 @@ test("a SIGHUP-ignoring process survives the graceful kill but the escalation ki
   child.on("exit", () => {
     exited = true;
   });
-  await sleep(150); // let the trap install
+  await sleep(TRAP_INSTALL_MS); // let the trap install
 
   // Map the IPty-shaped kill(signal) onto the real process, recording signals so
   // we prove the graceful kill was actually SENT (not merely that the process
@@ -82,11 +91,11 @@ test("a SIGHUP-ignoring process survives the graceful kill but the escalation ki
   };
   terminatePtyChild(handle); // real setTimeout escalation
 
-  await sleep(250); // past the graceful kill, before escalation
+  await sleep(PRE_ESCALATION_PROBE_MS); // past the graceful kill, before escalation
   assert.deepEqual(signals, ["SIGHUP"], "the graceful signal was actually sent");
   assert.equal(exited, false, "SIGHUP-ignoring process must survive the graceful kill");
 
-  await sleep(1000); // past KILL_ESCALATE_MS -> SIGKILL delivered
+  await sleep(POST_ESCALATION_TOTAL_MS); // past KILL_ESCALATE_MS -> SIGKILL delivered
   assert.deepEqual(signals, ["SIGHUP", "SIGKILL"], "escalation followed with SIGKILL");
   assert.equal(exited, true, "the SIGKILL escalation must terminate the stuck process");
 });
@@ -99,7 +108,7 @@ test("a normal process exits on the graceful signal; escalation is a harmless no
   child.on("exit", () => {
     exited = true;
   });
-  await sleep(100);
+  await sleep(SPAWN_SETTLE_MS);
   // The handle does NOT swallow - so the escalation's SIGKILL on the by-then
   // dead pid throws ESRCH straight into terminatePtyChild's own try/catch. If
   // that catch regressed, the throw would escape the real setTimeout callback
@@ -109,9 +118,9 @@ test("a normal process exits on the graceful signal; escalation is a harmless no
     kill: (sig) => process.kill(child.pid, sig ?? "SIGHUP"),
   };
   assert.doesNotThrow(() => terminatePtyChild(handle));
-  await sleep(300); // graceful SIGHUP kills a non-trapping process quickly
+  await sleep(GRACEFUL_EXIT_SETTLE_MS); // graceful SIGHUP kills a non-trapping process quickly
   assert.equal(exited, true, "a non-trapping process dies on the graceful signal");
-  await sleep(700); // escalation fires on the already-dead pid -> must not crash
+  await sleep(POST_ESCALATION_TOTAL_MS - GRACEFUL_EXIT_SETTLE_MS); // total wait passes the deadline -> must not crash
 });
 
 // Edge: terminating an already-exited process throws nothing (both signals hit a

--- a/tests/shared-constants.test.mjs
+++ b/tests/shared-constants.test.mjs
@@ -1,11 +1,42 @@
-// Pins shared, security-relevant values to one source of truth. The socket
-// permission mode existed as two independent copies (pty-host.ts, control.ts)
-// before being centralized - this test pins both the value and the location.
+// Pins shared, security-relevant and cross-module values to one source of
+// truth. Several existed as independent literal copies before centralization
+// (socket perms in pty-host.ts + control.ts; 2500ms probe timeout in
+// harnesses.ts + pty.ts + main.ts; exit 127 in pty.ts + cli-shim.ts) - these
+// tests pin both the value and the single location.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { SOCKET_FILE_PERMISSIONS } from "../dist-electron/paths.js";
+import { SOCKET_FILE_PERMISSIONS, OWNER_ONLY_FILE_MODE } from "../dist-electron/paths.js";
+import {
+  COMMAND_NOT_FOUND_EXIT_CODE,
+  COMMAND_PROBE_TIMEOUT_MS,
+} from "../dist-electron/constants.js";
+import { PS_LSTART_WIDTH } from "../dist-electron/pty-host-registry.js";
+import { SUMMARY_TEXT_MAX_CHARS } from "../dist-electron/local-summary-errors.js";
 
 test("control/pty-host sockets are owner-only (rw-------)", () => {
   assert.equal(SOCKET_FILE_PERMISSIONS, 0o600);
+});
+
+test("owner-only file mode is 0o600 and the socket mode derives from it", () => {
+  assert.equal(OWNER_ONLY_FILE_MODE, 0o600);
+  assert.equal(SOCKET_FILE_PERMISSIONS, OWNER_ONLY_FILE_MODE);
+});
+
+test("command-not-found exit code is the POSIX 127", () => {
+  assert.equal(COMMAND_NOT_FOUND_EXIT_CODE, 127);
+});
+
+test("external-command probe timeout is 2.5s", () => {
+  assert.equal(COMMAND_PROBE_TIMEOUT_MS, 2_500);
+});
+
+test("ps lstart field width matches the C-locale ctime format (24 chars)", () => {
+  assert.equal(PS_LSTART_WIDTH, 24);
+  // The format the width encodes - a literal C-locale ctime example:
+  assert.equal("Wed Jul  2 10:00:00 2026".length, PS_LSTART_WIDTH);
+});
+
+test("summary text cap is 160 chars", () => {
+  assert.equal(SUMMARY_TEXT_MAX_CHARS, 160);
 });

--- a/tests/snippets.test.mjs
+++ b/tests/snippets.test.mjs
@@ -86,7 +86,7 @@ test("normalizeSnippets enforces the cap", () => {
     id: `c${i}`,
     text: `cmd ${i}`,
   }));
-  assert.equal(normalizeSnippets(many).length, 200);
+  assert.equal(normalizeSnippets(many).length, SNIPPETS_MAX);
   assert.equal(normalizeSnippets(many, 3).length, 3);
 });
 

--- a/tsconfig.test-src.json
+++ b/tsconfig.test-src.json
@@ -21,6 +21,7 @@
     "src/double-shift.ts",
     "src/focus-reporting.ts",
     "src/project-reload.ts",
+    "src/preset-ids.ts",
     "src/pty-event-reducer.ts",
     "src/terminal-option-key.ts",
     "src/terminal-keys.ts",


### PR DESCRIPTION
## What

Full magic-numbers audit across production code and tests, run as a loop until a detection pass found nothing new (4 parallel detection passes over electron/, src logic, components, tests+e2e -> extraction -> round-2 audit of the result -> round-3 terminating sweep: clean). Every replacement is value-preserving; no behavior change intended or found.

## Cross-module DRY (values that had drifted into multiple copies)

- **`COMMAND_NOT_FOUND_EXIT_CODE = 127`** (new `electron/constants.ts`) - pty.ts's synthesized exit and the generated CLI shim carried independent copies that must agree.
- **`COMMAND_PROBE_TIMEOUT_MS = 2500`** - existed as TWO differently-named private constants (harnesses.ts, pty.ts) plus a third inline copy (main.ts Ollama probe).
- **`OWNER_ONLY_FILE_MODE = 0o600`** (paths.ts; `SOCKET_FILE_PERMISSIONS` now derives from it) - the host-registry record write was the one inline holdout.
- **`SUMMARY_TEXT_MAX_CHARS = 160`** - main.ts duplicated local-summary-errors.ts's cap.
- **Ollama backend pair** (main.ts): `OLLAMA_BASE_URL`, `SUMMARY_TEMPERATURE`, `SUMMARY_MAX_TOKENS` - each was duplicated across the OpenAI-compatible and Ollama request builders.
- **`RECENT_MENU_WIDTH_PX = 280`** (new `src/ui-constants.ts`) - was 3 copies: clamp math (ProjectsLeftLayout), inline style (UsageChip), CSS. The CSS half cannot import TS and is documented as hand-synced.
- **`PRESET_ID_CODEX` / `PRESET_ID_GEMINI`** (new `src/preset-ids.ts`) - behavior-keyed ids (scrollback preserve / WebGL fallback) that silently stop matching if a preset id changes; a test cross-checks the built-in against electron's `DEFAULT_PRESETS`.
- **`CODEX_RESUME_ARG` / `CLAUDE_RESUME_ARG`** (agentPreset.ts) - plus a test asserting `commandHasResumeFlag` recognizes exactly what `resumeArg` appends (the drift that would lose agent sessions).

## Tests now derive instead of duplicating

- `ipc-validation` derives the split-grid boundary from `MAX_SPLIT_ROWS/COLS` (+1 beyond-max cases) - raw 5/6 literals would have silently detuned the boundary tests if the production max moved. Pin test added.
- `pty-kill-escalate` sleeps and the e2e orphan-spec waits are anchored to the imported `KILL_ESCALATE_MS` (values preserved; margins documented as CI slack).
- `config-hot-reload` waits derive from the now-exported `WATCH_DEBOUNCE_MS`; `snippets` reuses `SNIPPETS_MAX`; `capture-site-assets` shares one `VIEWPORT` between set + clip clamps.
- New pins in `shared-constants.test.mjs` (127, 2500, 0o600 derivation, ps-lstart 24, 160); registry test asserts records are written owner-only. Pin diagnosticity mutation-checked (2500->3000 in dist => RED).

Other single-file extractions: SearchModal's whole relevance rubric hoisted into one `SCORE` table (the occurrence-cap 50 now visibly distinct from the unrelated `SEARCH_MAX_RESULTS = 50`); `PROJECT_STATE_SAVE_DEBOUNCE_MS` (App.tsx's last unnamed timing); ASCII ctrl-byte mapping consts (TerminalView); `PS_LSTART_WIDTH`, ps `maxBuffer` caps, `REMOTE_BRIDGE_MAX_BUFFER_BYTES`, `OLLAMA_MODEL_NAME_MAX_LEN` (+hoisted regex), `STALE_HOST_REPROBE_DELAY_MS`, `MACOS_FULLSCREEN_HACK_DELAY_MS`, `MAX_PATH_ENTRIES_RETURNED`, `OLLAMA_PULL_STDERR_MAX_BYTES`, `SUMMARY_TITLE_MAX_WORDS/CHARS`.

## Deliberately left (with justification)

- **FNV-1a hash constants** (App.tsx `summaryHash`) - canonical algorithm constants, self-documented by the function name.
- **PNG codec bytes + About-dialog inline CSS** (main.ts) - self-contained codec / embedded stylesheet; naming each byte hurts readability.
- **Stale-menu icon args** `(16, 224, 112, 0)` - single call site, color named in the comment.
- **`DEFAULT_WINDOW_STATE` 1280x800** - already fields of a named exported default.
- **remote-client's `250`** exit-flush delay - lives inside the `REMOTE_NODE_BRIDGE` template string; interpolating a constant into an embedded script hurts clarity more than it helps.
- **`tests/config-watcher.test.mjs` `SETTLE_MS = 1000`** - a top-level import of the production constant is FORBIDDEN by that test's own isolation design (it must set AYA_HOME before any paths.ts load); the relationship is documented in its comment.
- **Per-scenario Playwright waits** (300/800/1000/3000/5000/10000/15000) - timing tuned per interaction; a shared name would obscure why each differs. The redundant `10_000` overrides equal to the config default were left untouched to keep this PR extraction-only.
- **Test fixture data** (fake pids, geometry rects, usage samples, 80x24 spawn scaffolding) - arbitrary inert values, not domain constants; naming adds indirection without protection.
- **CSS design values, themes.ts palette data, protocol escape sequences** - design tokens / protocol bytes, not tuning knobs.
- **Known duplication flagged for a SEPARATE change** (out of extraction-only scope): `stripAnsi` logic duplicated between src/bell.ts and electron/pty.ts (a documented near-miss), and the `local-summary-errors.ts` module existing on both sides of the boundary.

## Verification

- 2 independent detection agents re-audited the diff: all replacements value-preserving, no orphaned literals, no new magic values introduced.
- Grok review (empirical - executed `renderCliShim` to confirm the generated script is byte-identical; verified the HEARTBEAT_CMD template output, SCORE spread shape, and that e2e's dist-electron imports have no module-load side effects): "safe to merge"; its one nit (hoist the Ollama regex) is applied. Codex was started as a second reviewer but its background task hung and was abandoned.
- 472/475 unit tests green; the 3 failures are the known sandbox `posix_spawnp` denial, reproduced identically on a clean tree (stash check). E2E specs parse (`--list`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
