### PR TITLE
Status bar: show the active worktree, not just its branch

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -20,6 +20,9 @@ export interface SeededEnv {
    *  project points at (so a test can assert MissingDirModal's "Create folder"
    *  created it, or "Use home" did not). */
   missingDirPath?: string;
+  /** Set only when `gitWorktree` is requested: the worktree the right tab runs
+   *  in (branch "wt/bar", one modified file). */
+  worktreeDir?: string;
 }
 
 export interface SeedOptions {
@@ -58,6 +61,10 @@ export interface SeedOptions {
    *  commit, then leave a modified tracked file + an untracked file so the
    *  StatusBar shows a branch + "2 dirty" + a diff. */
   gitRepo?: boolean;
+  /** Requires `gitRepo`. Add a git worktree on branch "wt/bar" with its own
+   *  dirty file, and bind the RIGHT tab to it (tab.cwd), so tests can check the
+   *  status bar follows the active terminal's checkout. Path: `worktreeDir`. */
+  gitWorktree?: boolean;
   /** Point the open project at a directory that does NOT exist, so the boot
    *  dir-check queues it and MissingDirModal appears. The path is exposed as
    *  `seeded.missingDirPath` so a test can assert "Create folder" made it. */
@@ -111,6 +118,7 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
     );
   }
 
+  let worktreeDir: string | undefined;
   if (opts.gitRepo) {
     const git = (...args: string[]) =>
       execFileSync("git", args, { cwd: projectDir, stdio: "ignore" });
@@ -122,6 +130,15 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
     // prefixes so test selectors don't collide on substrings.)
     writeFileSync(join(projectDir, "committed.txt"), "one\ntwoX\n");
     writeFileSync(join(projectDir, "added.txt"), "brand new\n");
+    if (opts.gitWorktree) {
+      // A second checkout with its OWN branch and its own single dirty file, so
+      // "which checkout is the status bar reading?" has an unambiguous answer.
+      worktreeDir = join(root, "wt-bar");
+      git("worktree", "add", "-q", "-b", "wt/bar", worktreeDir);
+      writeFileSync(join(worktreeDir, "committed.txt"), "one\ntwoWT\n");
+    }
+  } else if (opts.gitWorktree) {
+    throw new Error("seed: gitWorktree requires gitRepo");
   }
 
   if (opts.presets !== false) {
@@ -141,7 +158,12 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
         directory: effectiveProjectDir,
         tabs: [
           { id: left, presetId: "shell", name: "shell 1" },
-          { id: right, presetId: "shell", name: "shell 2" },
+          {
+            id: right,
+            presetId: "shell",
+            name: "shell 2",
+            ...(worktreeDir ? { cwd: worktreeDir } : {}),
+          },
         ],
         ...(split
           ? {
@@ -276,5 +298,6 @@ export function seedEnv(opts: SeedOptions = {}): SeededEnv {
     launchEnv,
     tabIds: { left, right },
     missingDirPath,
+    worktreeDir,
   };
 }

--- a/e2e/statusbar-worktree.spec.ts
+++ b/e2e/statusbar-worktree.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+// The status bar's git surface describes the ACTIVE TERMINAL's checkout. With a
+// tab bound to a git worktree, the project directory's branch and diff are the
+// wrong answer - before this, selecting that tab still showed the main
+// checkout, so the diff for the work happening in the worktree was invisible.
+
+test.use({ seedOptions: { gitRepo: true, gitWorktree: true, split: false } });
+
+function sidebarRow(window: Page, name: string) {
+  return window.locator(".aya-sidebar-row", {
+    has: window.locator(".aya-sidebar-name", { hasText: new RegExp(`^${name}$`) }),
+  });
+}
+
+test("status bar git follows the active terminal's worktree", async ({ window }) => {
+  const statusbar = window.locator(".aya-statusbar");
+  const dirtyBtn = window.locator(".aya-statusbar-button", { hasText: "dirty" });
+
+  // shell 1 runs in the project directory: its branch, its 2 dirty files.
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "feature/foo" })).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(dirtyBtn).toContainText("2 dirty", { timeout: 10000 });
+  await expect(statusbar.locator(".aya-statusbar-worktree")).toHaveCount(0);
+
+  // shell 2 is bound to the worktree -> branch, dirty count and the worktree
+  // chip all switch over.
+  await sidebarRow(window, "shell 2").click();
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "wt/bar" })).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(dirtyBtn).toContainText("1 dirty", { timeout: 10000 });
+  await expect(statusbar.locator(".aya-statusbar-worktree")).toContainText("wt-bar");
+
+  // The diff is the worktree's ("twoWT"), not the project directory's ("twoX").
+  await dirtyBtn.click();
+  const popover = window.locator(".aya-statusbar-popover");
+  await expect(popover.locator(".aya-dirty-file-row")).toHaveCount(1);
+  await popover.locator(".aya-dirty-file-row", { hasText: "committed.txt" }).click();
+  const diff = popover.locator(".aya-diff-view");
+  await expect(diff).toContainText("twoWT");
+  await expect(diff).not.toContainText("twoX");
+
+  // Back to shell 1: the project directory's state comes back, no stale
+  // worktree file list left over in the popover.
+  await sidebarRow(window, "shell 1").click();
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "feature/foo" })).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(popover).toHaveCount(0);
+  await expect(dirtyBtn).toContainText("2 dirty", { timeout: 10000 });
+});
+
+// The case this was actually built for: nobody bound a tab to anything. You run
+// an agent (or yourself) in the project directory, a worktree gets created, and
+// the console moves into it. The status bar has to follow the console, because
+// the cwd Aya spawned the terminal with says nothing about where it is now.
+test("status bar follows a `cd` into a worktree", async ({ window, seeded }) => {
+  const statusbar = window.locator(".aya-statusbar");
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "feature/foo" })).toBeVisible({
+    timeout: 10000,
+  });
+
+  // shell 1 was spawned in the project directory; move it into the worktree.
+  const pane = window.locator(".aya-pane").first();
+  await pane.locator(".xterm-screen").click();
+  await window.keyboard.insertText(`cd ${seeded.worktreeDir}`);
+  await window.keyboard.press("Enter");
+
+  // The cwd poll runs on the git cadence, so allow a couple of ticks.
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "wt/bar" })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(statusbar.locator(".aya-statusbar-worktree")).toContainText("wt-bar");
+  await expect(
+    window.locator(".aya-statusbar-button", { hasText: "dirty" }),
+  ).toContainText("1 dirty", { timeout: 10000 });
+
+  // And back: the console leaves, the status bar leaves with it.
+  await window.keyboard.insertText(`cd ${seeded.projectDir}`);
+  await window.keyboard.press("Enter");
+  await expect(statusbar.locator(".aya-statusbar-item", { hasText: "feature/foo" })).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+test("the checkout picker pins a worktree until you follow the terminal again", async ({
+  window,
+}) => {
+  const statusbar = window.locator(".aya-statusbar");
+  const picker = window.locator('[data-testid="checkout-picker"]');
+  // Two worktrees exist, so the branch chip is a picker.
+  await expect(picker).toBeVisible({ timeout: 10000 });
+  await expect(picker).toContainText("feature/foo");
+
+  await picker.click();
+  const rows = window.locator(".aya-checkout-row");
+  await expect(rows).toHaveCount(2);
+  // Each row carries that checkout's own branch and dirty count.
+  await expect(rows.filter({ hasText: "wt-bar" })).toContainText("wt/bar");
+  await expect(rows.filter({ hasText: "wt-bar" })).toContainText("1 dirty");
+  await expect(rows.filter({ hasText: "feature/foo" })).toContainText("2 dirty");
+
+  // Pin the worktree while the console stays in the project directory.
+  await rows.filter({ hasText: "wt-bar" }).click();
+  await expect(picker).toContainText("wt/bar");
+  await expect(statusbar.locator(".aya-statusbar-worktree")).toContainText("wt-bar");
+  await expect(
+    window.locator(".aya-statusbar-button", { hasText: "dirty" }),
+  ).toContainText("1 dirty", { timeout: 10000 });
+
+  // Un-pin: back to what the terminal is in.
+  await picker.click();
+  await window.locator(".aya-statusbar-popover-action", { hasText: "Follow terminal" }).click();
+  await expect(picker).toContainText("feature/foo", { timeout: 10000 });
+});

--- a/electron/git.ts
+++ b/electron/git.ts
@@ -5,7 +5,7 @@
 import { exec, execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
-import type { ProjectGitInfo, Worktree } from "./types";
+import type { ProjectGitInfo, Worktree, WorktreeStatus } from "./types";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -201,6 +201,46 @@ export async function removeWorktree(
     return { ok: true, path };
   } catch (err) {
     return { ok: false, error: gitErrorMessage(err) };
+  }
+}
+
+/** Every worktree of the repo, each with its live branch and dirty count, for
+ *  the status bar's checkout picker. The per-worktree `git status` calls only
+ *  run when there is more than one worktree — with a single checkout there is
+ *  nothing to pick between, and the status bar already polls that one. */
+export async function listWorktreeStatus(
+  directory: string,
+): Promise<WorktreeStatus[]> {
+  const worktrees = await listWorktrees(directory);
+  if (worktrees.length < 2) {
+    return worktrees.map((w) => ({ ...w, dirty: 0 }));
+  }
+  return Promise.all(
+    worktrees.map(async (w) => {
+      // A prunable worktree's checkout is gone; running git there just fails.
+      if (w.prunable || w.bare) return { ...w, dirty: 0 };
+      const info = await getGitInfo(w.path);
+      return { ...w, branch: info.branch ?? w.branch, dirty: info.dirty };
+    }),
+  );
+}
+
+/** The root of the checkout containing `directory` (its own root for a git
+ *  worktree, not the main one), or null outside a repo. A live terminal cwd can
+ *  sit deep inside a worktree, and the rest of this file's callers assume a
+ *  checkout root: `git status --porcelain` reports paths from the root, so the
+ *  untracked-file diff synthesis would read them against the wrong base. */
+export async function getGitRoot(directory: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["--no-optional-locks", "rev-parse", "--show-toplevel"],
+      { cwd: directory, ...OPTS },
+    );
+    const root = stdout.trim();
+    return root.length > 0 ? root : null;
+  } catch {
+    return null;
   }
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,7 +55,14 @@ import {
   listRemotePresets,
   listRemoteDirectory,
 } from "./remote-client";
-import { getGitChangedFiles, getGitDiff, getGitInfo, listWorktrees } from "./git";
+import {
+  getGitChangedFiles,
+  getGitDiff,
+  getGitInfo,
+  getGitRoot,
+  listWorktrees,
+  listWorktreeStatus,
+} from "./git";
 import { getGitHubLink, isGitHubCliAvailable } from "./github";
 import {
   AYA_HOME,
@@ -1930,6 +1937,11 @@ function registerIpc(): void {
       throw err;
     }
   });
+  // Live cwd of a terminal's process (null when unavailable) - the client
+  // already turns an old host's "unknown request" into null.
+  ipcMain.handle("pty:cwd", async (_e, ptyId: unknown) =>
+    ptyHost.getCwd(requireString(ptyId, "pty:cwd.ptyId")),
+  );
   ipcMain.handle("pty:search", async (_e, query: unknown) =>
     ptyHost.search(requireString(query, "pty:search.query")),
   );
@@ -2212,6 +2224,12 @@ function registerIpc(): void {
   );
   ipcMain.handle("env:git-worktrees", async (_e, directory: unknown) =>
     listWorktrees(requireString(directory, "env:git-worktrees.directory")),
+  );
+  ipcMain.handle("env:git-root", async (_e, directory: unknown) =>
+    getGitRoot(requireString(directory, "env:git-root.directory")),
+  );
+  ipcMain.handle("env:git-worktree-status", async (_e, directory: unknown) =>
+    listWorktreeStatus(requireString(directory, "env:git-worktree-status.directory")),
   );
   ipcMain.handle("env:github-link", async (_e, directory: unknown) =>
     getGitHubLink(requireString(directory, "env:github-link.directory")),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -21,6 +21,7 @@ const api: AyaApi = {
     ipcRenderer.invoke("pty:resize", ptyId, cols, rows),
   ptyKill: (ptyId) => ipcRenderer.invoke("pty:kill", ptyId),
   ptyBuffer: (ptyId) => ipcRenderer.invoke("pty:buffer", ptyId),
+  ptyCwd: (ptyId) => ipcRenderer.invoke("pty:cwd", ptyId),
   ptySearch: (query) => ipcRenderer.invoke("pty:search", query),
   harnessSearch: (req) => ipcRenderer.invoke("harness:search", req),
   restartPtyHost: () => ipcRenderer.invoke("pty-host:restart"),
@@ -90,6 +91,9 @@ const api: AyaApi = {
   getGitDiff: (directory) => ipcRenderer.invoke("env:git-diff", directory),
   getGitWorktrees: (directory) =>
     ipcRenderer.invoke("env:git-worktrees", directory),
+  getGitRoot: (directory) => ipcRenderer.invoke("env:git-root", directory),
+  getGitWorktreeStatus: (directory) =>
+    ipcRenderer.invoke("env:git-worktree-status", directory),
   getGitHubLink: (directory) =>
     ipcRenderer.invoke("env:github-link", directory),
   createWorktree: (req) => ipcRenderer.invoke("env:git-worktree-add", req),

--- a/electron/process-cwd.ts
+++ b/electron/process-cwd.ts
@@ -1,0 +1,66 @@
+// Live working directory of a PTY's process. Aya otherwise knows only the cwd
+// it SPAWNED a terminal with, which goes stale the moment you `cd` - typically
+// into a git worktree an agent just created. The status bar's git surface wants
+// the directory the console is actually in, so it asks for this.
+//
+// macOS has no /proc, so we shell out to lsof (~70ms, hence: active terminal
+// only, on the existing 3s status poll). Linux reads /proc/<pid>/cwd directly.
+// Windows: unsupported, callers fall back to the spawn cwd.
+
+import { execFile } from "node:child_process";
+import { readlink } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// lsof on a single pid is quick, but it can hang on an unresponsive mount;
+// a cwd we failed to read is a non-event (we fall back), so cap it hard.
+const LSOF_TIMEOUT_MS = 1500;
+
+/** Pull the cwd out of `lsof -Fn` field output. Field mode prints one item per
+ *  line prefixed by its field letter ("p1234", "fcwd", "n/path"); we want the
+ *  `n` line that follows the `fcwd` line. Exported for unit tests. */
+export function parseLsofCwd(stdout: string): string | null {
+  let inCwdRecord = false;
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("f")) {
+      inCwdRecord = line.slice(1).trim() === "cwd";
+    } else if (inCwdRecord && line.startsWith("n")) {
+      const path = line.slice(1).trim();
+      return path.length > 0 ? path : null;
+    }
+  }
+  return null;
+}
+
+/** The process's current working directory, or null when it can't be read
+ *  (dead process, unsupported platform, missing lsof, permission denied).
+ *  Read-only and side-effect free. */
+export async function getProcessCwd(pid: number): Promise<string | null> {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (process.platform === "win32") return null;
+  if (process.platform === "linux") {
+    try {
+      return await readlink(`/proc/${pid}/cwd`);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      "lsof",
+      ["-a", "-d", "cwd", "-p", String(pid), "-Fn"],
+      {
+        timeout: LSOF_TIMEOUT_MS,
+        windowsHide: true,
+        // Electron launched from Finder gets a minimal PATH; lsof lives in
+        // /usr/sbin there, which that PATH does include - but a user shell
+        // config can have narrowed it, so name the directory explicitly.
+        env: { ...process.env, PATH: `${process.env.PATH ?? ""}:/usr/sbin` },
+      },
+    );
+    return parseLsofCwd(stdout);
+  } catch {
+    return null;
+  }
+}

--- a/electron/pty-host-client.ts
+++ b/electron/pty-host-client.ts
@@ -163,6 +163,19 @@ export class PtyHostClient {
     return typeof result === "string" ? result : "";
   }
 
+  /** Live cwd of a PTY's child, or null when it can't be determined. A host
+   *  left over from a build that predates this request answers "unknown
+   *  request" — that rejection is a null here, not an error the caller has to
+   *  care about (the status bar just keeps using the spawn cwd). */
+  async getCwd(ptyId: string): Promise<string | null> {
+    try {
+      const result = await this.request({ id: 0, type: "cwd", ptyId });
+      return typeof result === "string" && result.length > 0 ? result : null;
+    } catch {
+      return null;
+    }
+  }
+
   private async request(
     request: PtyHostRequest,
     // Applied AFTER connect() resolves, right before the socket write - for

--- a/electron/pty-host-protocol.ts
+++ b/electron/pty-host-protocol.ts
@@ -9,6 +9,9 @@ export type PtyHostRequest =
   | { id: number; type: "shutdown" }
   | { id: number; type: "search"; query: string }
   | { id: number; type: "buffer"; ptyId: string }
+  // Live cwd of a PTY's child. Added after 0.7.8: a host from an older build
+  // answers "unknown request", which the client turns back into null.
+  | { id: number; type: "cwd"; ptyId: string }
   | { id: number; type: "version" };
 
 export type PtyHostResponse =

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -20,6 +20,7 @@ import { createPtyDataCoalescer } from "./pty-event-coalescer";
 import {
   activePtyCount,
   getBufferedOutput,
+  getPtyCwd,
   killPty,
   shutdownPtyChildren,
   resizePty,
@@ -140,6 +141,9 @@ async function handle(request: PtyHostRequest): Promise<unknown> {
   }
   if (request.type === "buffer") {
     return getBufferedOutput(request.ptyId);
+  }
+  if (request.type === "cwd") {
+    return getPtyCwd(request.ptyId);
   }
   if (request.type === "version") {
     // pid lets a client correlate the socket-connected host with a registry

--- a/electron/pty.ts
+++ b/electron/pty.ts
@@ -26,6 +26,7 @@ import {
 import { AYA_HOME, CONTROL_SOCKET_PATH } from "./paths";
 import { COMMAND_NOT_FOUND_EXIT_CODE, COMMAND_PROBE_TIMEOUT_MS } from "./constants";
 import { userShell } from "./shell";
+import { getProcessCwd } from "./process-cwd";
 import { ptyLog } from "./pty-log";
 
 // Timeout for the shell `command -v` existence check during spawn preflight.
@@ -719,6 +720,16 @@ export async function spawnPty(req: SpawnRequest, sink: PtyEventSink): Promise<v
     // for it. On the success path the flush already emptied this.
     pendingWrites.delete(req.ptyId);
   }
+}
+
+/** The live cwd of a PTY's child process — where the console actually IS, as
+ *  opposed to the cwd it was spawned with (which a `cd`, typically into a fresh
+ *  git worktree, leaves behind). null when the PTY is gone or the platform /
+ *  environment can't answer; callers fall back to the spawn cwd. */
+export async function getPtyCwd(ptyId: string): Promise<string | null> {
+  const p = ptys.get(ptyId);
+  if (!p) return null;
+  return getProcessCwd(p.pid);
 }
 
 export function writePty(ptyId: string, data: string): void {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -203,6 +203,13 @@ export interface Worktree {
   prunable: boolean;
 }
 
+/** A worktree plus its live state, for the status bar's checkout picker.
+ *  `dirty` is 0 for a repo with a single worktree (nothing to pick between, so
+ *  the per-worktree status calls are skipped) and for prunable/bare ones. */
+export interface WorktreeStatus extends Worktree {
+  dirty: number;
+}
+
 export type SpawnFailureReason =
   | "cwd-missing"
   | "cwd-not-directory"
@@ -454,6 +461,10 @@ export interface AyaApi {
   ptyResize(ptyId: string, cols: number, rows: number): Promise<void>;
   ptyKill(ptyId: string): Promise<void>;
   ptyBuffer(ptyId: string): Promise<string>;
+  /** Live cwd of a terminal's process - where the console actually is after a
+   *  `cd`, not the cwd Aya spawned it with. null when it can't be read (old
+   *  PTY host, dead process, unsupported platform). */
+  ptyCwd(ptyId: string): Promise<string | null>;
   /** Case-insensitive substring search across every live PTY's recent
    *  output buffer. Returns one hit per matching pty (the first match plus
    *  an extra-occurrences count). */
@@ -572,6 +583,12 @@ export interface AyaApi {
     path: string;
     force?: boolean;
   }): Promise<GitMutationResult>;
+  /** Root of the checkout containing `directory` (a worktree's own root), or
+   *  null outside a repo. */
+  getGitRoot(directory: string): Promise<string | null>;
+  /** Worktrees of the repo containing `directory`, each with branch + dirty
+   *  count (dirty is 0 when the repo has a single worktree). */
+  getGitWorktreeStatus(directory: string): Promise<WorktreeStatus[]>;
   /** GitHub URL for the current branch: its PR, else the branch tree page. */
   getGitHubLink(directory: string): Promise<GitHubLink | null>;
   /** True if the `gh` CLI is on PATH. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { detectApproval } from "./bell";
 import { commandWithAutoResume } from "./agentPreset";
-import { projectBaseCwd, tabFromTerminal } from "./worktree";
+import { gitContextCwd, projectBaseCwd, tabFromTerminal } from "./worktree";
 import { findStatusTarget } from "./control-status-target";
 import {
   clearedTerminalStatus,
@@ -93,6 +93,7 @@ import {
   type UsageAccount,
   type WorkingTab,
   type Worktree,
+  type WorktreeStatus,
 } from "./types";
 
 // Cadence for polling the active project's git branch/dirty count (no inotify watch).
@@ -481,17 +482,20 @@ function samePollPayload<T>(prev: T, next: T): boolean {
   return JSON.stringify(prev) === JSON.stringify(next);
 }
 
-/** setGit updater that no-ops (same reference back) when the slug's git info
- *  is unchanged — the common case for the 3s status-bar poll. */
+/** setGit updater that no-ops (same reference back) when that directory's git
+ *  info is unchanged — the common case for the 3s status-bar poll. Keyed by
+ *  directory, not project slug: a worktree tab reads its OWN checkout, so one
+ *  project can hold several entries and switching tabs must not show the
+ *  previous checkout's branch until the next poll lands. */
 function mergeGitInfo(
   g: Record<string, ProjectGitInfo>,
-  slug: string,
+  directory: string,
   info: ProjectGitInfo,
 ): Record<string, ProjectGitInfo> {
-  const cur = g[slug];
+  const cur = g[directory];
   return cur && cur.branch === info.branch && cur.dirty === info.dirty
     ? g
-    : { ...g, [slug]: info };
+    : { ...g, [directory]: info };
 }
 
 function shellQuote(s: string): string {
@@ -749,12 +753,25 @@ export function App() {
     CUSTOM_DONE_SOUND_STORAGE_KEY,
     SOUND_PATH_CODEC,
   );
-  // Git worktrees for the active (local) project, when the experimental flag is
-  // on. Drives the launcher's worktree target and the per-row branch chip.
-  const [worktrees, setWorktrees] = useState<Worktree[]>([]);
-  // Bumped after a create/remove so the list effect re-reads; without it a
-  // freshly created worktree would not appear until the project changed.
+  // Worktrees of the active (local) project, with branch + dirty count. Polled
+  // (not loaded once per project switch) because an agent asked to "work in a
+  // worktree" creates one mid-session — it has to show up without a restart.
+  // Feeds the status bar's checkout picker; the sidebar's worktree grouping and
+  // launcher target additionally require the experimental flag.
+  const [worktrees, setWorktrees] = useState<WorktreeStatus[]>([]);
+  // Bumped after a create/remove so the poll effect re-fires immediately;
+  // without it a freshly created worktree would wait out the poll interval.
   const [worktreeNudge, setWorktreeNudge] = useState(0);
+  // Checkout the user PINNED in the status bar (slug -> path), overriding the
+  // "follow the console" default. Session-only: a pin is a look-at-this-now
+  // decision, not a project setting.
+  const [pinnedCheckout, setPinnedCheckout] = useState<Record<string, string>>(
+    {},
+  );
+  // Checkout root the ACTIVE terminal is really in: its process cwd (which a
+  // `cd` moves) resolved to the enclosing git root. null until the first read,
+  // or when it can't be determined — then the spawn cwd stands in.
+  const [liveCheckout, setLiveCheckout] = useState<string | null>(null);
   const [railWidth, setRailWidth] = useState(DEFAULT_RAIL_WIDTH_PX);
   const [localSummariesEnabled, setLocalSummariesEnabled] =
     usePersistentPreference(LOCAL_SUMMARIES_STORAGE_KEY, LOCAL_SUMMARIES_CODEC);
@@ -802,25 +819,44 @@ export function App() {
     setShowSettings(true);
   }, []);
 
-  // Status-bar branch / dirty count goes stale once you `git checkout` in a
-  // shell or commit something — there's no inotify watch, just a small poll
-  // for the active project. ~50ms subprocess, 3s cadence; cancelled on
-  // project switch.
+  // Active terminal, derived early: the git surface below follows the checkout
+  // THIS terminal is in, so its id/cwd are needed before the poll effects.
+  const activeTabId = activeProjectId
+    ? (activeTabByProject[activeProjectId] ?? null)
+    : null;
+  const activeTerminal = activeTabId ? (terminals[activeTabId] ?? null) : null;
+
+  // The active project's own checkout — where a terminal with no worktree
+  // binding runs. null for remote projects (no local working tree).
+  const activeProjectCheckout = useMemo(() => {
+    if (!activeProjectId) return null;
+    const project = findProject(projects, activeProjectId);
+    if (!project || project.remote) return null;
+    const base = projectFallbacks[project.slug] ?? project.directory;
+    return gitContextCwd(base, activeTerminal?.cwd);
+  }, [activeProjectId, projects, projectFallbacks, activeTerminal?.cwd]);
+
+  // Follow the console: read the active terminal's REAL cwd (a `cd` — or an
+  // agent that made itself a worktree and moved into it — leaves the spawn cwd
+  // behind) and resolve it to the enclosing checkout root, since the cwd can be
+  // a subdirectory. Active terminal only, on the git cadence: ~70ms on macOS
+  // (lsof; there is no /proc), so this is not something to run per tab.
+  const liveCwdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!activeProjectId) return;
+    liveCwdRef.current = null;
+    setLiveCheckout(null);
+    if (!activeTabId || !activeProjectCheckout) return;
     let cancelled = false;
     const refresh = () => {
-      const project = projectsRef.current.find(
-        (p) => p.slug === activeProjectId,
-      );
-      if (!project || cancelled) return;
-      if (project.remote) {
-        setGit((g) => mergeGitInfo(g, project.slug, { branch: null, dirty: 0 }));
-        return;
-      }
-      void window.aya.getGitInfo(project.directory).then((info) => {
+      void window.aya.ptyCwd(activeTabId).then(async (cwd) => {
+        if (cancelled || !cwd) return;
+        // Same cwd as last tick — the resolved root can't have changed, so skip
+        // the `git rev-parse`. Only a cd (or the first read) pays for it.
+        if (cwd === liveCwdRef.current) return;
+        const root = await window.aya.getGitRoot(cwd);
         if (cancelled) return;
-        setGit((g) => mergeGitInfo(g, project.slug, info));
+        liveCwdRef.current = cwd;
+        setLiveCheckout(root);
       });
     };
     const stop = pollVisible(refresh, GIT_STATUS_POLL_INTERVAL_MS);
@@ -828,29 +864,78 @@ export function App() {
       cancelled = true;
       stop();
     };
-  }, [activeProjectId]);
+  }, [activeTabId, activeProjectCheckout]);
 
-  // Load the active local project's git worktrees when the experimental flag is
-  // on. The list changes rarely (add/remove worktree), so we load on project
-  // switch / flag toggle rather than polling.
+  // The checkout the status bar's git surface describes, in priority order:
+  // what the user pinned in the picker, else where the console actually is,
+  // else the terminal's spawn cwd (a worktree binding or the project dir).
+  // null = nothing to read (no project, or a remote one).
+  const activeGitDirectory = useMemo(() => {
+    if (!activeProjectCheckout) return null;
+    const pinned = activeProjectId ? pinnedCheckout[activeProjectId] : null;
+    return pinned ?? liveCheckout ?? activeProjectCheckout;
+  }, [activeProjectCheckout, activeProjectId, pinnedCheckout, liveCheckout]);
+
+  // Status-bar branch / dirty count goes stale once you `git checkout` in a
+  // shell or commit something — there's no inotify watch, just a small poll
+  // for the active checkout. ~50ms subprocess, 3s cadence; cancelled on
+  // project / worktree-tab switch.
   useEffect(() => {
-    if (!worktreesEnabled || !activeProjectId) {
-      setWorktrees([]);
-      return;
-    }
-    const project = projectsRef.current.find((p) => p.slug === activeProjectId);
-    if (!project || project.remote) {
+    if (!activeGitDirectory) return;
+    let cancelled = false;
+    const refresh = () => {
+      if (cancelled) return;
+      void window.aya.getGitInfo(activeGitDirectory).then((info) => {
+        if (cancelled) return;
+        setGit((g) => mergeGitInfo(g, activeGitDirectory, info));
+      });
+    };
+    const stop = pollVisible(refresh, GIT_STATUS_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  }, [activeGitDirectory]);
+
+  // Poll the active local project's worktrees (with branch + dirty count). It
+  // used to load once per project switch, which meant a worktree an agent
+  // created during the session stayed invisible until you switched away and
+  // back. `git worktree list` is ~8ms and the per-worktree status calls only
+  // run when there is more than one checkout to tell apart.
+  useEffect(() => {
+    if (!activeProjectCheckout) {
       setWorktrees([]);
       return;
     }
     let cancelled = false;
-    void window.aya.getGitWorktrees(project.directory).then((list) => {
-      if (!cancelled) setWorktrees(list);
-    });
+    const refresh = () => {
+      void window.aya.getGitWorktreeStatus(activeProjectCheckout).then((list) => {
+        if (cancelled) return;
+        setWorktrees((prev) => (samePollPayload(prev, list) ? prev : list));
+      });
+    };
+    const stop = pollVisible(refresh, GIT_STATUS_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
+      stop();
     };
-  }, [worktreesEnabled, activeProjectId, worktreeNudge]);
+  }, [activeProjectCheckout, worktreeNudge]);
+
+  // Drop a pin whose worktree is gone (removed, or the project now points at a
+  // different repo). Left in place it would aim the whole git surface at a dead
+  // path, and with no branch to render there would be no chip left to click to
+  // undo it. Only acts on a non-empty list, so a failed read doesn't unpin.
+  useEffect(() => {
+    if (!activeProjectId || worktrees.length === 0) return;
+    const pinned = pinnedCheckout[activeProjectId];
+    if (!pinned || worktrees.some((w) => w.path === pinned)) return;
+    setPinnedCheckout((prev) => {
+      if (!(activeProjectId in prev)) return prev;
+      const next = { ...prev };
+      delete next[activeProjectId];
+      return next;
+    });
+  }, [activeProjectId, worktrees, pinnedCheckout]);
 
   // Re-read the account-wide usage snapshot a user hook writes (~/.aya/usage.json).
   // Aya only reads the file — it never fetches usage or touches any token.
@@ -1571,7 +1656,7 @@ export function App() {
       for (const p of openProjects) {
         if (!p.remote && dirChecks[openProjects.indexOf(p)]) {
           void window.aya.getGitInfo(p.directory).then((info) => {
-            setGit((g) => mergeGitInfo(g, p.slug, info));
+            setGit((g) => mergeGitInfo(g, p.directory, info));
           });
         }
       }
@@ -2649,7 +2734,8 @@ export function App() {
       });
 
       if (project.remote) {
-        setGit((g) => mergeGitInfo(g, project.slug, { branch: null, dirty: 0 }));
+        // No git entry for remotes: activeGitDirectory is null for them, so the
+        // status bar has nothing to look up and renders no git strip.
         hydrateProjectTerminals(project, project.remote.directory);
         void window.aya
           .listRemotePresets(project.remote.sshTarget)
@@ -2666,7 +2752,7 @@ export function App() {
       if (exists) {
         hydrateProjectTerminals(project, project.directory);
         void window.aya.getGitInfo(project.directory).then((info) => {
-          setGit((g) => mergeGitInfo(g, project.slug, info));
+          setGit((g) => mergeGitInfo(g, project.directory, info));
         });
       } else {
         setMissingDirQueue((prev) => [
@@ -2722,7 +2808,7 @@ export function App() {
         }));
         setActiveProjectId(withTabs.slug);
         void window.aya.getGitInfo(withTabs.directory).then((info) =>
-          setGit((g) => mergeGitInfo(g, withTabs.slug, info)),
+          setGit((g) => mergeGitInfo(g, withTabs.directory, info)),
         );
         setNewProjectModal(null);
       } catch (err) {
@@ -2768,7 +2854,6 @@ export function App() {
             ...projectStateRef.current.recent,
           ]),
         });
-        setGit((g) => mergeGitInfo(g, localProject.slug, { branch: null, dirty: 0 }));
         setRemotePresetsByProject((prev) => ({
           ...prev,
           [localProject.slug]: result.presets,
@@ -3056,7 +3141,7 @@ export function App() {
     if (project) {
       hydrateProjectTerminals(project, project.directory);
       void window.aya.getGitInfo(project.directory).then((info) => {
-        setGit((g) => mergeGitInfo(g, project.slug, info));
+        setGit((g) => mergeGitInfo(g, project.directory, info));
       });
     }
     dequeueMissingDir();
@@ -3107,10 +3192,7 @@ export function App() {
     ),
     sameArrayItems,
   );
-  const activeTabId = activeProjectId
-    ? (activeTabByProject[activeProjectId] ?? null)
-    : null;
-  const activeTerminal = activeTabId ? (terminals[activeTabId] ?? null) : null;
+  // (activeTabId / activeTerminal are derived up with the git-surface effects.)
   const terminalSoundPrefs = useMemo(
     () => ({
       enabled: terminalSoundsEnabled,
@@ -3132,35 +3214,27 @@ export function App() {
   });
   const snippetsOpenForActiveTerminal =
     !!activeTerminal && snippetDrawerTerminalId === activeTerminal.id;
-  const activeGit = activeProjectId ? (git[activeProjectId] ?? null) : null;
-  const activeGithubLink = activeProjectId
-    ? (githubLinks[activeProjectId] ?? null)
+  // Git surface (branch, dirty, diff, GitHub link) reads the active terminal's
+  // checkout — see activeGitDirectory — so all of it is keyed by directory.
+  const activeGit = activeGitDirectory ? (git[activeGitDirectory] ?? null) : null;
+  const activeGithubLink = activeGitDirectory
+    ? (githubLinks[activeGitDirectory] ?? null)
     : null;
-  // Resolve the PR/branch link only when the active project or its branch
+  // Resolve the PR/branch link only when the active checkout or its branch
   // changes — `gh pr view` hits the GitHub API, so we deliberately keep it off
   // the 3s git poll. Local repos only; remote projects have no working tree.
   const activeBranch = activeGit?.branch ?? null;
-  const activeDirectory = activeProject?.directory ?? null;
-  const activeIsRemote = !!activeProject?.remote;
   useEffect(() => {
-    if (!showGitHubLink || !activeProjectId || activeIsRemote || !activeDirectory) {
-      return;
-    }
+    if (!showGitHubLink || !activeGitDirectory) return;
     let cancelled = false;
-    void window.aya.getGitHubLink(activeDirectory).then((link) => {
+    void window.aya.getGitHubLink(activeGitDirectory).then((link) => {
       if (cancelled) return;
-      setGithubLinks((prev) => ({ ...prev, [activeProjectId]: link }));
+      setGithubLinks((prev) => ({ ...prev, [activeGitDirectory]: link }));
     });
     return () => {
       cancelled = true;
     };
-  }, [
-    showGitHubLink,
-    activeProjectId,
-    activeDirectory,
-    activeIsRemote,
-    activeBranch,
-  ]);
+  }, [showGitHubLink, activeGitDirectory, activeBranch]);
   // Split panes are not supported in the experimental "projects-left" layout
   // (terminals live in a top tab strip there). Ignore any saved split so the
   // body shows a single terminal, and disable the split actions. The project's
@@ -3410,6 +3484,25 @@ export function App() {
     [allProjects, openKnownProject],
   );
   const openSearch = useCallback(() => setShowSearch(true), []);
+  // Status-bar checkout picker: pin a worktree, or go back to following the
+  // console. Pinning by path (not index) so a worktree added or removed between
+  // renders can't silently repoint the pin at a different checkout.
+  const pinCheckout = useCallback(
+    (path: string | null) => {
+      const slug = activeProjectIdRef.current;
+      if (!slug) return;
+      setPinnedCheckout((prev) => {
+        if (!path) {
+          if (!(slug in prev)) return prev;
+          const next = { ...prev };
+          delete next[slug];
+          return next;
+        }
+        return prev[slug] === path ? prev : { ...prev, [slug]: path };
+      });
+    },
+    [],
+  );
   const minimizeWindow = useCallback(
     () => void window.aya.minimizeWindow(),
     [],
@@ -3912,6 +4005,12 @@ export function App() {
       <StatusBar
         project={activeProject}
         git={activeGit}
+        gitDirectory={activeGitDirectory}
+        worktrees={worktrees}
+        checkoutPinned={
+          !!activeProjectId && !!pinnedCheckout[activeProjectId]
+        }
+        onPickCheckout={pinCheckout}
         githubLink={activeGithubLink}
         showGitHubLink={showGitHubLink}
         terminal={activeTerminal}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -5,6 +5,7 @@ import type {
   GitHubLink,
   ProjectConfig,
   TerminalState,
+  WorktreeStatus,
 } from "../types";
 import { diffFileLineIndex } from "../diff-navigation";
 
@@ -19,6 +20,17 @@ interface GitInfo {
 interface Props {
   project: ProjectConfig | null;
   git: GitInfo | null;
+  /** The checkout `git` describes and the changed files / diff are read from:
+   *  what the user pinned, else where the active terminal's console actually
+   *  is, else its spawn cwd. null for remote projects (no local working tree). */
+  gitDirectory: string | null;
+  /** Worktrees of the active project (branch + dirty count), for the checkout
+   *  picker. Fewer than 2 entries = nothing to pick, no picker. */
+  worktrees: WorktreeStatus[];
+  /** True while `gitDirectory` comes from a pin rather than from the console. */
+  checkoutPinned: boolean;
+  /** Pin a checkout by path, or null to go back to following the console. */
+  onPickCheckout: (path: string | null) => void;
   githubLink: GitHubLink | null;
   showGitHubLink: boolean;
   terminal: TerminalState | null;
@@ -30,9 +42,19 @@ interface Props {
   onOpenAttentionCenter: () => void;
 }
 
+/** Last path segment — how a worktree is named in the UI (git itself has no
+ *  name for one; the directory is its identity). */
+function checkoutName(path: string): string {
+  return path.replace(/\/+$/, "").split("/").pop() || path;
+}
+
 function StatusBarImpl({
   project,
   git,
+  gitDirectory,
+  worktrees,
+  checkoutPinned,
+  onPickCheckout,
   githubLink,
   showGitHubLink,
   terminal,
@@ -44,7 +66,18 @@ function StatusBarImpl({
   onOpenAttentionCenter,
 }: Props) {
   const waiting = terminal?.status === "waiting";
+  // Non-null only while the git strip describes a checkout other than the
+  // project's own — then the branch chip says which one, so "main" read from a
+  // worktree is never mistaken for the project directory's branch.
+  const worktreeName =
+    gitDirectory && project && gitDirectory !== project.directory
+      ? checkoutName(gitDirectory)
+      : null;
+  // A single checkout is not a choice, so the picker only exists from 2 up.
+  const canPickCheckout = worktrees.length > 1;
   const externalStatus = terminal?.externalStatus;
+  const checkoutRef = useRef<HTMLDivElement>(null);
+  const [showCheckouts, setShowCheckouts] = useState(false);
   const dirtyRef = useRef<HTMLDivElement>(null);
   const [showDirtyFiles, setShowDirtyFiles] = useState(false);
   const [dirtyFiles, setDirtyFiles] = useState<GitChangedFile[]>([]);
@@ -68,29 +101,49 @@ function StatusBarImpl({
   }, [showDirtyFiles]);
 
   useEffect(() => {
+    if (!showCheckouts) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!checkoutRef.current?.contains(event.target as Node)) {
+        setShowCheckouts(false);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    return () => window.removeEventListener("pointerdown", onPointerDown, true);
+  }, [showCheckouts]);
+
+  // A picker that vanished (worktree removed, project switched) must not leave
+  // an orphaned dropdown floating over the status bar.
+  useEffect(() => {
+    if (!canPickCheckout) setShowCheckouts(false);
+  }, [canPickCheckout]);
+
+  // Reset on any checkout change, not just a project switch: moving to a tab
+  // bound to another worktree must not leave the previous worktree's file list
+  // and diff on screen.
+  useEffect(() => {
     setShowDirtyFiles(false);
     setDirtyFiles([]);
     setShowDiff(false);
     setDiffText("");
     setDiffQuery("");
     setScrollToPath(null);
-  }, [project?.directory]);
+  }, [gitDirectory]);
 
   const toggleDirtyFiles = () => {
-    if (!project) return;
+    if (!gitDirectory) return;
     setShowDirtyFiles((open) => !open);
     setDirtyFilesLoading(true);
-    void window.aya.getGitChangedFiles(project.directory).then((files) => {
+    void window.aya.getGitChangedFiles(gitDirectory).then((files) => {
       setDirtyFiles(files);
       setDirtyFilesLoading(false);
     });
   };
 
   const loadDiff = () => {
-    if (!project) return;
+    if (!gitDirectory) return;
     setShowDiff(true);
     setDiffLoading(true);
-    void window.aya.getGitDiff(project.directory).then((diff) => {
+    void window.aya.getGitDiff(gitDirectory).then((diff) => {
       setDiffText(diff);
       setDiffLoading(false);
     });
@@ -185,12 +238,74 @@ function StatusBarImpl({
         {attentionCount > 0 ? `${attentionCount} attention` : "activity"}
       </button>
       {git?.branch && (
-        <span className="aya-statusbar-item">
-          <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
-            fork_right
-          </span>
-          {git.branch}
-        </span>
+        <div className="aya-statusbar-popover-host" ref={checkoutRef}>
+          <BranchChip
+            branch={git.branch}
+            worktreeName={worktreeName}
+            directory={gitDirectory}
+            pinned={checkoutPinned}
+            canPick={canPickCheckout}
+            open={showCheckouts}
+            onToggle={() => setShowCheckouts((open) => !open)}
+          />
+          {showCheckouts && (
+            <div
+              className="aya-statusbar-popover aya-statusbar-popover--checkouts"
+              role="dialog"
+              aria-label="Checkouts"
+            >
+              <div className="aya-statusbar-popover-title">
+                <span>Worktrees</span>
+                {checkoutPinned && (
+                  <button
+                    className="aya-statusbar-popover-action"
+                    type="button"
+                    onClick={() => {
+                      onPickCheckout(null);
+                      setShowCheckouts(false);
+                    }}
+                  >
+                    Follow terminal
+                  </button>
+                )}
+              </div>
+              <div className="aya-checkout-list">
+                {worktrees.map((w) => (
+                  <button
+                    className={`aya-checkout-row ${
+                      w.path === gitDirectory ? "aya-checkout-row--current" : ""
+                    }`}
+                    type="button"
+                    key={w.path}
+                    title={w.path}
+                    onClick={() => {
+                      onPickCheckout(w.path);
+                      setShowCheckouts(false);
+                    }}
+                  >
+                    <span className="aya-checkout-icon">⑂</span>
+                    <span className="aya-checkout-name">
+                      {checkoutName(w.path)}
+                    </span>
+                    {w.isMain && (
+                      <span className="aya-worktree-header-tag">main</span>
+                    )}
+                    <span className="aya-checkout-branch">
+                      {w.branch ?? (w.detached ? "detached" : "-")}
+                    </span>
+                    <span
+                      className={`aya-checkout-dirty ${
+                        w.dirty > 0 ? "aya-checkout-dirty--warn" : ""
+                      }`}
+                    >
+                      {w.prunable ? "stale" : w.dirty > 0 ? `${w.dirty} dirty` : "clean"}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       )}
       {showGitHubLink && githubLink && (
         <button
@@ -302,6 +417,77 @@ function StatusBarImpl({
         </span>
       ) : null}
     </footer>
+  );
+}
+
+/** The branch label. Static text with a single checkout; with more than one it
+ *  becomes the picker's trigger, and says whether what you see is pinned or is
+ *  following the console. */
+function BranchChip({
+  branch,
+  worktreeName,
+  directory,
+  pinned,
+  canPick,
+  open,
+  onToggle,
+}: {
+  branch: string;
+  worktreeName: string | null;
+  directory: string | null;
+  pinned: boolean;
+  canPick: boolean;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const where = worktreeName ? `Worktree ${directory}` : directory;
+  const title = canPick
+    ? `${where}\nBranch ${branch}\n${
+        pinned ? "Pinned - click to pick another checkout" : "Following the active terminal"
+      }`
+    : (where ?? undefined);
+  const body = (
+    <>
+      <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
+        fork_right
+      </span>
+      {branch}
+      {worktreeName && (
+        <span className="aya-statusbar-worktree">⑂ {worktreeName}</span>
+      )}
+      {pinned && (
+        <span
+          style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}
+          title="Pinned checkout"
+        >
+          push_pin
+        </span>
+      )}
+    </>
+  );
+  if (!canPick) {
+    return (
+      <span className="aya-statusbar-item" title={title}>
+        {body}
+      </span>
+    );
+  }
+  return (
+    <button
+      className="aya-statusbar-item aya-statusbar-button"
+      data-testid="checkout-picker"
+      type="button"
+      title={title}
+      // Inline dropdown — keep terminal focus (same as the other status-bar
+      // popovers).
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onToggle}
+    >
+      {body}
+      <span style={{ fontFamily: "Material Symbols Outlined", fontSize: ICON_SIZE_SM_PX }}>
+        {open ? "expand_more" : "expand_less"}
+      </span>
+    </button>
   );
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1075,6 +1075,72 @@ body {
 .aya-statusbar-item--agent-active { color: var(--fg-secondary); }
 .aya-statusbar-item--agent-done { color: var(--status-active); }
 .aya-statusbar-item--agent-error { color: var(--status-error); }
+.aya-statusbar-popover--checkouts {
+  width: min(380px, calc(100vw - 24px));
+}
+.aya-checkout-list {
+  overflow-y: auto;
+}
+.aya-checkout-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--fg-secondary);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+.aya-checkout-row:hover {
+  background: var(--bg-tertiary);
+  color: var(--fg-primary);
+}
+.aya-checkout-row--current {
+  color: var(--fg-primary);
+  box-shadow: inset 2px 0 0 var(--accent, var(--border-strong));
+}
+.aya-checkout-icon {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+.aya-checkout-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aya-checkout-branch {
+  flex-shrink: 0;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-tertiary);
+  font-family: var(--font-mono);
+}
+.aya-checkout-dirty {
+  flex-shrink: 0;
+  min-width: 52px;
+  text-align: right;
+  color: var(--fg-tertiary);
+}
+.aya-checkout-dirty--warn { color: var(--status-waiting); }
+.aya-statusbar-worktree {
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  color: var(--fg-tertiary);
+  font-size: 10px;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .aya-statusbar-spacer { flex: 1; }
 .aya-statusbar-popover-host {
   position: relative;

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,13 @@ export interface Worktree {
   prunable: boolean;
 }
 
+/** A worktree plus its live state, for the status bar's checkout picker.
+ *  `dirty` is 0 for a repo with a single worktree (nothing to pick between, so
+ *  the per-worktree status calls are skipped) and for prunable/bare ones. */
+export interface WorktreeStatus extends Worktree {
+  dirty: number;
+}
+
 export type SpawnFailureReason =
   | "cwd-missing"
   | "cwd-not-directory"
@@ -570,6 +577,10 @@ export interface AyaApi {
   ptyResize(ptyId: string, cols: number, rows: number): Promise<void>;
   ptyKill(ptyId: string): Promise<void>;
   ptyBuffer(ptyId: string): Promise<string>;
+  /** Live cwd of a terminal's process - where the console actually is after a
+   *  `cd`, not the cwd Aya spawned it with. null when it can't be read (old
+   *  PTY host, dead process, unsupported platform). */
+  ptyCwd(ptyId: string): Promise<string | null>;
   ptySearch(query: string): Promise<BufferSearchHit[]>;
   /** Experimental harness-aware search: scans the LOCAL Claude Code / Codex
    *  session transcripts for the tab's cwd (history, not terminal output). */
@@ -673,6 +684,12 @@ export interface AyaApi {
     path: string;
     force?: boolean;
   }): Promise<GitMutationResult>;
+  /** Root of the checkout containing `directory` (a worktree's own root), or
+   *  null outside a repo. */
+  getGitRoot(directory: string): Promise<string | null>;
+  /** Worktrees of the repo containing `directory`, each with branch + dirty
+   *  count (dirty is 0 when the repo has a single worktree). */
+  getGitWorktreeStatus(directory: string): Promise<WorktreeStatus[]>;
   getGitHubLink(directory: string): Promise<GitHubLink | null>;
   githubCliAvailable(): Promise<boolean>;
   pickDirectory(): Promise<string | null>;

--- a/src/web/bridge.ts
+++ b/src/web/bridge.ts
@@ -67,6 +67,7 @@ export function createWebAya(transport: WebTransport): AyaApi {
     ptyResize: inv("pty:resize"),
     ptyKill: inv("pty:kill"),
     ptyBuffer: inv("pty:buffer"),
+    ptyCwd: inv("pty:cwd"),
     ptySearch: inv("pty:search"),
     harnessSearch: inv("harness:search"),
     restartPtyHost: inv("pty-host:restart"),
@@ -122,6 +123,8 @@ export function createWebAya(transport: WebTransport): AyaApi {
     getGitChangedFiles: inv("env:git-changed-files"),
     getGitDiff: inv("env:git-diff"),
     getGitWorktrees: inv("env:git-worktrees"),
+    getGitRoot: inv("env:git-root"),
+    getGitWorktreeStatus: inv("env:git-worktree-status"),
     getGitHubLink: inv("env:github-link"),
     githubCliAvailable: inv("env:github-cli-available"),
     // Repository mutations stay on the desktop app, where the user can see the

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -11,6 +11,18 @@ export function projectBaseCwd(project: ProjectConfig): string {
   return project.remote ? project.remote.directory : project.directory;
 }
 
+/** The checkout the git surface (branch / dirty / diff / GitHub link) should
+ *  describe: the active terminal's worktree cwd when that tab is bound to one,
+ *  otherwise the project's own base directory. A plain tab spawns in the base
+ *  cwd, so this is a no-op for it — but a tab running in a worktree would
+ *  otherwise report the main checkout's branch and its (usually empty) diff. */
+export function gitContextCwd(
+  baseCwd: string,
+  terminalCwd: string | null | undefined,
+): string {
+  return terminalCwd && terminalCwd !== baseCwd ? terminalCwd : baseCwd;
+}
+
 /** Map a live terminal back to its persisted WorkingTab. Keeps the worktree cwd
  *  binding only when it differs from the project's own directory, so an ordinary
  *  main-dir tab stays cwd-free (and keeps following the project if its directory

--- a/tests/git-worktrees.test.mjs
+++ b/tests/git-worktrees.test.mjs
@@ -6,12 +6,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-const { parseWorktrees, listWorktrees, createWorktree, removeWorktree } =
-  await import("../dist-electron/git.js");
+const {
+  parseWorktrees,
+  listWorktrees,
+  createWorktree,
+  removeWorktree,
+  listWorktreeStatus,
+  getGitRoot,
+} = await import("../dist-electron/git.js");
 
 // --- parseWorktrees (pure) ---------------------------------------------------
 
@@ -273,4 +279,77 @@ test("the surfaced error is git's reason, not its progress chatter", async () =>
   assert.equal(again.ok, false);
   assert.doesNotMatch(again.error, /Preparing worktree/i);
   assert.match(again.error, /already exists/i);
+});
+
+// --- listWorktreeStatus / getGitRoot (integration, real git) -----------------
+
+test("listWorktreeStatus reports each worktree's own branch and dirty count", async () => {
+  const root = makeRepo();
+  const feature = tmpWorktreePath("feature");
+  try {
+    execSync(`git worktree add "${feature}" -b feature`, { cwd: root });
+    // Distinct states: main dirty by two files, the worktree by one.
+    writeFileSync(join(root, "a.txt"), "changed");
+    writeFileSync(join(root, "new.txt"), "untracked");
+    writeFileSync(join(feature, "a.txt"), "changed in worktree");
+
+    const list = await listWorktreeStatus(root);
+    assert.equal(list.length, 2);
+    const main = list.find((w) => w.isMain);
+    const wt = list.find((w) => !w.isMain);
+    assert.equal(main.branch, "main");
+    assert.equal(main.dirty, 2);
+    assert.equal(wt.branch, "feature");
+    assert.equal(wt.dirty, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("listWorktreeStatus skips the status calls for a single checkout", async () => {
+  const root = makeRepo();
+  try {
+    writeFileSync(join(root, "a.txt"), "changed");
+    const list = await listWorktreeStatus(root);
+    assert.equal(list.length, 1);
+    // Nothing to pick between, so dirty is not computed - the status bar polls
+    // this one checkout separately.
+    assert.equal(list[0].dirty, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("listWorktreeStatus returns [] outside a repo", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "aya-wt-status-nonrepo-"));
+  try {
+    assert.deepEqual(await listWorktreeStatus(dir), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("getGitRoot resolves a subdirectory to its OWN checkout root", async () => {
+  const root = makeRepo();
+  const feature = tmpWorktreePath("feature");
+  try {
+    execSync(`git worktree add "${feature}" -b feature`, { cwd: root });
+    mkdirSync(join(feature, "deep", "nested"), { recursive: true });
+    // A live terminal cwd can sit anywhere under the checkout; the git surface
+    // needs the worktree's root, not the main repo's.
+    const resolved = await getGitRoot(join(feature, "deep", "nested"));
+    assert.equal(realpathSync(resolved), realpathSync(feature));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("getGitRoot returns null outside a repo and for a missing dir", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "aya-root-nonrepo-"));
+  try {
+    assert.equal(await getGitRoot(dir), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  assert.equal(await getGitRoot("/no/such/dir/aya-xyz-123"), null);
 });

--- a/tests/process-cwd.test.mjs
+++ b/tests/process-cwd.test.mjs
@@ -1,0 +1,66 @@
+// Live cwd of a process. The parser is pure (lsof field output); getProcessCwd
+// itself is exercised against this very test process, which is the only pid we
+// can be sure exists and whose cwd we already know.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { parseLsofCwd, getProcessCwd } = await import(
+  "../dist-electron/process-cwd.js"
+);
+
+test("parseLsofCwd takes the n line that follows fcwd", () => {
+  // What `lsof -a -d cwd -p PID -Fn` prints: pid, then one record per fd.
+  const out = "p59321\nfcwd\nn/Users/me/Projects/aya\n";
+  assert.equal(parseLsofCwd(out), "/Users/me/Projects/aya");
+});
+
+test("parseLsofCwd tolerates extra field lines inside the record", () => {
+  // Other -F selectors (access mode, lock) interleave their own lines.
+  const out = "p1\nfcwd\na \nl \nn/tmp/here\n";
+  assert.equal(parseLsofCwd(out), "/tmp/here");
+});
+
+test("parseLsofCwd ignores paths of other file descriptors", () => {
+  // -a -d cwd should keep other fds out, but a path from one must never be
+  // mistaken for the cwd if lsof does report extra records.
+  const out = "p1\nftxt\nn/usr/bin/zsh\nfcwd\nn/tmp/here\nf3\nn/dev/null\n";
+  assert.equal(parseLsofCwd(out), "/tmp/here");
+});
+
+test("parseLsofCwd returns null when there is no cwd record", () => {
+  assert.equal(parseLsofCwd("p1\nftxt\nn/usr/bin/zsh\n"), null);
+  assert.equal(parseLsofCwd(""), null);
+});
+
+test("parseLsofCwd keeps spaces in the path", () => {
+  assert.equal(parseLsofCwd("fcwd\nn/tmp/my dir/repo\n"), "/tmp/my dir/repo");
+});
+
+test("getProcessCwd reads this process's own cwd", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("no cwd lookup on Windows");
+    return;
+  }
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "aya-cwd-")));
+  const previous = process.cwd();
+  try {
+    process.chdir(dir);
+    const cwd = await getProcessCwd(process.pid);
+    assert.equal(cwd && realpathSync(cwd), dir);
+  } finally {
+    process.chdir(previous);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("getProcessCwd returns null for a bad pid instead of throwing", async () => {
+  assert.equal(await getProcessCwd(-1), null);
+  assert.equal(await getProcessCwd(0), null);
+  // A pid far above the typical max: no such process, so no cwd.
+  assert.equal(await getProcessCwd(4194303), null);
+});

--- a/tests/web-git-worktree.test.mjs
+++ b/tests/web-git-worktree.test.mjs
@@ -1,0 +1,142 @@
+// Aya Web (experimental): the status bar's git surface asks for the ACTIVE
+// TERMINAL's checkout, which for a worktree tab is a directory outside the
+// project. The browser bridge must forward that directory as-is - the renderer
+// code is shared with Electron, so if the bridge only served the project dir,
+// the web mode would silently keep showing the main checkout.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WebSocket } from "ws";
+
+const { startWebServer } = await import("../dist-electron/web-server.js");
+const { webCredentials } = await import("../dist-electron/web-config.js");
+const { captureIpcHandlers } = await import("../dist-electron/web-ipc.js");
+const { getGitInfo, getGitDiff } = await import("../dist-electron/git.js");
+
+const PASSWORD = "test-password-123";
+
+// Register the git channels the way main.ts does, through the same capture
+// wrapper the web bridge reads from (no Electron here, so ipcMain is a stub).
+const stubIpcMain = { handle: () => {} };
+captureIpcHandlers(stubIpcMain);
+stubIpcMain.handle("env:git", (_e, directory) => getGitInfo(directory));
+stubIpcMain.handle("env:git-diff", (_e, directory) => getGitDiff(directory));
+
+/** A repo on "feature/foo" plus a worktree on "wt/bar", each with its own
+ *  distinct modification of the same tracked file. */
+function makeRepoWithWorktree() {
+  const root = mkdtempSync(join(tmpdir(), "aya-web-git-"));
+  const repo = join(root, "repo");
+  mkdirSync(repo);
+  const git = (...args) => execFileSync("git", args, { cwd: repo, stdio: "ignore" });
+  git("init", "-q", "-b", "feature/foo");
+  writeFileSync(join(repo, "committed.txt"), "one\ntwo\n");
+  git("add", "committed.txt");
+  git("-c", "user.email=t@e", "-c", "user.name=t", "commit", "-qm", "init");
+  writeFileSync(join(repo, "committed.txt"), "one\ntwoMAIN\n");
+  const worktree = join(root, "wt-bar");
+  git("worktree", "add", "-q", "-b", "wt/bar", worktree);
+  writeFileSync(join(worktree, "committed.txt"), "one\ntwoWT\n");
+  return { root, repo, worktree };
+}
+
+async function startTestServer() {
+  const distDir = mkdtempSync(join(tmpdir(), "aya-web-"));
+  writeFileSync(join(distDir, "web.html"), "<html>aya web test</html>");
+  const config = {
+    enabled: true,
+    port: 0,
+    host: "127.0.0.1",
+    user: "tester",
+    ...webCredentials(PASSWORD, false),
+  };
+  const handle = await startWebServer({
+    appVersion: "0.0.0-test",
+    isDev: false,
+    distDir,
+    getConfig: () => config,
+  });
+  return {
+    handle,
+    base: `http://127.0.0.1:${handle.port}`,
+    cleanup: async () => {
+      await handle.close();
+      rmSync(distDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function wsOpen(url, cookie) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, { headers: { cookie } });
+    const frames = [];
+    const waiters = [];
+    ws.on("message", (raw) => {
+      const frame = JSON.parse(String(raw));
+      const waiter = waiters.shift();
+      if (waiter) waiter(frame);
+      else frames.push(frame);
+    });
+    ws.on("open", () =>
+      resolve({
+        ws,
+        next: () =>
+          new Promise((resolveNext) => {
+            const buffered = frames.shift();
+            if (buffered) resolveNext(buffered);
+            else waiters.push(resolveNext);
+          }),
+      }),
+    );
+    ws.on("error", reject);
+  });
+}
+
+test("the web bridge reads a worktree directory, not just the project dir", async () => {
+  const { root, repo, worktree } = makeRepoWithWorktree();
+  const { base, cleanup } = await startTestServer();
+  try {
+    const login = await fetch(`${base}/api/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user: "tester", password: PASSWORD }),
+    });
+    const cookie = login.headers.get("set-cookie").split(";")[0];
+    const { ws, next } = await wsOpen(base.replace("http:", "ws:") + "/ws", cookie);
+    try {
+      await next(); // hello
+
+      const invoke = async (id, channel, directory) => {
+        ws.send(JSON.stringify({ t: "invoke", id, channel, args: [directory] }));
+        const frame = await next();
+        assert.equal(frame.ok, true, `${channel} failed: ${frame.error}`);
+        return frame.value;
+      };
+
+      // Project directory: its own branch and its own change.
+      assert.deepEqual(await invoke(1, "env:git", repo), {
+        branch: "feature/foo",
+        dirty: 1,
+      });
+      assert.match(await invoke(2, "env:git-diff", repo), /twoMAIN/);
+
+      // Worktree directory: the branch and diff a worktree tab must show.
+      assert.deepEqual(await invoke(3, "env:git", worktree), {
+        branch: "wt/bar",
+        dirty: 1,
+      });
+      const worktreeDiff = await invoke(4, "env:git-diff", worktree);
+      assert.match(worktreeDiff, /twoWT/);
+      assert.doesNotMatch(worktreeDiff, /twoMAIN/);
+    } finally {
+      ws.close();
+    }
+  } finally {
+    await cleanup();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/worktree.test.mjs
+++ b/tests/worktree.test.mjs
@@ -4,7 +4,11 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { projectBaseCwd, tabFromTerminal } from "../dist-test/worktree.js";
+import {
+  gitContextCwd,
+  projectBaseCwd,
+  tabFromTerminal,
+} from "../dist-test/worktree.js";
 
 const term = (over) => ({
   id: "t1",
@@ -66,6 +70,23 @@ test("tabFromTerminal omits cwd for a main-dir tab (equal to the base)", () => {
 test("tabFromTerminal omits cwd when the terminal has none", () => {
   const tab = tabFromTerminal(term({ cwd: "" }), "/home/me/repo");
   assert.equal(Object.prototype.hasOwnProperty.call(tab, "cwd"), false);
+});
+
+test("gitContextCwd follows a worktree tab, not the project directory", () => {
+  assert.equal(
+    gitContextCwd("/home/me/repo", "/home/me/repo-wt/feature"),
+    "/home/me/repo-wt/feature",
+  );
+});
+
+test("gitContextCwd stays on the base cwd for a plain tab", () => {
+  assert.equal(gitContextCwd("/home/me/repo", "/home/me/repo"), "/home/me/repo");
+});
+
+test("gitContextCwd falls back to the base cwd with no terminal cwd", () => {
+  assert.equal(gitContextCwd("/home/me/repo", null), "/home/me/repo");
+  assert.equal(gitContextCwd("/home/me/repo", undefined), "/home/me/repo");
+  assert.equal(gitContextCwd("/home/me/repo", ""), "/home/me/repo");
 });
 
 test("round-trip: a worktree binding survives terminal -> tab", () => {


### PR DESCRIPTION
## Summary
- The status bar branch chip now reads the checkout the active tab is actually in, not always the project's main checkout - a tab running in a git worktree previously showed the main checkout's branch and diff instead of its own.
- Added a checkout picker on the branch chip listing all of the project's worktrees with live branch + dirty counts, with the ability to pin a checkout or follow the active terminal.
- The active checkout is resolved from the terminal's live cwd (via a new PTY host `cwd` request / `getPtyCwd`), so it tracks a `cd` into a worktree, not just the tab's spawn cwd.

## Test plan
- [x] `npm run test` (typecheck + build + `node --test`): 626/626 passing
- [x] New/updated unit tests: `tests/git-worktrees.test.mjs` (`listWorktreeStatus`, `getGitRoot`), `tests/worktree.test.mjs` (`gitContextCwd`), `tests/process-cwd.test.mjs`, `tests/web-git-worktree.test.mjs`
- [x] New e2e spec: `e2e/statusbar-worktree.spec.ts` (not run in this session - requires `npm run test:e2e`)
- [ ] Manual click-through of the checkout picker in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)