### PR TITLE
Respawn continuity: in-session restarts of an agent tab resume its session

### DIFF
--- a/e2e/respawn-resume.spec.ts
+++ b/e2e/respawn-resume.spec.ts
@@ -71,7 +71,9 @@ async function openMarkerTabAndFinishFirstRun(window: Page, projectDir: string) 
   await window.locator(".aya-launcher .aya-launcher-btn", { hasText: "Marker" }).click();
   await expect(window.getByTestId("sidebar-terminal")).toHaveCount(3);
 
-  const markerRow = window.locator('[data-terminal-name="Marker"]');
+  // Scoped to the sidebar row - the terminal pane carries the same
+  // data-terminal-name, so an unscoped locator trips strict mode.
+  const markerRow = window.locator('.aya-sidebar-row[data-terminal-name="Marker"]');
   await expect(markerRow.locator(".aya-sidebar-statusdot--idle")).toBeVisible({
     timeout: 10_000,
   });

--- a/e2e/respawn-resume.spec.ts
+++ b/e2e/respawn-resume.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "./fixtures";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { Page } from "@playwright/test";
+
+// Continuity across IN-SESSION respawns (the "empty console after a reload"
+// report): a launcher-opened agent tab is NOT boot-restored, so its FIRST
+// spawn must not carry a resume flag - but once it has run a session
+// (confirmed live output - wasSpawned, #67), a restart must respawn WITH the
+// resume flag, or the agent starts a brand-new empty session and the user's
+// conversation is lost.
+//
+// Two restart paths are covered, and they are the only two user-facing ones:
+//  - right-click sidebar -> "Restart terminal" (App.forceRestartTerminal)
+//  - Shift+Enter in an exited terminal (App.restartTerminal)
+// Both must spawn via the restartTrigger effect, AFTER the `restored` flip
+// re-renders - a direct spawn from the event handler reads the pre-render
+// command and silently drops the resume arg (the race this spec pins).
+//
+// Marker trick: the preset is inferred as claude via CLAUDE_CONFIG_DIR= and
+// pipes `echo run` into `tee -- respawn-marker.txt`. The `echo` output marks
+// the tab as having run (wasSpawned needs confirmed live output); the `--`
+// makes tee treat EVERYTHING after it as an output file, so the ` --continue`
+// Aya appends on a resuming respawn becomes a second tee output file. The
+// assertion is therefore file EXISTENCE in the project cwd:
+//   fresh spawn   -> respawn-marker.txt only
+//   resuming spawn -> respawn-marker.txt AND a file literally named --continue
+// This works on both GNU and BSD tee (without `--`, GNU tee would reject
+// --continue as an unknown option and write nothing).
+//
+// CI-only: needs real PTY execution.
+test.skip(!process.env.CI, "needs real PTY execution (unavailable in local sandbox)");
+
+test.use({
+  seedOptions: {
+    split: false,
+    presetList: [
+      {
+        id: "shell",
+        name: "Shell",
+        icon: "$",
+        color: "",
+        // NOT an agent - keeps the seeded boot-restored tabs out of the way.
+        command: "$SHELL",
+      },
+      {
+        id: "marker",
+        name: "Marker",
+        icon: "m",
+        color: "",
+        // Agent-inferred (CLAUDE_CONFIG_DIR=). NOTE: no `sh -c` wrapper (the
+        // `-c` token trips commandHasResumeFlag and suppresses the append),
+        // and nothing after the tee file list (the resume arg is appended at
+        // the END of the command line and must land on tee's operands).
+        command: "CLAUDE_CONFIG_DIR=/tmp/aya-e2e-rr echo run | tee -- respawn-marker.txt",
+      },
+    ],
+  },
+});
+
+// Opens a Marker tab from the classic launcher (restored=false), waits until
+// the renderer has processed the whole first run, and returns the two paths
+// the assertions poll. The status dot is the deterministic "renderer caught
+// up" signal: a new tab starts as `running` and only turns `idle` when the
+// exit(0) event lands - which the event bus processes strictly AFTER the
+// `run` output that marks the tab as having had a session. (The exit hint
+// printed into xterm is not readable here - the single view may render via
+// WebGL, which leaves .xterm-rows empty.)
+async function openMarkerTabAndFinishFirstRun(window: Page, projectDir: string) {
+  await expect(window.getByTestId("xterm-host").first()).toBeVisible();
+  await window.locator(".aya-launcher .aya-launcher-btn", { hasText: "Marker" }).click();
+  await expect(window.getByTestId("sidebar-terminal")).toHaveCount(3);
+
+  const markerRow = window.locator('[data-terminal-name="Marker"]');
+  await expect(markerRow.locator(".aya-sidebar-statusdot--idle")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const markerPath = join(projectDir, "respawn-marker.txt");
+  const continuePath = join(projectDir, "--continue");
+  expect(existsSync(markerPath), "first spawn must have run (tee wrote the marker)").toBe(true);
+  expect(
+    existsSync(continuePath),
+    "first spawn of a launcher tab must be a fresh session (no resume arg)",
+  ).toBe(false);
+  return { markerRow, continuePath };
+}
+
+test("right-click Restart of a launcher-opened agent tab resumes the session", async ({
+  window,
+  seeded,
+}) => {
+  const { markerRow, continuePath } = await openMarkerTabAndFinishFirstRun(
+    window,
+    seeded.projectDir,
+  );
+
+  await markerRow.click({ button: "right" });
+  const menu = window.locator(".aya-context-menu");
+  await expect(menu).toBeVisible();
+  await menu.getByText("Restart terminal").click();
+
+  // The respawn must carry the resume arg - the tab already had a session.
+  await expect.poll(() => existsSync(continuePath), { timeout: 10_000 }).toBe(true);
+});
+
+test("Shift+Enter restart of an exited launcher-opened agent tab resumes the session", async ({
+  window,
+  seeded,
+}) => {
+  const { continuePath } = await openMarkerTabAndFinishFirstRun(window, seeded.projectDir);
+
+  // The Marker tab is active (launcher opens select it) and has exited with
+  // code 0, so the custom key handler honors Shift+Enter as "restart".
+  await window.getByTestId("xterm-host").first().click();
+  await window.keyboard.press("Shift+Enter");
+
+  await expect.poll(() => existsSync(continuePath), { timeout: 10_000 }).toBe(true);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2008,6 +2008,15 @@ export function App() {
     // Drop the confirmed-session marker so the id doesn't linger (and can't be
     // mistaken for a re-mount if the id were ever reused).
     forgetSpawn(id);
+    // Drop the restart-trigger counter too - entries are tiny, but a
+    // long-lived session cycling many tabs would otherwise retain one per
+    // closed id forever (#94).
+    setRestartTriggers((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
     void window.aya.ptyKill(id);
     appendProjectEvent({
       projectSlug: t.projectSlug,
@@ -2791,6 +2800,16 @@ export function App() {
     // session before a failed respawn keeps continuity through the sticky
     // `restored` flag flipped by that earlier restart.
     const hadSession = wasSpawned(id) && !terminal?.spawnFailure;
+    if (terminal?.spawnFailure) {
+      // The veto must not be one-shot: the banner's synthetic data event
+      // marked wasSpawned for a tab with NO real session, and the state
+      // update below clears spawnFailure - so a second restart landing
+      // before the retry resolves would see wasSpawned && !spawnFailure and
+      // latch `restored` for a session that never existed (#87). Drop the
+      // poisoned marker; a tab that had a real session keeps continuity
+      // through the sticky `restored` flag regardless.
+      forgetSpawn(id);
+    }
     setTerminals((prev) => {
       const t = prev[id];
       if (!t) return prev;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2832,8 +2832,9 @@ export function App() {
     {},
   );
 
-  /** Right-click → "Restart" handler. Kills the existing PTY (alive or
-   *  not) and asks TerminalView to spawn a fresh one. */
+  /** Right-click → "Restart" handler. Kills the PTY if it can still be
+   *  alive (see the maybeAlive gate) and asks TerminalView to spawn a
+   *  fresh one. */
   const forceRestartTerminal = useCallback(async (id: string) => {
     const t = terminalsRef.current[id];
     if (!t) return;
@@ -2841,13 +2842,24 @@ export function App() {
     // it - the respawned agent tab must resume its conversation (see
     // restartTerminal for the rationale, including the spawnFailure veto).
     const hadSession = wasSpawned(id) && !t.spawnFailure;
-    // Await the kill so the main-side ptys map is empty by the time the
-    // new spawn IPC arrives — otherwise spawnPty treats it as a re-mount
-    // and replays the old buffer instead of starting fresh.
-    try {
-      await window.aya.ptyKill(id);
-    } catch {
-      /* ignore — best effort */
+    // Kill only a possibly-live PTY. For an already-dead tab (exited - which
+    // includes spawn failures, they emit a synthetic exit - or stopped by a
+    // host restart) the host map has no entry, so killPty would arm its
+    // pending-kill marker (the closed-tab race guard) and that marker would
+    // swallow the respawn the trigger below requests - a silent "Restart did
+    // nothing" for up to the marker's TTL. A death the renderer has not seen
+    // yet (exit event still in flight) can still hit that window; the gate
+    // covers every state the user can actually observe when clicking.
+    const maybeAlive = t.exitCode === null && !t.stopped;
+    if (maybeAlive) {
+      // Await the kill so the main-side ptys map is empty by the time the
+      // new spawn IPC arrives — otherwise spawnPty treats it as a re-mount
+      // and replays the old buffer instead of starting fresh.
+      try {
+        await window.aya.ptyKill(id);
+      } catch {
+        /* ignore — best effort */
+      }
     }
     // Forget the confirmed-session marker AFTER the kill: a still-alive process
     // can emit output between the request and the kill landing, which would

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { commandWithAutoResume } from "./agentPreset";
 import { projectBaseCwd, tabFromTerminal } from "./worktree";
 import { findStatusTarget } from "./control-status-target";
 import { clearedTerminalStatus } from "./pty-event-reducer";
-import { forgetSpawn } from "./spawnSession";
+import { forgetSpawn, wasSpawned } from "./spawnSession";
 import {
   applyExternalProjectEdits,
   mergeProjectsFromDisk,
@@ -2774,6 +2774,23 @@ export function App() {
    *  can resume updating status when the new PTY emits data. */
   const restartTerminal = useCallback((id: string) => {
     const terminal = terminalsRef.current[id];
+    // Continuity across in-session respawns: if this tab already ran a session
+    // (confirmed live output - wasSpawned, #67), the respawn must carry the
+    // agent resume arg exactly like a boot-restored tab, or a launcher-opened
+    // claude/codex tab comes back as a brand-new EMPTY session and the
+    // conversation is lost. Flipping `restored` is the one gate
+    // terminalCommand already reads. A deliberately fresh session = close the
+    // tab and open a new one from the launcher.
+    //
+    // spawnFailure veto: the host paints the failure banner as a synthetic
+    // `data` event (pty.ts reportSpawnFailure) which can mark wasSpawned
+    // before the spawn-failed state lands in the ref the router guards on -
+    // and a tab whose spawn FAILED has no session to resume. Without the
+    // veto, the banner's Restart would append --continue and resume an
+    // unrelated conversation from the same cwd. A tab that had a REAL
+    // session before a failed respawn keeps continuity through the sticky
+    // `restored` flag flipped by that earlier restart.
+    const hadSession = wasSpawned(id) && !terminal?.spawnFailure;
     setTerminals((prev) => {
       const t = prev[id];
       if (!t) return prev;
@@ -2786,9 +2803,15 @@ export function App() {
           bell: false,
           spawnFailure: undefined,
           stopped: undefined,
+          restored: t.restored || hadSession,
         },
       };
     });
+    // Spawn via the restartTrigger effect in TerminalView - it fires AFTER
+    // this state batch re-renders, so the command it reads already carries the
+    // resume arg from the restored flip above. Spawning directly in the
+    // caller (the old way) raced the re-render and lost the -c.
+    setRestartTriggers((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }));
     // Also clear the activity timestamp so the dot doesn't claim "recently
     // active" until the new PTY actually writes something.
     delete lastActivityRef.current[id];
@@ -2814,6 +2837,10 @@ export function App() {
   const forceRestartTerminal = useCallback(async (id: string) => {
     const t = terminalsRef.current[id];
     if (!t) return;
+    // Read the had-a-session marker BEFORE the kill and forgetSpawn below wipe
+    // it - the respawned agent tab must resume its conversation (see
+    // restartTerminal for the rationale, including the spawnFailure veto).
+    const hadSession = wasSpawned(id) && !t.spawnFailure;
     // Await the kill so the main-side ptys map is empty by the time the
     // new spawn IPC arrives — otherwise spawnPty treats it as a re-mount
     // and replays the old buffer instead of starting fresh.
@@ -2840,6 +2867,7 @@ export function App() {
           bell: false,
           spawnFailure: undefined,
           stopped: undefined,
+          restored: cur.restored || hadSession,
         },
       };
     });

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -410,23 +410,11 @@ function TerminalViewComponent({
   // banner's "Restart" - without the spawn it would only clear the banner and
   // leave a "running" terminal with no process.
   const respawnInPlace = useCallback(() => {
-    const t = xtermRef.current;
-    if (!t) return;
+    // Delegate to the restartTrigger path: onRequestRestart clears the failed
+    // state AND bumps the trigger, whose effect spawns after the re-render
+    // (with the resume-aware command) and resets didPostLoadResizeRef itself.
     onRequestRestart?.();
-    // The spawn-failure banner chunk already flipped this ref to true, so a
-    // successful respawn would skip the one-time post-load SIGWINCH that
-    // fullscreen TUIs need. Reset it like the forced-restart path does.
-    didPostLoadResizeRef.current = false;
-    void window.aya.ptySpawn({
-      ptyId: terminal.id,
-      projectSlug: terminal.projectSlug,
-      presetId: terminal.presetId,
-      command: commandRef.current,
-      cwd: cwdRef.current,
-      cols: Math.max(t.cols, TERMINAL_FALLBACK_COLS),
-      rows: Math.max(t.rows, TERMINAL_FALLBACK_ROWS),
-    });
-  }, [onRequestRestart, terminal.id, terminal.projectSlug, terminal.presetId]);
+  }, [onRequestRestart]);
 
   const fitTerminal = useCallback((shouldFocus = false) => {
     if (fitFrameRef.current !== null) {
@@ -751,19 +739,11 @@ function TerminalViewComponent({
         if (action === "restart") {
           // Shift+Enter on a cleanly-exited terminal: restart in the same pane.
           ev.preventDefault();
-          const t = xtermRef.current;
-          if (!t) return false;
-          t.writeln("\x1b[2m[restarting...]\x1b[0m");
+          // No local spawn: onRequestRestart bumps the restartTrigger and its
+          // effect spawns AFTER the state re-render - so the command already
+          // carries the resume arg for a tab that had a session. Spawning here
+          // read the pre-render command and lost the -c.
           onRequestRestart?.();
-          void window.aya.ptySpawn({
-            ptyId: terminal.id,
-            projectSlug: terminal.projectSlug,
-            presetId: terminal.presetId,
-            command: commandRef.current,
-            cwd: cwdRef.current,
-            cols: Math.max(t.cols, TERMINAL_FALLBACK_COLS),
-            rows: Math.max(t.rows, TERMINAL_FALLBACK_ROWS),
-          });
           canRestartRef.current = false;
           return false;
         }

--- a/tests/agent-preset.test.mjs
+++ b/tests/agent-preset.test.mjs
@@ -111,6 +111,21 @@ test("commandWithAutoResume returns the original command verbatim when skipped",
   assert.equal(commandWithAutoResume(preset({ command: "   " }), true), "   ");
 });
 
+test("the e2e respawn-resume marker preset appends onto tee's operand list", () => {
+  // Pins the contract e2e/respawn-resume.spec.ts is built on: this exact
+  // command (a) infers as claude, (b) has no token commandHasResumeFlag would
+  // read as an existing resume flag (`tee --` must not count), and (c) gets
+  // the resume arg appended at the very END of the line, where tee (after its
+  // `--`) treats it as a second output file - the spec asserts that file
+  // exists. If any of these drift, the e2e goes silently vacuous.
+  const command = "CLAUDE_CONFIG_DIR=/tmp/aya-e2e-rr echo run | tee -- respawn-marker.txt";
+  const p = preset({ command });
+  assert.equal(effectiveAgent(p), "claude");
+  assert.equal(commandHasResumeFlag(p, command), false);
+  assert.equal(commandWithAutoResume(p, true), `${command} --continue`);
+  assert.equal(commandWithAutoResume(p, false), command);
+});
+
 // --- pinned resume-arg vocabulary (cross-checked against its own detector) ---
 import {
   CODEX_RESUME_ARG,


### PR DESCRIPTION
## Problem

Follow-up to the user-facing half of #83: every so often all consoles reload, and claude/codex tabs that were opened from the launcher (not boot-restored) come back as brand-new EMPTY sessions - the conversation is lost.

Root cause: the resume arg (`--continue` / `resume --last`) was gated on `terminal.restored`, which only boot hydration sets. Every in-session respawn (right-click Restart, Shift+Enter after an exit, recovery-banner Restart) of a launcher-opened tab spawned a fresh session.

## Fix (three parts)

1. **State**: `restartTerminal` and `forceRestartTerminal` capture `wasSpawned(id)` (the confirmed-live-output marker from #67) BEFORE the kill/`forgetSpawn` wipe it, and flip `restored: t.restored || hadSession`. The existing `commandWithAutoResume` gate in `terminalCommand` picks it up - no second gate. `restored` is not persisted (`WorkingTab` keeps only id/presetId/name/cwd), so boot behavior is unchanged, and non-agent presets no-op.
2. **Ordering**: all restart paths now spawn via the `restartTrigger` effect, which fires AFTER the state batch re-renders - so the command it reads already carries the resume arg. The old Shift+Enter and recovery-banner paths spawned directly from the event handler with the pre-render command and silently dropped the flag (race caught in review).
3. **spawnFailure veto** (review finding): the host paints the failure banner as a synthetic `data` event (`spawn-failed -> data -> exit` back-to-back), which can mark `wasSpawned` for a tab that never ran. Without a veto, the banner's Restart would append `--continue` and resume an UNRELATED conversation from the same cwd. `hadSession` is therefore `wasSpawned(id) && !spawnFailure`. A tab that had a real session before a failed respawn keeps continuity through the sticky `restored` flag from that earlier restart.

A deliberately fresh session is still one gesture away: close the tab and open a new one from the launcher.

## Tests

- `e2e/respawn-resume.spec.ts` (CI-only, real PTY): a launcher-opened agent tab first spawns WITHOUT the resume arg, then a right-click Restart AND a Shift+Enter restart each respawn WITH it. Marker trick: the preset pipes `echo run` into `tee -- respawn-marker.txt`; the appended ` --continue` lands after tee's `--` and becomes a second output file, so both assertions are plain file existence (works on GNU tee on the ubuntu runner and BSD tee locally). The sidebar status dot (`running -> idle` on exit 0) is the deterministic "renderer processed the run" signal - xterm text is not readable under WebGL.
- `tests/agent-preset.test.mjs` pins the marker preset's contract (infers claude, `tee --` does not trip `commandHasResumeFlag`, the append lands at the end of the line) so heuristic drift cannot silently vacate the e2e.
- Full unit suite green: 584/584.

Scope note: the e2e pins "a restart ends up WITH the resume arg" (red if the restored flip or the trigger rerouting is removed); it does not pin "exactly one spawn". The recovery-banner path shares the same code path (`onRequestRestart -> restartTerminal -> trigger effect`) but is not separately e2e'd - making a first spawn fail and the retry succeed deterministically in CI is not practical, so the veto is covered by review + the shared-path tests.

## Review

Two independent Grok passes: the first caught the pre-render spawn race (part 2) and the structurally-broken first draft of the e2e; the second confirmed the spawnFailure veto closes its ship gate with no regression to the legit resume case. No conflicting findings, so no tiebreaker pass was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up commit: dead-tab force-restart was silently swallowed (pre-existing)

The new e2e caught a real, pre-existing product bug on CI: right-click "Restart terminal" on an ALREADY-EXITED tab never respawned. `forceRestartTerminal` always awaited `ptyKill`; for a dead tab the host map has no entry, so `killPty` arms the pending-kill marker (the closed-tab race guard, 5s TTL) and that marker makes `spawnPty` silently drop the respawn requested milliseconds later. The existing restart e2e never caught it because it restarts a live shell.

Fix: kill only when the tab can still be alive (`exitCode === null && !stopped`). Grok verified the gate (dead-only signals under current host/reducer ordering, no orphan risk); the residual exit-event-in-flight window is documented in the commit and now observable via the `spawn-dropped-pending-kill` line in #85's lifecycle log.


## Post-review hardening (adversarial loop, round 2)

A second review loop (Grok + Codex, 3 rounds) found the spawnFailure veto was one-shot: the banner's synthetic data event marks `wasSpawned` for a tab with no real session, and `restartTerminal`'s veto path cleared `spawnFailure` while leaving that poisoned marker - so a second restart landing in the retry window latched `restored=true` for a session that never existed and a later successful spawn would resume an unrelated conversation (#87). The veto path now calls `forgetSpawn(id)`; `forceRestartTerminal` already self-healed via its unconditional `forgetSpawn`. Also prunes the closed tab's `restartTriggers` entry (#94, pre-existing retention).

Known accepted risk, recorded and closed as not planned: `wasSpawned` is an any-output proxy, so a preset with pre-agent output restarted mid-setup can still earn a resume flag (#96).
