### PR TITLE
Codex usage chip: survive the new single-window rate_limits schema

### DIFF
--- a/electron/usage-codex.ts
+++ b/electron/usage-codex.ts
@@ -90,28 +90,69 @@ function accountMetaFromEvent(obj: {
   return { id, label };
 }
 
-/** Map Codex's rate_limits object to Aya's shared UsageData. `primary` is the
- *  5-hour window, `secondary` the weekly one; both carry `used_percent`.
- *  `resets_at` is Unix SECONDS (Codex's wire format). `updatedAtMs` is when the
- *  snapshot was produced. Returns null if either percentage is missing. */
+// Windows at or below this length render as the "5h" ring; anything longer
+// (the weekly 10080) is the "week" ring. Newer Codex schemas carry
+// window_minutes per window; older ones didn't, so position is the fallback.
+const SHORT_WINDOW_MAX_MINUTES = 600;
+
+interface CodexRawWindow {
+  used_percent?: unknown;
+  resets_at?: unknown;
+  window_minutes?: unknown;
+}
+
+/** Map Codex's rate_limits to UsageData. Historically this REQUIRED both
+ *  `primary` and `secondary` windows - newer Codex plans set `secondary: null`
+ *  and report a single weekly window in `primary` (window_minutes: 10080),
+ *  which silently killed the chip. Now: every window that carries a finite
+ *  used_percent is kept, classified by its own window_minutes (short -> 5h
+ *  ring, long -> week ring; positional fallback when absent), and a snapshot
+ *  with at least ONE valid window is a valid snapshot. */
 export function codexUsageFromRateLimit(
   rl: unknown,
   updatedAtMs: number,
 ): UsageData | null {
   if (typeof rl !== "object" || rl === null) return null;
-  const r = rl as {
-    primary?: { used_percent?: unknown; resets_at?: unknown };
-    secondary?: { used_percent?: unknown; resets_at?: unknown };
+  const r = rl as { primary?: unknown; secondary?: unknown };
+
+  const toWindow = (
+    raw: unknown,
+  ): { pct: number; resetsAt?: string; minutes?: number } | null => {
+    if (typeof raw !== "object" || raw === null) return null;
+    const w = raw as CodexRawWindow;
+    if (typeof w.used_percent !== "number" || !Number.isFinite(w.used_percent)) {
+      return null;
+    }
+    const minutes =
+      typeof w.window_minutes === "number" && Number.isFinite(w.window_minutes)
+        ? w.window_minutes
+        : undefined;
+    return {
+      pct: w.used_percent,
+      resetsAt: isoFromUnixSeconds(w.resets_at),
+      minutes,
+    };
   };
-  const p = r.primary?.used_percent;
-  const s = r.secondary?.used_percent;
-  if (typeof p !== "number" || !Number.isFinite(p)) return null;
-  if (typeof s !== "number" || !Number.isFinite(s)) return null;
-  return {
-    fiveHour: { pct: p, resetsAt: isoFromUnixSeconds(r.primary?.resets_at) },
-    sevenDay: { pct: s, resetsAt: isoFromUnixSeconds(r.secondary?.resets_at) },
-    updatedAt: new Date(updatedAtMs).toISOString(),
-  };
+
+  const result: UsageData = { updatedAt: new Date(updatedAtMs).toISOString() };
+  const positions: Array<"fiveHour" | "sevenDay"> = ["fiveHour", "sevenDay"];
+  [r.primary, r.secondary].forEach((raw, i) => {
+    const win = toWindow(raw);
+    if (!win) return;
+    const slot: "fiveHour" | "sevenDay" =
+      win.minutes !== undefined
+        ? win.minutes <= SHORT_WINDOW_MAX_MINUTES
+          ? "fiveHour"
+          : "sevenDay"
+        : positions[i];
+    // Slot conflict (two windows classifying to the same ring): DROP the
+    // extra rather than relabeling it as the other ring - a silently
+    // mislabeled limit is worse than an omitted one.
+    if (result[slot] !== undefined) return;
+    result[slot] = { pct: win.pct, resetsAt: win.resetsAt };
+  });
+  if (result.fiveHour === undefined && result.sevenDay === undefined) return null;
+  return result;
 }
 
 /** Scan rollout JSONL lines (oldest→newest) and return UsageData from the LAST

--- a/electron/usage-codex.ts
+++ b/electron/usage-codex.ts
@@ -32,7 +32,14 @@ export interface CodexUsageSource {
 
 function isoFromUnixSeconds(sec: unknown): string | undefined {
   if (typeof sec !== "number" || !Number.isFinite(sec)) return undefined;
-  return new Date(sec * 1000).toISOString();
+  const ms = sec * 1000;
+  // ECMAScript Date range guard: a finite but absurd resets_at (corrupt
+  // rollout line) would make toISOString throw RangeError, and that throw
+  // propagates through the usage:get-codex IPC handler into an uncaught
+  // rejection that silently stops the chip from refreshing (#93). An
+  // out-of-range value means "no reset time", not a poisoned snapshot.
+  if (Math.abs(ms) > 8.64e15) return undefined;
+  return new Date(ms).toISOString();
 }
 
 function firstString(...values: unknown[]): string | undefined {

--- a/electron/usage.ts
+++ b/electron/usage.ts
@@ -22,10 +22,11 @@ export interface UsageWindow {
 }
 
 export interface UsageData {
-  /** Rolling 5-hour window. */
-  fiveHour: UsageWindow;
-  /** Rolling 7-day (weekly) window — the account-wide cap. */
-  sevenDay: UsageWindow;
+  /** Rolling 5-hour window. Optional: newer Codex plans expose only a single
+   *  (weekly) window, so a snapshot may carry either ring alone. */
+  fiveHour?: UsageWindow;
+  /** Rolling 7-day (weekly) window — the account-wide cap. Optional, see above. */
+  sevenDay?: UsageWindow;
   /** ISO 8601 time the hook last wrote this snapshot. */
   updatedAt: string;
 }
@@ -49,10 +50,14 @@ function isWindow(x: unknown): x is UsageWindow {
 export function isUsageData(x: unknown): x is UsageData {
   if (typeof x !== "object" || x === null) return false;
   const r = x as Record<string, unknown>;
+  // At least one window must be present, and every present window must be
+  // well-formed. (Newer Codex plans report a single weekly window; Claude's
+  // hook always writes both - both shapes are valid snapshots.)
   return (
-    isWindow(r.fiveHour) &&
-    isWindow(r.sevenDay) &&
-    typeof r.updatedAt === "string"
+    typeof r.updatedAt === "string" &&
+    (r.fiveHour !== undefined || r.sevenDay !== undefined) &&
+    (r.fiveHour === undefined || isWindow(r.fiveHour)) &&
+    (r.sevenDay === undefined || isWindow(r.sevenDay))
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aya",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aya",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "hasInstallScript": true,
       "dependencies": {
         "@xterm/addon-web-links": "^0.12.0",

--- a/src/components/UsageChip.tsx
+++ b/src/components/UsageChip.tsx
@@ -82,8 +82,13 @@ function UsageRow({
   );
 }
 
-function averageWeeklyPct(accounts: UsageAccount[]): number {
-  if (accounts.length === 0) return 0;
+function averageUsagePct(accounts: UsageAccount[]): {
+  pct: number;
+  /** Which ring the average was computed from - the popover label must not
+   *  claim "weekly" for a 5h-only fallback (#92). */
+  ring: "weekly" | "5h";
+} {
+  if (accounts.length === 0) return { pct: 0, ring: "weekly" };
   // Average the WEEKLY ring across accounts that have one; only when no
   // account exposes a weekly window (5h-only schema) fall back to the 5h
   // ring, so a lone short-window account still lights the chip instead of
@@ -92,7 +97,10 @@ function averageWeeklyPct(accounts: UsageAccount[]): number {
   const pool = weekly.length > 0 ? weekly : accounts;
   const pick = (a: UsageAccount) =>
     a.usage.sevenDay?.pct ?? a.usage.fiveHour?.pct ?? 0;
-  return pool.reduce((sum, a) => sum + pick(a), 0) / pool.length;
+  return {
+    pct: pool.reduce((sum, a) => sum + pick(a), 0) / pool.length,
+    ring: weekly.length > 0 ? "weekly" : "5h",
+  };
 }
 
 function allUsageStale(accounts: UsageAccount[]): boolean {
@@ -128,7 +136,7 @@ export function UsageChip({
   if (accounts.length === 0) return null;
 
   const stale = allUsageStale(accounts);
-  const weeklyPct = averageWeeklyPct(accounts);
+  const { pct: weeklyPct, ring: avgRing } = averageUsagePct(accounts);
   const ringPct = Math.max(0, Math.min(100, weeklyPct));
   const accountText =
     accounts.length === 1 ? "1 account" : `${accounts.length} accounts`;
@@ -283,7 +291,7 @@ export function UsageChip({
                 paddingTop: 8,
               }}
             >
-              {Math.round(weeklyPct)}% average weekly used
+              {Math.round(weeklyPct)}% average {avgRing} used
             </div>
           )}
         </div>

--- a/src/components/UsageChip.tsx
+++ b/src/components/UsageChip.tsx
@@ -84,10 +84,15 @@ function UsageRow({
 
 function averageWeeklyPct(accounts: UsageAccount[]): number {
   if (accounts.length === 0) return 0;
-  const total = accounts.reduce((sum, account) => {
-    return sum + account.usage.sevenDay.pct;
-  }, 0);
-  return total / accounts.length;
+  // Average the WEEKLY ring across accounts that have one; only when no
+  // account exposes a weekly window (5h-only schema) fall back to the 5h
+  // ring, so a lone short-window account still lights the chip instead of
+  // silently skewing a "weekly" average alongside real weekly numbers.
+  const weekly = accounts.filter((a) => a.usage.sevenDay !== undefined);
+  const pool = weekly.length > 0 ? weekly : accounts;
+  const pick = (a: UsageAccount) =>
+    a.usage.sevenDay?.pct ?? a.usage.fiveHour?.pct ?? 0;
+  return pool.reduce((sum, a) => sum + pick(a), 0) / pool.length;
 }
 
 function allUsageStale(accounts: UsageAccount[]): boolean {
@@ -255,12 +260,16 @@ export function UsageChip({
                     {fmtClock(account.usage.updatedAt)}
                   </span>
                 </div>
-                <UsageRow label="5h" win={account.usage.fiveHour} accent={accent} />
-                <UsageRow
-                  label="week"
-                  win={account.usage.sevenDay}
-                  accent={accent}
-                />
+                {account.usage.fiveHour && (
+                  <UsageRow label="5h" win={account.usage.fiveHour} accent={accent} />
+                )}
+                {account.usage.sevenDay && (
+                  <UsageRow
+                    label="week"
+                    win={account.usage.sevenDay}
+                    accent={accent}
+                  />
+                )}
               </div>
             );
           })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,8 +44,9 @@ export interface UsageWindow {
   resetsAt?: string;
 }
 export interface UsageData {
-  fiveHour: UsageWindow;
-  sevenDay: UsageWindow;
+  /** Optional: newer Codex plans expose only a single (weekly) window. */
+  fiveHour?: UsageWindow;
+  sevenDay?: UsageWindow;
   updatedAt: string;
 }
 export interface UsageAccount {

--- a/tests/usage-codex.test.mjs
+++ b/tests/usage-codex.test.mjs
@@ -50,22 +50,79 @@ test("does NOT swap the windows (5h is primary, not the weekly 25%)", () => {
   assert.equal(u.sevenDay.pct, 25.0);
 });
 
-test("null when a window's used_percent is missing or non-numeric", () => {
-  assert.equal(codexUsageFromRateLimit({ primary: { used_percent: 1 } }, 0), null);
+test("a single valid window is a VALID snapshot (newer Codex plans have one)", () => {
+  // Contract change (the chip used to vanish on these): one finite window
+  // suffices. Position decides the ring when window_minutes is absent.
+  const only5h = codexUsageFromRateLimit({ primary: { used_percent: 1 } }, 0);
+  assert.equal(only5h.fiveHour.pct, 1);
+  assert.equal(only5h.sevenDay, undefined);
+  // An invalid sibling window is dropped, not fatal:
+  const bad5h = codexUsageFromRateLimit(
+    { primary: { used_percent: "1" }, secondary: { used_percent: 2 } },
+    0,
+  );
+  assert.equal(bad5h.fiveHour, undefined);
+  assert.equal(bad5h.sevenDay.pct, 2);
+  const nan5h = codexUsageFromRateLimit(
+    { primary: { used_percent: NaN }, secondary: { used_percent: 2 } },
+    0,
+  );
+  assert.equal(nan5h.fiveHour, undefined);
+  assert.equal(nan5h.sevenDay.pct, 2);
+});
+
+test("null only when NO window carries a finite used_percent", () => {
+  assert.equal(codexUsageFromRateLimit({ primary: {}, secondary: null }, 0), null);
   assert.equal(
     codexUsageFromRateLimit(
-      { primary: { used_percent: "1" }, secondary: { used_percent: 2 } },
+      { primary: { used_percent: "x" }, secondary: { used_percent: NaN } },
       0,
     ),
     null,
   );
-  assert.equal(
-    codexUsageFromRateLimit(
-      { primary: { used_percent: NaN }, secondary: { used_percent: 2 } },
-      0,
-    ),
-    null,
+});
+
+test("REAL new-schema payload: secondary null, weekly primary -> week ring only", () => {
+  // Verbatim shape observed live on 2026-08-01 (plan_type plus): the chip
+  // disappeared because the old parser demanded a secondary window.
+  const u = codexUsageFromRateLimit(
+    {
+      limit_id: "codex",
+      limit_name: null,
+      primary: { used_percent: 0.0, window_minutes: 10080, resets_at: 1786182650 },
+      secondary: null,
+      credits: { has_credits: false, unlimited: false, balance: "0" },
+      plan_type: "plus",
+    },
+    1780000000000,
   );
+  assert.equal(u.fiveHour, undefined, "no short window in the new schema");
+  assert.equal(u.sevenDay.pct, 0, "zero percent is a VALUE, not absence");
+  assert.equal(u.sevenDay.resetsAt, new Date(1786182650 * 1000).toISOString());
+});
+
+test("two same-class windows: the extra is DROPPED, never relabeled as the other ring", () => {
+  const u = codexUsageFromRateLimit(
+    {
+      primary: { used_percent: 3, window_minutes: 300 },
+      secondary: { used_percent: 9, window_minutes: 60 }, // also short -> conflict
+    },
+    0,
+  );
+  assert.equal(u.fiveHour.pct, 3, "first short window keeps the 5h ring");
+  assert.equal(u.sevenDay, undefined, "the extra short window must NOT masquerade as weekly");
+});
+
+test("window_minutes outranks position: a short secondary renders as the 5h ring", () => {
+  const u = codexUsageFromRateLimit(
+    {
+      primary: { used_percent: 30, window_minutes: 10080 },
+      secondary: { used_percent: 7, window_minutes: 300 },
+    },
+    0,
+  );
+  assert.equal(u.fiveHour.pct, 7);
+  assert.equal(u.sevenDay.pct, 30);
 });
 
 test("null for null / non-object", () => {
@@ -92,14 +149,25 @@ test("latestUsageFromLines uses the NEWEST complete snapshot + its timestamp", (
   assert.equal(u.updatedAt, "2026-06-03T11:00:00.000Z"); // the line's own timestamp
 });
 
-test("latestUsageFromLines skips an incomplete trailing snapshot for an earlier complete one", () => {
+test("latestUsageFromLines skips a VALUELESS trailing snapshot for an earlier valid one", () => {
   const lines = [
     line("2026-06-03T10:00:00.000Z", { primary: { used_percent: 5 }, secondary: { used_percent: 10 } }),
-    line("2026-06-03T11:00:00.000Z", { primary: { used_percent: 9 } }), // no secondary → not renderable
+    line("2026-06-03T11:00:00.000Z", { primary: {}, secondary: null }), // nothing renderable
   ];
   const u = latestUsageFromLines(lines, 0);
-  assert.equal(u.fiveHour.pct, 5); // fell back to the complete earlier snapshot
+  assert.equal(u.fiveHour.pct, 5); // fell back to the earlier valid snapshot
   assert.equal(u.sevenDay.pct, 10);
+});
+
+test("latestUsageFromLines: a trailing SINGLE-window snapshot wins (it is complete now)", () => {
+  const lines = [
+    line("2026-06-03T10:00:00.000Z", { primary: { used_percent: 5 }, secondary: { used_percent: 10 } }),
+    line("2026-06-03T11:00:00.000Z", { primary: { used_percent: 9 } }),
+  ];
+  const u = latestUsageFromLines(lines, 0);
+  assert.equal(u.fiveHour.pct, 9);
+  assert.equal(u.sevenDay, undefined);
+  assert.equal(u.updatedAt, "2026-06-03T11:00:00.000Z");
 });
 
 test("latestUsageFromLines falls back to fallbackMs when the line has no timestamp", () => {

--- a/tests/usage-codex.test.mjs
+++ b/tests/usage-codex.test.mjs
@@ -130,6 +130,21 @@ test("null for null / non-object", () => {
   assert.equal(codexUsageFromRateLimit(42, 0), null);
 });
 
+test("a finite but out-of-range resets_at drops the reset time, never throws (#93)", () => {
+  // Corrupt rollout data: resets_at far outside the ECMAScript Date range
+  // used to throw RangeError out of toISOString, and the throw propagated
+  // through the usage IPC handler and silently killed the chip's refresh.
+  const u = codexUsageFromRateLimit(
+    {
+      primary: { used_percent: 12, window_minutes: 10080, resets_at: 1e20 },
+      secondary: null,
+    },
+    0,
+  );
+  assert.equal(u.sevenDay.pct, 12, "the window itself must survive");
+  assert.equal(u.sevenDay.resetsAt, undefined, "out-of-range reset time is omitted");
+});
+
 test("resetsAt accepts only Unix seconds; absent/other types omit it", () => {
   const u = codexUsageFromRateLimit(
     { primary: { used_percent: 1, resets_at: "2026-01-01" }, secondary: { used_percent: 2 } },

--- a/tests/usage.test.mjs
+++ b/tests/usage.test.mjs
@@ -34,8 +34,14 @@ test("accepts windows without resetsAt (optional)", () => {
   );
 });
 
-test("rejects a missing window", () => {
-  assert.equal(isUsageData({ fiveHour: { pct: 30 }, updatedAt: "x" }), false);
+test("accepts a single-window snapshot (newer Codex plans have one)", () => {
+  assert.equal(isUsageData({ fiveHour: { pct: 30 }, updatedAt: "x" }), true);
+  assert.equal(isUsageData({ sevenDay: { pct: 0 }, updatedAt: "x" }), true);
+});
+
+test("rejects a snapshot with NO windows, and a present-but-invalid window", () => {
+  assert.equal(isUsageData({ updatedAt: "x" }), false);
+  assert.equal(isUsageData({ fiveHour: { pct: "30" }, updatedAt: "x" }), false);
 });
 
 test("rejects a non-numeric pct", () => {


### PR DESCRIPTION
## The bug

The Codex usage chip vanished (only the Claude one remained) while Codex was being actively used.

## Root cause - diagnosed on live data, not Aya's regression

Newer Codex CLI writes a NEW `rate_limits` schema into its rollout JSONL. Observed verbatim on a live machine:

```json
"rate_limits": {
  "limit_id": "codex", "plan_type": "plus",
  "primary":  { "used_percent": 0.0, "window_minutes": 10080, "resets_at": ... },
  "secondary": null,
  "credits": { ... }
}
```

One weekly window in `primary` (`window_minutes: 10080`), and **`secondary: null`**. Aya's parser hard-required BOTH windows' `used_percent`, so every new snapshot was rejected -> `readCodexUsage()` returned null -> the chip silently disappeared. (Reproduced deterministically: all 20 newest rollouts carried fresh snapshots, and the compiled parser returned null on them.) Two latent issues fixed along the way: the old mapping labeled `primary` as the "5h" ring by position - now wrong, since primary can be the weekly window - and `used_percent: 0` must count as a value, not absence.

## The fix

- **Parser** (`codexUsageFromRateLimit`): every window with a finite `used_percent` is kept, classified by its own `window_minutes` (<= 600 -> "5h" ring, longer -> "week"; positional fallback preserves the old schema's mapping). At least one valid window = valid snapshot. A same-ring conflict DROPS the extra window - a silently mislabeled limit is worse than an omitted one (review finding).
- **Shape**: `UsageData.fiveHour/sevenDay` are optional; `isUsageData` requires `updatedAt` + at least one well-formed window. Claude's dual-window hook output is unchanged and still valid. A consumer sweep found no other `.fiveHour`/`.sevenDay` readers outside the edited files.
- **Chip**: rings render conditionally; the top-level number averages the weekly ring across weekly-bearing accounts only, falling back to the 5h ring solely when no account has a weekly window (review finding: a 5h-only account must not skew a "weekly" average).

## Tests

Updated to the new contract + new pins: a verbatim copy of the live new-schema payload (weekly-only, `secondary: null`, `0.0` percent), `window_minutes`-outranks-position, drop-on-conflict, single-window validator cases. Classification is mutation-checked (forcing every window into the 5h ring turns 2 tests RED). Full suite 589/589 green.

Also syncs `package-lock.json`'s version field with the 0.7.8 bump in package.json (was left at 0.7.7).

Reviewed by Grok (verdict: ship; both its findings applied). Codex-as-second-reviewer was attempted twice; its background task died silently both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-review hardening (adversarial loop, rounds 1-2)

A second review loop (Grok + Codex, 3 rounds) came back clean on the parser and shape changes; two follow-ups landed in a hardening commit: the popover footer now says which ring the average was computed from instead of always claiming "weekly" (#92), and isoFromUnixSeconds gained an ECMAScript Date-range guard so a corrupt finite resets_at can no longer throw RangeError through the usage IPC and silently stop the chip refresh (#93, pre-existing on main). Suite: 590/590.
