### PR TITLE
PTY lifecycle log: durable JSONL trail for diagnosing mass console reloads

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -29,6 +29,7 @@ import {
   type PtyEventSink,
 } from "./pty";
 import type { PtyEvent } from "./types";
+import { ptyLog } from "./pty-log";
 
 // Wait before shutting down the idle pty host with no clients or ptys (ms).
 const IDLE_SHUTDOWN_TIMEOUT_MS = 30_000;
@@ -54,9 +55,13 @@ let hostShutdownStarted = false;
  *  process.exit(0) - the host stays alive long enough to actually deliver the
  *  escalation), then remove the registry record (children confirmed dead; a
  *  crash exit skips this and leaves the record for next-launch GC) and exit. */
-function beginShutdown(): void {
+function beginShutdown(reason: string): void {
   if (hostShutdownStarted) return; // the in-flight shutdown owns the exit
   hostShutdownStarted = true;
+  // The reason is the single most valuable line in the lifecycle log: it
+  // distinguishes "a client told this host to die" (staleness handoff) from
+  // an OS signal when every console dies at once.
+  ptyLog.append("host-shutdown", { reason, children: activePtyCount() });
   closeSocket();
   shutdownPtyChildren(() => {
     removeHostRecord(process.pid);
@@ -127,7 +132,7 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
     return null;
   }
   if (request.type === "shutdown") {
-    beginShutdown();
+    beginShutdown("client-request");
     return null;
   }
   if (request.type === "search") {
@@ -177,7 +182,10 @@ const HOST_IDENTITY: HostIdentity = computeHostIdentity();
 function scheduleIdleShutdown(): void {
   if (clients.size > 0 || activePtyCount() > 0 || idleTimer) return;
   idleTimer = setTimeout(() => {
-    if (clients.size === 0 && activePtyCount() === 0) process.exit(0);
+    if (clients.size === 0 && activePtyCount() === 0) {
+      ptyLog.append("host-idle-exit");
+      process.exit(0);
+    }
   }, IDLE_SHUTDOWN_TIMEOUT_MS);
 }
 
@@ -241,6 +249,10 @@ function start(): void {
     // launcher, future spawn change) we skip the record - degrading to
     // pre-registry behavior instead of recording an unkillable/foreign group.
     // writeHostRecord itself refuses an empty startTime (unverifiable record).
+    ptyLog.append("host-start", {
+      version: HOST_IDENTITY.version,
+      scriptHash: HOST_IDENTITY.scriptHash.slice(0, 8),
+    });
     const pgid = ownPgid();
     if (pgid === process.pid) {
       writeHostRecord({
@@ -259,8 +271,8 @@ function start(): void {
   // children (and, being same-version, the registry would keep it forever). Do a
   // real graceful shutdown instead - beginShutdown is idempotent, so a signal
   // racing an in-flight socket "shutdown" joins it instead of double-draining.
-  process.once("SIGTERM", beginShutdown);
-  process.once("SIGINT", beginShutdown);
+  process.once("SIGTERM", () => beginShutdown("SIGTERM"));
+  process.once("SIGINT", () => beginShutdown("SIGINT"));
   process.once("exit", closeSocket);
 }
 

--- a/electron/pty-log.ts
+++ b/electron/pty-log.ts
@@ -1,0 +1,91 @@
+// Durable PTY lifecycle log: one JSON object per line, appended to
+// ~/.aya/pty-events.log by whichever process runs the PTY layer (normally the
+// detached pty host). It exists to answer, after the fact, questions the
+// in-memory Attention Center feed cannot (it dies with the renderer):
+// "what killed all my consoles at 03:12?" - a burst of exit/kill lines, a
+// host-shutdown-begin with its reason, or a fresh host-start tells the story.
+//
+// Design constraints:
+// - Logging must NEVER break the PTY layer: every append is wrapped, all
+//   failures are swallowed.
+// - Small and self-limiting: the file rotates to a single `.1` generation at
+//   PTY_LOG_MAX_BYTES, so it cannot grow unbounded on a chatty session.
+// - Every line carries ts (ISO), pid (writer - distinguishes overlapping
+//   hosts during a handoff), and ev (event name); event-specific fields
+//   follow. Sizes are measured in BYTES (Buffer.byteLength), not string
+//   length - commands can contain multibyte characters.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { AYA_HOME } from "./paths";
+
+export const PTY_LOG_FILE = path.join(AYA_HOME, "pty-events.log");
+export const PTY_LOG_MAX_BYTES = 1_000_000;
+
+export interface PtyLogWriter {
+  append(event: string, fields?: Record<string, unknown>): void;
+}
+
+/** Create a lifecycle-log writer. Exported (with an injectable path and cap)
+ *  so tests can exercise append/rotation against a temp file; production code
+ *  uses the `ptyLog` singleton below. */
+export function createPtyLog(
+  file: string = PTY_LOG_FILE,
+  maxBytes: number = PTY_LOG_MAX_BYTES,
+): PtyLogWriter {
+  // Lazily stat'ed on first append, then tracked in-process. A concurrent
+  // writer (second host during a handoff) can make the size drift; the only
+  // consequence is rotating slightly early or late, which is fine.
+  let size = -1;
+  return {
+    append(event, fields) {
+      try {
+        const line = `${JSON.stringify({
+          ts: new Date().toISOString(),
+          pid: process.pid,
+          ev: event,
+          ...fields,
+        })}\n`;
+        const bytes = Buffer.byteLength(line);
+        if (size < 0) {
+          try {
+            size = fs.statSync(file).size;
+          } catch {
+            size = 0;
+          }
+        }
+        if (size + bytes > maxBytes) {
+          try {
+            fs.renameSync(file, `${file}.1`);
+          } catch {
+            // Nothing to rotate (or a concurrent writer won the rename).
+          }
+          size = 0;
+        }
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.appendFileSync(file, line);
+        size += bytes;
+      } catch {
+        // Logging must never break the PTY layer.
+      }
+    },
+  };
+}
+
+/** Singleton used by the PTY layer. The file path is resolved lazily at the
+ *  FIRST append and honors a process.env.AYA_HOME set after module load -
+ *  unit tests import the compiled pty module statically (so paths.ts already
+ *  snapshotted the real home) and only then point AYA_HOME at a tmpdir; eager
+ *  resolution here would make those tests write into the user's real ~/.aya. */
+let lazyLog: PtyLogWriter | null = null;
+export const ptyLog: PtyLogWriter = {
+  append(event, fields) {
+    if (!lazyLog) {
+      const env = process.env.AYA_HOME?.trim();
+      lazyLog = createPtyLog(
+        env ? path.join(path.resolve(env), "pty-events.log") : PTY_LOG_FILE,
+      );
+    }
+    lazyLog.append(event, fields);
+  },
+};

--- a/electron/pty-log.ts
+++ b/electron/pty-log.ts
@@ -7,7 +7,9 @@
 //
 // Design constraints:
 // - Logging must NEVER break the PTY layer: every append is wrapped, all
-//   failures are swallowed.
+//   THROWN failures are swallowed. (A blocked sync write - hung NFS $HOME,
+//   a FIFO planted at the log path - is not a throw and would stall the
+//   host; accepted risk, see #95.)
 // - Small and self-limiting: the file rotates to a single `.1` generation at
 //   PTY_LOG_MAX_BYTES, so it cannot grow unbounded on a chatty session.
 // - Every line carries ts (ISO), pid (writer - distinguishes overlapping
@@ -47,7 +49,12 @@ export function createPtyLog(
           ...fields,
         })}\n`;
         const bytes = Buffer.byteLength(line);
-        if (size < 0) {
+        if (size < 0 || size + bytes > maxBytes) {
+          // Re-stat instead of trusting the in-process counter before acting
+          // on it: a concurrent writer (second host during a handoff) may
+          // have rotated already, and rotating again off a stale size would
+          // rename a near-empty file OVER the freshly rotated generation and
+          // destroy it (#89).
           try {
             size = fs.statSync(file).size;
           } catch {
@@ -55,11 +62,13 @@ export function createPtyLog(
           }
         }
         if (size + bytes > maxBytes) {
-          try {
-            fs.renameSync(file, `${file}.1`);
-          } catch {
-            // Nothing to rotate (or a concurrent writer won the rename).
-          }
+          // No inner try: if the rename fails (`.1` unwritable), the outer
+          // catch drops this line while `size` keeps the real file size - the
+          // cap must hold even when rotation is impossible, and the previous
+          // unconditional `size = 0` here let the file grow without bound
+          // (#89). A single line larger than the whole cap is dropped the
+          // same way (spawn already clamps its command field).
+          fs.renameSync(file, `${file}.1`);
           size = 0;
         }
         fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -14,6 +14,7 @@ import type { PtyEvent, SpawnFailureReason, SpawnRequest } from "./types";
 import { AYA_HOME, CONTROL_SOCKET_PATH } from "./paths";
 import { COMMAND_NOT_FOUND_EXIT_CODE, COMMAND_PROBE_TIMEOUT_MS } from "./constants";
 import { userShell } from "./shell";
+import { ptyLog } from "./pty-log";
 
 // Timeout for the shell `command -v` existence check during spawn preflight.
 
@@ -354,6 +355,9 @@ function reportSpawnFailure(
   reason: SpawnFailureReason,
   message: string,
 ): void {
+  // Log BEFORE the destroyed-sink bail: the failure happened either way, and
+  // a failure nobody could see is exactly what the forensic log is for.
+  ptyLog.append("spawn-failed", { ptyId, reason });
   if (sink.isDestroyed()) return;
   const banner = `\r\n\x1b[1;31maya: \x1b[0m\x1b[31m${message}\x1b[0m\r\n\r\n`;
   sink.sendPtyEvent({ type: "spawn-failed", ptyId, reason, detail: message });
@@ -417,6 +421,7 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
   if (shuttingDown) {
     // The host is tearing down; a new PTY here would miss the shutdown snapshot
     // and be orphaned on exit. Drop the spawn.
+    ptyLog.append("spawn-dropped-shutting-down", { ptyId: req.ptyId });
     return;
   }
   if (pendingKills.has(req.ptyId)) {
@@ -424,6 +429,7 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     // mounting and the IPC round-trip). Drop the spawn so we don't orphan a
     // process the user already asked to discard.
     pendingKills.delete(req.ptyId);
+    ptyLog.append("spawn-dropped-pending-kill", { ptyId: req.ptyId });
     return;
   }
   if (ptys.has(req.ptyId)) {
@@ -432,6 +438,10 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     // xterm.js can repaint the existing scrollback. The PTY's own onData
     // continues to deliver new bytes to the renderer.
     const buffered = getBufferedOutput(req.ptyId);
+    ptyLog.append("spawn-replay", {
+      ptyId: req.ptyId,
+      bytes: Buffer.byteLength(buffered),
+    });
     if (buffered && !sink.isDestroyed()) {
       sink.sendPtyEvent({
         type: "data",
@@ -455,6 +465,7 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     // Re-mount of a tab that already ran this session, but its PTY is gone (the
     // process died while the host stayed up). Don't silently start a fresh
     // process - tell the renderer so it can show a stopped/restartable state.
+    ptyLog.append("no-session", { ptyId: req.ptyId });
     if (!sink.isDestroyed()) {
       sink.sendPtyEvent({ type: "no-session", ptyId: req.ptyId });
     }
@@ -568,10 +579,22 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
       } catch {
         // already gone
       }
+      ptyLog.append("spawn-killed-on-shutdown", { ptyId: req.ptyId });
       return;
     }
 
     ptys.set(req.ptyId, child);
+    // The command is logged verbatim: it is the single most diagnostic field
+    // (e.g. did this respawn carry --continue?), and it is already stored in
+    // plaintext in ~/.aya/presets.json - the log adds no new exposure.
+    ptyLog.append("spawn", {
+      ptyId: req.ptyId,
+      childPid: child.pid,
+      projectSlug: req.projectSlug,
+      presetId: req.presetId,
+      cwd,
+      command: req.command,
+    });
 
     child.onData((chunk) => {
       appendToOutputBuffer(req.ptyId, chunk);
@@ -585,6 +608,7 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
       }
       ptys.delete(req.ptyId);
       outputBuffers.delete(req.ptyId);
+      ptyLog.append("exit", { ptyId: req.ptyId, exitCode });
       if (sink.isDestroyed()) return;
       sink.sendPtyEvent({ type: "exit", ptyId: req.ptyId, exitCode });
     });
@@ -636,6 +660,7 @@ export function terminatePtyChild(
 export function killPty(ptyId: string): void {
   outputBuffers.delete(ptyId);
   const p = ptys.get(ptyId);
+  ptyLog.append("kill", { ptyId, live: !!p });
   if (!p) {
     // No PTY for this id yet — either it never existed, or the spawn IPC is
     // still in flight. Mark it so a late-arriving spawnPty bails out. The
@@ -718,6 +743,7 @@ export function shutdownPtyChildren(
   // snapshot below and getting orphaned when the host exits.
   shuttingDown = true;
   const children = [...ptys.values()];
+  ptyLog.append("children-shutdown", { children: children.length });
   ptys.clear();
   outputBuffers.clear();
   pendingKills.clear();

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -459,6 +459,7 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     // renderer, so emitting no-session here would falsely strand the tab as
     // stopped. (Checked before attachOnly so the host is robust regardless of
     // the renderer's confirmed-output gating.)
+    ptyLog.append("spawn-dropped-in-flight", { ptyId: req.ptyId });
     return;
   }
   if (req.attachOnly) {
@@ -573,6 +574,9 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
       // Registering now would orphan this child, and a scheduled escalation might
       // not fire before the host exits - so force-kill it synchronously (the
       // SIGKILL syscall dooms it regardless of the host's remaining lifetime).
+      child.onExit(({ exitCode }) => {
+        ptyLog.append("exit", { ptyId: req.ptyId, exitCode, killed: true });
+      });
       try {
         child.kill();
         child.kill("SIGKILL");
@@ -593,7 +597,10 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
       projectSlug: req.projectSlug,
       presetId: req.presetId,
       cwd,
-      command: req.command,
+      // Clamped: the command is unbounded user input, and a single line
+      // larger than the log cap would blow straight past it (#89). 4 KB
+      // keeps every realistic command (and its resume arg) intact.
+      command: req.command.slice(0, 4096),
     });
 
     child.onData((chunk) => {
@@ -673,6 +680,13 @@ export function killPty(ptyId: string): void {
   // PTY), then terminate with SIGKILL escalation so a signal-ignoring child
   // can't survive and get orphaned.
   ptys.delete(ptyId);
+  // The spawn-time onExit skips its "exit" append once the map entry is gone
+  // (its identity guard exists so a respawn under the same id is not wrongly
+  // torn down) - so log the killed child's actual exit here, or the forensic
+  // trail shows a kill with no evidence the child ever died (#88).
+  p.onExit(({ exitCode }) => {
+    ptyLog.append("exit", { ptyId, exitCode, killed: true });
+  });
   terminatePtyChild(p);
 }
 
@@ -742,8 +756,17 @@ export function shutdownPtyChildren(
   // Block any further spawns (including one mid-preflight) from escaping the
   // snapshot below and getting orphaned when the host exits.
   shuttingDown = true;
-  const children = [...ptys.values()];
+  const entries = [...ptys.entries()];
+  const children = entries.map(([, child]) => child);
   ptyLog.append("children-shutdown", { children: children.length });
+  // Same identity-guard gap as killPty: the map is cleared below, so the
+  // spawn-time onExit never logs these deaths. Log each child's exit (with
+  // code) from here so a mass shutdown leaves a per-child trail (#88).
+  for (const [ptyId, child] of entries) {
+    child.onExit(({ exitCode }) => {
+      ptyLog.append("exit", { ptyId, exitCode, killed: true });
+    });
+  }
   ptys.clear();
   outputBuffers.clear();
   pendingKills.clear();

--- a/tests/pty-attach-only.test.mjs
+++ b/tests/pty-attach-only.test.mjs
@@ -7,10 +7,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawnPty } from "../dist-electron/pty.js";
+import { killPty, spawnPty } from "../dist-electron/pty.js";
 
 // pty.ts logs lifecycle events to $AYA_HOME/pty-events.log (resolved lazily at
 // the first append), so redirect it before any spawnPty call - otherwise unit
@@ -40,6 +40,29 @@ test("attachOnly with no live session emits no-session and does not spawn", asyn
   const req = baseReq({ attachOnly: true });
   await spawnPty(req, sink);
   assert.deepEqual(sink.events, [{ type: "no-session", ptyId: req.ptyId }]);
+});
+
+test("lifecycle events land in $AYA_HOME/pty-events.log (lazy singleton + wiring)", async () => {
+  // AYA_HOME was set ABOVE, after pty.js was already imported - so a hit here
+  // pins BOTH halves of the isolation story (#91): the ptyLog singleton must
+  // resolve its path lazily at the first append (an eager import-time binding
+  // would write into the user's real ~/.aya and leave this file empty), and
+  // the pty.ts call sites must actually fire (deleting the appends would also
+  // leave this file empty while every event-sink assertion stays green).
+  const sink = fakeSink();
+  const req = baseReq({ attachOnly: true });
+  await spawnPty(req, sink);
+  killPty(req.ptyId); // dead id -> arms the pending-kill marker, logs live:false
+  const lines = readFileSync(join(process.env.AYA_HOME, "pty-events.log"), "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+  const noSession = lines.find((l) => l.ev === "no-session" && l.ptyId === req.ptyId);
+  assert.ok(noSession, "the no-session event must be logged");
+  assert.equal(noSession.pid, process.pid);
+  const kill = lines.find((l) => l.ev === "kill" && l.ptyId === req.ptyId);
+  assert.ok(kill, "the kill event must be logged");
+  assert.equal(kill.live, false);
 });
 
 test("attachOnly returns before command/cwd validation (no spawn-failed)", async () => {

--- a/tests/pty-attach-only.test.mjs
+++ b/tests/pty-attach-only.test.mjs
@@ -7,7 +7,15 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { spawnPty } from "../dist-electron/pty.js";
+
+// pty.ts logs lifecycle events to $AYA_HOME/pty-events.log (resolved lazily at
+// the first append), so redirect it before any spawnPty call - otherwise unit
+// runs write into the user's real ~/.aya.
+process.env.AYA_HOME = mkdtempSync(join(tmpdir(), "aya-pty-test-"));
 
 function fakeSink() {
   const events = [];

--- a/tests/pty-double-spawn.test.mjs
+++ b/tests/pty-double-spawn.test.mjs
@@ -8,7 +8,15 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { spawnPty } from "../dist-electron/pty.js";
+
+// pty.ts logs lifecycle events to $AYA_HOME/pty-events.log (resolved lazily at
+// the first append), so redirect it before any spawnPty call - otherwise unit
+// runs write into the user's real ~/.aya.
+process.env.AYA_HOME = mkdtempSync(join(tmpdir(), "aya-pty-test-"));
 
 function fakeSink() {
   const events = [];

--- a/tests/pty-double-spawn.test.mjs
+++ b/tests/pty-double-spawn.test.mjs
@@ -8,7 +8,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnPty } from "../dist-electron/pty.js";
@@ -45,6 +45,17 @@ test("a concurrent spawn for the same id is suppressed (no second process)", asy
   );
   // ...the racing second call bails at the in-flight guard: no events at all.
   assert.deepEqual(sink2.events, [], "concurrent duplicate spawn must be suppressed");
+
+  // The drop must not be silent (#90): the lifecycle log is the only place a
+  // suppressed duplicate is distinguishable from a request that never arrived.
+  const logLines = readFileSync(join(process.env.AYA_HOME, "pty-events.log"), "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+  assert.ok(
+    logLines.some((l) => l.ev === "spawn-dropped-in-flight" && l.ptyId === req.ptyId),
+    "the in-flight drop must leave a spawn-dropped-in-flight line",
+  );
 });
 
 test("a sequential re-spawn after the first finished is NOT suppressed", async () => {

--- a/tests/pty-kill-escalate.test.mjs
+++ b/tests/pty-kill-escalate.test.mjs
@@ -15,6 +15,14 @@ import {
   activePtyCount,
   KILL_ESCALATE_MS,
 } from "../dist-electron/pty.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// pty.ts logs lifecycle events to $AYA_HOME/pty-events.log (resolved lazily at
+// the first append), so redirect it before any PTY call - otherwise unit runs
+// write into the user's real ~/.aya.
+process.env.AYA_HOME = mkdtempSync(join(tmpdir(), "aya-pty-test-"));
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 

--- a/tests/pty-log.test.mjs
+++ b/tests/pty-log.test.mjs
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createPtyLog, PTY_LOG_MAX_BYTES } from "../dist-electron/pty-log.js";
+import { createPtyLog, ptyLog, PTY_LOG_MAX_BYTES } from "../dist-electron/pty-log.js";
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), "aya-pty-log-"));
 
@@ -91,11 +91,69 @@ test("rotation accounts for bytes, not string length (multibyte command)", () =>
   assert.equal(readLines(file)[0].command, cmd);
 });
 
+test("a failed rotation keeps the cap: overflow lines are dropped, never appended past it (#89)", () => {
+  const dir = tmp();
+  const file = path.join(dir, "pty-events.log");
+  // The rotation target is a DIRECTORY, so renameSync fails on every attempt.
+  fs.mkdirSync(`${file}.1`);
+  const log = createPtyLog(file, 120);
+  log.append("spawn", { ptyId: "first" });
+  log.append("spawn", { ptyId: "second" }); // crosses the cap; cannot rotate
+  log.append("spawn", { ptyId: "third" }); // regression guard: size must NOT have reset to 0
+  const lines = readLines(file);
+  assert.equal(
+    lines.length,
+    1,
+    "un-rotatable overflow must be dropped - the old unconditional size=0 appended it and grew the file without bound",
+  );
+  assert.equal(lines[0].ptyId, "first");
+  assert.ok(fs.statSync(file).size <= 120, "the cap must hold even when rotation is impossible");
+});
+
+test("a stale in-process size never double-rotates over a fresh generation (#89)", () => {
+  const file = path.join(tmp(), "pty-events.log");
+  const log = createPtyLog(file, 200);
+  log.append("spawn", { ptyId: "aaaa" });
+  log.append("spawn", { ptyId: "bbbb" }); // cached size now ~150 of the 200 cap
+  // Simulate a concurrent host having rotated: the full file moved to .1 and a
+  // fresh (empty) file sits at the path, while THIS writer's counter is stale.
+  fs.renameSync(file, `${file}.1`);
+  fs.writeFileSync(file, "");
+  log.append("spawn", { ptyId: "cccc" });
+  assert.equal(
+    readLines(`${file}.1`).length,
+    2,
+    "the writer must re-stat and see the fresh file - rotating off the stale counter would rename the near-empty file OVER .1 and destroy the generation",
+  );
+  assert.equal(readLines(file)[0].ptyId, "cccc");
+});
+
+test("the ptyLog singleton resolves AYA_HOME lazily at the first append (#91)", () => {
+  // pty-log.js was imported at the top of this file, BEFORE this env write -
+  // an eager import-time binding (the natural regression) would aim at the
+  // real ~/.aya and leave this tmpdir empty.
+  const home = tmp();
+  process.env.AYA_HOME = home;
+  ptyLog.append("host-start", { version: "test" });
+  const lines = readLines(path.join(home, "pty-events.log"));
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0].ev, "host-start");
+});
+
 test("append never throws when the path is unwritable", () => {
   const dir = tmp();
   const blocker = path.join(dir, "not-a-dir");
   fs.writeFileSync(blocker, "plain file");
   // Parent of the log path is a FILE -> mkdir/append fail internally.
   const log = createPtyLog(path.join(blocker, "pty-events.log"), PTY_LOG_MAX_BYTES);
+  assert.doesNotThrow(() => log.append("spawn", { ptyId: "t1" }));
+});
+
+test("append never throws when the log path itself is a directory (append leg, #91)", () => {
+  // Here mkdirSync(dirname) SUCCEEDS and the failure comes from appendFileSync
+  // (EISDIR) - a regression that only guards the mkdir leg stays red here.
+  const file = path.join(tmp(), "pty-events.log");
+  fs.mkdirSync(file);
+  const log = createPtyLog(file, PTY_LOG_MAX_BYTES);
   assert.doesNotThrow(() => log.append("spawn", { ptyId: "t1" }));
 });

--- a/tests/pty-log.test.mjs
+++ b/tests/pty-log.test.mjs
@@ -1,0 +1,101 @@
+// PTY lifecycle log (pty-log.ts): JSONL append + size-capped rotation. The log
+// is the forensic record for "what killed all my consoles at 03:12?" - so the
+// assertions read the FILE back (the observable a human greps later), not the
+// writer's internals, and the failure-swallowing contract is pinned (a broken
+// log must never break the PTY layer).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createPtyLog, PTY_LOG_MAX_BYTES } from "../dist-electron/pty-log.js";
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), "aya-pty-log-"));
+
+const readLines = (file) =>
+  fs
+    .readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+
+test("append writes one parseable JSON line with ts/pid/ev plus fields", () => {
+  const file = path.join(tmp(), "pty-events.log");
+  const log = createPtyLog(file, PTY_LOG_MAX_BYTES);
+  log.append("spawn", { ptyId: "t1", command: "claude --continue" });
+  log.append("exit", { ptyId: "t1", exitCode: 0 });
+
+  const lines = readLines(file);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0].ev, "spawn");
+  assert.equal(lines[0].ptyId, "t1");
+  assert.equal(lines[0].command, "claude --continue");
+  assert.equal(lines[0].pid, process.pid);
+  // ts must be a real ISO timestamp (greppable + sortable), not a raw number.
+  assert.ok(!Number.isNaN(Date.parse(lines[0].ts)), `bad ts: ${lines[0].ts}`);
+  assert.equal(lines[1].ev, "exit");
+  assert.equal(lines[1].exitCode, 0);
+});
+
+test("append creates the parent directory when missing", () => {
+  const file = path.join(tmp(), "nested", "deeper", "pty-events.log");
+  createPtyLog(file, PTY_LOG_MAX_BYTES).append("host-start", { version: "0.0.0" });
+  assert.equal(readLines(file)[0].ev, "host-start");
+});
+
+test("rotation moves the full file to .1 and starts fresh", () => {
+  const file = path.join(tmp(), "pty-events.log");
+  // Cap low enough that the second line cannot fit after the first.
+  const log = createPtyLog(file, 120);
+  log.append("spawn", { ptyId: "first" });
+  log.append("spawn", { ptyId: "second" });
+
+  const rotated = readLines(`${file}.1`);
+  const current = readLines(file);
+  assert.equal(rotated.length, 1);
+  assert.equal(rotated[0].ptyId, "first");
+  assert.equal(current.length, 1);
+  assert.equal(current[0].ptyId, "second");
+});
+
+test("rotation accounts for bytes, not string length (multibyte command)", () => {
+  const file = path.join(tmp(), "pty-events.log");
+  // "ąęść" is 4 chars / 8 bytes in UTF-8. Pick the cap BETWEEN two lines'
+  // total CHAR length and their total BYTE length: a byte-based counter must
+  // rotate on the second append, while a length-based one (the natural
+  // regression) concludes both lines fit and skips the rotation - so that
+  // mutation turns this test red instead of passing by accident.
+  const cmd = "ąęść".repeat(8);
+  const refLine = `${JSON.stringify({
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    ev: "spawn",
+    command: cmd,
+  })}\n`;
+  const lineChars = refLine.length;
+  const lineBytes = Buffer.byteLength(refLine);
+  assert.ok(lineBytes > lineChars, "sanity: the command must be multibyte");
+  const cap = lineChars * 2 + 1; // > 2 lines in chars, < 2 lines in bytes
+  assert.ok(lineBytes * 2 > cap, "sanity: byte accounting must overflow this cap");
+  assert.ok(lineBytes <= cap, "sanity: the first line alone must fit");
+
+  const log = createPtyLog(file, cap);
+  log.append("spawn", { command: cmd });
+  log.append("spawn", { command: cmd });
+  assert.equal(
+    readLines(`${file}.1`).length,
+    1,
+    "byte-counted cap must rotate on the second append",
+  );
+  assert.equal(readLines(file)[0].command, cmd);
+});
+
+test("append never throws when the path is unwritable", () => {
+  const dir = tmp();
+  const blocker = path.join(dir, "not-a-dir");
+  fs.writeFileSync(blocker, "plain file");
+  // Parent of the log path is a FILE -> mkdir/append fail internally.
+  const log = createPtyLog(path.join(blocker, "pty-events.log"), PTY_LOG_MAX_BYTES);
+  assert.doesNotThrow(() => log.append("spawn", { ptyId: "t1" }));
+});


### PR DESCRIPTION
## Problem

For #83 (periodic mass console reloads) I have no durable record to diagnose anything after the fact: the Attention Center feed lives in renderer memory and dies with it, and the PTY host logs nothing at all.

## What this adds

`electron/pty-log.ts`: one JSON line per lifecycle event appended to `~/.aya/pty-events.log`, rotated to a single `.1` generation at ~1MB. Every line carries `ts` (ISO), `pid` (distinguishes overlapping hosts during a handoff) and `ev`; appends are fully wrapped so logging can never break the PTY layer.

Logged events:

- **Host lifecycle**: `host-start` (version + script hash), `host-shutdown` with its **reason** (`client-request` vs `SIGTERM`/`SIGINT` - distinguishes a staleness handoff from an OS signal when every console dies at once), `host-idle-exit`, `children-shutdown` (count).
- **Per-PTY**: `spawn` (child pid, cwd, command clamped to 4KB - shows at a glance whether a respawn carried `--continue`; commands are already stored in plaintext in `presets.json`, so no new exposure), `spawn-replay` (re-mount attach), `no-session`, `spawn-failed` (reason - logged even when the sink is already gone), `exit` (code; `killed: true` when the death was an intentional kill/shutdown), `kill` (live or not).
- **Every silent drop in the spawn path** (surfaced during review): `spawn-dropped-pending-kill` (the kill-race guard - this exact path silently ate the forced respawn of a dead tab; fixed separately in #84), `spawn-dropped-shutting-down`, `spawn-killed-on-shutdown`, `spawn-dropped-in-flight` (concurrent duplicate suppressed).

Data chunks are deliberately NOT logged - the hot path stays untouched.

So the next mass reload will read like: a burst of `exit`/`kill` lines (children died - with codes), or a `host-shutdown` with its reason, or a fresh `host-start` (new host took over) - each pointing at a different culprit.

## Isolation note

The `ptyLog` singleton resolves its path lazily at the first append and honors `process.env.AYA_HOME` set after module load. This matters because the PTY unit tests import the compiled module statically - eager resolution wrote test noise into my real `~/.aya` (caught while building this); the three PTY unit-test files now point `AYA_HOME` at a tmpdir.

## Tests

`tests/pty-log.test.mjs` pins the JSONL shape (read back from the file, not the writer's internals), parent-dir creation, rotation to `.1`, byte-based rotation accounting (cap picked between two lines' char total and byte total; verified empirically - mutating `Buffer.byteLength` to `.length` turns exactly that test red), and the never-throws contract on an unwritable path. Full suite: 588/588.

## Review

Grok pass found three gaps, all fixed: the multibyte rotation test was initially a facade (cap did not separate char- from byte-accounting), and two shutdown-window drops plus the destroyed-sink `spawn-failed` path were still silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-review hardening (adversarial loop, rounds 1-3)

A second review loop (Grok + Codex, 3 rounds) found four gaps, all fixed in the follow-up commit:

- **Exit lines for intentional deaths** (#88): killPty/shutdownPtyChildren removed the child from the map before terminating it, so the onExit identity guard skipped the `exit` append on exactly the paths that deliberately kill consoles. The kill paths now log `exit` with `killed: true` themselves.
- **Rotation hardening** (#89): the writer re-stats before rotating (a second host's stale counter could double-rotate a near-empty file OVER the freshly rotated generation), a failed rename drops the overflow line instead of un-capping the file, and the spawn command field is clamped to 4KB.
- **spawn-dropped-in-flight** (#90): the concurrent-spawn suppression was the one spawn-path drop still silent.
- **Test pins** (#91): lazy-singleton isolation, call-site wiring, both rotation fixes and the appendFileSync never-throws leg are now red/green-pinned. Suite: 593/593.

Accepted risk, recorded and closed as not planned: blocking (non-throwing) sync fs I/O on a hung $HOME can stall the host (#95).
