### PR TITLE
Build the AppImage with the static runtime, not legacy FUSE2

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,20 @@ chmod +x Aya-0.7.7.AppImage
 ./Aya-0.7.7.AppImage
 ```
 
-If AppImage complains about FUSE, use the DEB.
+The AppImage ships the statically linked AppImage runtime, so it does **not**
+need the obsolete `libfuse2`, which Ubuntu 24.04+ and Debian 13 no longer
+install. It uses `fusermount3` from the `fuse3` package, which those
+distributions do install by default.
+
+On a system with no FUSE at all, run the AppImage without mounting it:
+
+```sh
+APPIMAGE_EXTRACT_AND_RUN=1 ./Aya-0.7.7.AppImage
+```
+
+Older releases (0.7.9 and earlier) embedded the legacy runtime and failed with
+`dlopen(): error loading libfuse.so.2` / `AppImages require FUSE to run.`. Use
+`APPIMAGE_EXTRACT_AND_RUN=1`, install `libfuse2t64`, or use the DEB.
 
 ## Build from source
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
       "buildResources": "build",
       "output": "release"
     },
+    "toolsets": {
+      "appimage": "1.0.3"
+    },
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
## Problem

The Linux AppImage does not start on Ubuntu 24.04+ or Debian 13:

```
dlopen(): error loading libfuse.so.2

AppImages require FUSE to run.
```

electron-builder defaults `toolsets.appimage` to `"0.0.0"`, which selects the legacy **AppImageKit 12** toolset. That runtime `dlopen`s `libfuse.so.2` at startup, and those distributions dropped `libfuse2` from the default install. The runtime bails out before the payload is mounted, so Electron never runs and nothing in the app can catch it.

Confirmed against the current `main`: the build logs `downloaded label=appimage-12.0.1.7z`.

## Fix

Pin `build.toolsets.appimage` to `1.0.3` (runtime 20251108). It links libfuse statically and shells out to `fusermount3` from the `fuse3` package, which those distributions do install by default, and it honours `APPIMAGE_EXTRACT_AND_RUN=1` as a no-FUSE fallback.

## Verification

Built both variants and ran each with `libfuse.so.2` bind-mounted over an empty file in a private mount namespace:

| build | result without libfuse |
| --- | --- |
| `main` (legacy FUSE2) | `dlopen(): error loading libfuse.so.2` |
| this PR (static runtime) | app boots, creates `aya.sock` / `aya-remote.sock`, writes `presets.json`, `themes.json`, `window-state.json` |

Also verified `APPIMAGE_EXTRACT_AND_RUN=1` works with no libfuse present at all — that is the workaround documented for already-published releases.

- `npm test` — 610/610 pass
- `--linux deb` still builds; the deb target does not use this toolset
- AppImage shrank from 129 MB to 120 MB

## Notes

- Upstream marks `1.0.2` / `1.0.3` as **beta**; `"0.0.0"` is the only "stable" value and it is the broken one. `1.0.2` is the same runtime without the fix for electron-builder#9598, if a more conservative pin is preferred.
- Unrelated, not touched here: the README download links still point at **v0.7.7** while v0.7.9 is released.